### PR TITLE
defn: reasoning combinators for functors

### DIFF
--- a/src/Cat/Functor/Reasoning.lagda.md
+++ b/src/Cat/Functor/Reasoning.lagda.md
@@ -1,0 +1,113 @@
+```agda
+open import 1Lab.Path
+
+open import Cat.Base
+import Cat.Reasoning
+
+module Cat.Functor.Reasoning
+  {o ℓ o′ ℓ′}
+  {𝒞 : Precategory o ℓ} {𝒟 : Precategory o′ ℓ′}
+  (F : Functor 𝒞 𝒟) where
+
+module 𝒞 = Cat.Reasoning 𝒞
+module 𝒟 = Cat.Reasoning 𝒟
+open Functor F public
+```
+
+<!--
+```agda
+private variable
+  A B C : 𝒞.Ob
+  a b c d : 𝒞.Hom A B
+  X Y Z : 𝒟.Ob
+  f g h i : 𝒟.Hom X Y
+```
+-->
+
+
+# Reasoning Combinators for Functors
+
+The combinators exposed in [category reasoning] abstract out a lot of common
+algebraic manipulations, and make proofs much more concise. However, once functors
+get involved, those combinators start to get unwieldy! Therefore, we have
+to write some new combinators for working with functors specifically.
+This module is meant to be imported qualified.
+
+[category reasoning]: Cat.Reasoning.html
+
+## Identity Morphisms
+
+```agda
+module _ (a≡id : a ≡ 𝒞.id) where
+  elim : F₁ a ≡ 𝒟.id
+  elim = ap F₁ a≡id ∙ F-id
+
+  eliml : F₁ a 𝒟.∘ f ≡ f 
+  eliml = 𝒟.eliml elim
+
+  elimr : f 𝒟.∘ F₁ a ≡ f
+  elimr = 𝒟.elimr elim
+
+  introl : f ≡ F₁ a 𝒟.∘ f
+  introl = 𝒟.introl elim
+
+  intror : f ≡ f 𝒟.∘ F₁ a
+  intror = 𝒟.intror elim
+```
+
+## Reassociations
+
+```agda
+module _ (ab≡c : a 𝒞.∘ b ≡ c) where
+  collapse : F₁ a 𝒟.∘ F₁ b ≡ F₁ c
+  collapse = sym (F-∘ a b) ∙ ap F₁ ab≡c
+
+  pulll : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ f) ≡ F₁ c 𝒟.∘ f
+  pulll = 𝒟.pulll collapse
+
+  pullr : (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b ≡ f 𝒟.∘ F₁ c
+  pullr = 𝒟.pullr collapse
+
+module _ (c≡ab : c ≡ a 𝒞.∘ b) where
+  expand : F₁ c ≡ F₁ a 𝒟.∘ F₁ b
+  expand = sym (collapse (sym c≡ab))
+
+  pushl : F₁ c 𝒟.∘ f ≡ F₁ a 𝒟.∘ (F₁ b 𝒟.∘ f)
+  pushl = 𝒟.pushl expand
+
+  pushr : f 𝒟.∘ F₁ c ≡ (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b
+  pushr = 𝒟.pushr expand
+
+module _ (p : a 𝒞.∘ c ≡ b 𝒞.∘ d) where
+  weave : F₁ a 𝒟.∘ F₁ c ≡ F₁ b 𝒟.∘ F₁ d
+  weave = sym (F-∘ a c) ∙ ap F₁ p ∙ F-∘ b d
+
+  extendl : F₁ a 𝒟.∘ (F₁ c 𝒟.∘ f) ≡ F₁ b 𝒟.∘ (F₁ d 𝒟.∘ f)
+  extendl = 𝒟.extendl weave
+
+  extendr : (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ c ≡ (f 𝒟.∘ F₁ b) 𝒟.∘ F₁ d
+  extendr = 𝒟.extendr weave
+```
+
+## Cancellation
+
+```agda
+module _ (inv : a 𝒞.∘ b ≡ 𝒞.id) where
+  annihilate : F₁ a 𝒟.∘ F₁ b ≡ 𝒟.id
+  annihilate = sym (F-∘ a b) ∙ ap F₁ inv ∙ F-id
+
+  cancell : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ f) ≡ f
+  cancell = 𝒟.cancell annihilate
+
+  cancelr : (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b ≡ f
+  cancelr = 𝒟.cancelr annihilate
+
+  insertl : f ≡ F₁ a 𝒟.∘ (F₁ b 𝒟.∘ f)
+  insertl = 𝒟.insertl annihilate
+
+  insertr : f ≡ (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b
+  insertr = 𝒟.insertr annihilate
+
+  cancel-inner : (f 𝒟.∘ F₁ a) 𝒟.∘ (F₁ b 𝒟.∘ g) ≡ f 𝒟.∘ g
+  cancel-inner = 𝒟.cancel-inner annihilate
+```

