### PR TITLE
Couple web improvements

### DIFF
--- a/support/web/agda-cats.scss
+++ b/support/web/agda-cats.scss
@@ -59,7 +59,6 @@ article {
   padding-top: 2em;
   padding-bottom: 2em;
   margin-top: 0 !important;
-  width: 85ch;
   max-width: 100%;
 
   > :nth-child(1), > pre.Agda:first-of-type {

--- a/support/web/default.scss
+++ b/support/web/default.scss
@@ -99,10 +99,6 @@ main {
 
   box-sizing: border-box;
 
-  div#title h2 {
-    display: none;
-  }
-
   div#post-toc-container {
     aside#toc {
       display: none;
@@ -318,9 +314,6 @@ table {
       flex-direction: row;
       justify-content: center;
     }
-    nav {
-      display: none;
-    }
   }
 }
 
@@ -331,23 +324,6 @@ table {
 
   main {
     max-width: 100%;
-    > div#title {
-      font-size: 15pt;
-      h1, h2 {
-        margin: 0;
-      }
-
-      h2 {
-        font-style: italic;
-        font-weight: normal;
-        display: block;
-        z-index: 1;
-      }
-
-      margin-top: 0.5em;
-      margin-bottom: 1em;
-      @include centered-contents;
-    }
 
     div#post-toc-container {
       display: grid;

--- a/support/web/default.scss
+++ b/support/web/default.scss
@@ -352,6 +352,10 @@ table {
           gap: 0.5em;
           width: 100%;
 
+          a[href]#logo.hover-highlight {
+            background-color: unset;
+          }
+
           > hr {
             margin-top: 0.25em;
             margin-bottom: 0.25em;

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -69,7 +69,7 @@
       </h3>
 
       <!-- Cube logo -->
-      <a href="/">
+      <a id=logo href="/">
         <img alt="1Lab"
             src="/static/cube-72x.png"
             style="display: block; margin-bottom: 1em; margin: auto;"

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -69,12 +69,14 @@
       </h3>
 
       <!-- Cube logo -->
-      <img alt="1Lab"
-           src="/static/cube-72x.png"
-           style="display: block; margin-bottom: 1em; margin: auto;"
-           width="32px"
-           height="32px"
-        />
+      <a href="/">
+        <img alt="1Lab"
+            src="/static/cube-72x.png"
+            style="display: block; margin-bottom: 1em; margin: auto;"
+            width="32px"
+            height="32px"
+          />
+      </a>
 
       <!-- Actual table of contents (separated from the rest by
       horizontal rules) -->
@@ -103,7 +105,7 @@
       <div id=return style="white-space: nowrap;">
       $if(is-index)$
       $else$
-        <a href="index.html">️back to index</a> <br />
+        <a href="/">back to index</a> <br />
       $endif$
         <a href="all-pages.html">view all pages</a> <br />
         <a href="https://github.com/plt-amy/cubical-1lab/blob/$source$">link to source</a> <br />
@@ -122,7 +124,7 @@
       $if(is-index)$
       $else$
       <div id=return>
-        <a href="index.html">️back to index</a>
+        <a href="/">back to index</a>
       </div>
       $endif$
 


### PR DESCRIPTION
Currently [1Lab.Counterexamples.IsIso](https://1lab.dev/1Lab.Counterexamples.IsIso.html) doesn't fit horizontally on my screen, and I can't even scroll it:

![](https://f.monade.li/dZv3Ea.png)

This fixes that, and also makes the 🧊 link back to the index so that you don't have to scroll to the bottom of the navigation bar.