--- a/src/Cat/Functor/Reasoning.lagda.md
+++ b/src/Cat/Functor/Reasoning.lagda.md
@@ -87,6 +87,10 @@ module _ (p : a 𝒞.∘ c ≡ b 𝒞.∘ d) where
 
   extendr : (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ c ≡ (f 𝒟.∘ F₁ b) 𝒟.∘ F₁ d
   extendr = 𝒟.extendr weave
+
+  extend-inner :
+    f 𝒟.∘ F₁ a 𝒟.∘ F₁ c 𝒟.∘ g ≡ f 𝒟.∘ F₁ b 𝒟.∘ F₁ d 𝒟.∘ g
+  extend-inner = 𝒟.extend-inner weave
 ```
 
 ## Cancellation

--- a/src/Cat/Functor/Reasoning.lagda.md
+++ b/src/Cat/Functor/Reasoning.lagda.md
@@ -115,3 +115,14 @@ module _ (inv : a 𝒞.∘ b ≡ 𝒞.id) where
   cancel-inner : (f 𝒟.∘ F₁ a) 𝒟.∘ (F₁ b 𝒟.∘ g) ≡ f 𝒟.∘ g
   cancel-inner = 𝒟.cancel-inner annihilate
 ```
+
+## Notation
+
+Writing `ap F₁ p` is somewhat clunky, so we define a bit of notation
+to make it somewhat cleaner.
+
+```agda
+⟨_⟩ : a ≡ b → F₁ a ≡ F₁ b
+⟨_⟩ = ap F₁
+```
+

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -178,3 +178,22 @@ module _ {y z} (f : y ≅ z) where
     f .from ∘ f .to ∘ h   ≡⟨ cancell (f .invr) ⟩
     h                     ∎
 ```
+
+## Notation
+
+When doing equational reasoning, it's often somewhat clumsy to have to write
+`ap (f ∘_) p` when proving that `f ∘ g ≡ f ∘ h`. To fix this, we define steal
+some cute mixfix notation from `agda-categories` which allows us to write
+`≡⟨ refl⟩∘⟨ p ⟩` instead, which is much more aesthetically pleasing!
+
+```agda
+_⟩∘⟨_ : f ≡ h → g ≡ i → f ∘ g ≡ h ∘ i
+_⟩∘⟨_ = ap₂ _∘_
+
+refl⟩∘⟨_ : g ≡ h → f ∘ g ≡ f ∘ h
+refl⟩∘⟨_ {f = f} p = ap (f ∘_) p
+
+_⟩∘⟨refl : f ≡ h → f ∘ g ≡ h ∘ g
+_⟩∘⟨refl {g = g} p = ap (_∘ g) p
+```
+

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -101,6 +101,9 @@ module _ (p : f ∘ h ≡ g ∘ i) where
     a ∘ (f ∘ h) ≡⟨ ap (a ∘_) p ⟩
     a ∘ (g ∘ i) ≡⟨ assoc a g i ⟩
     (a ∘ g) ∘ i ∎
+
+  extend-inner : a ∘ f ∘ h ∘ b ≡ a ∘ g ∘ i ∘ b
+  extend-inner {a = a} = ap (a ∘_) extendl
 ```
 
 ## Cancellation

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -79,6 +79,14 @@ module _ (ab≡c : a ∘ b ≡ c) where
     f ∘ (a ∘ b) ≡⟨ ap (f ∘_) ab≡c ⟩
     f ∘ c ∎
 
+module _ (c≡ab : c ≡ a ∘ b) where
+
+  pushl : c ∘ f ≡ a ∘ (b ∘ f)
+  pushl = sym (pulll (sym c≡ab))
+
+  pushr : f ∘ c ≡ (f ∘ a) ∘ b
+  pushr = sym (pullr (sym c≡ab))
+
 module _ (p : f ∘ h ≡ g ∘ i) where
   extendl : f ∘ (h ∘ b) ≡ g ∘ (i ∘ b)
   extendl {b = b} =


### PR DESCRIPTION
# Description

This PR adds a handful of reasoning combinators for functors ala `Cat.Reasoning`. I've also stolen `pushl`/`pushr` from `agda-categories`, as those can be useful.

# Notes
Coming up with these names is hard! I'm definitely open to suggestions.