### PR TITLE
Some refactoring of the Shakefile 

### DIFF
--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -20,13 +20,12 @@
 {-# LANGUAGE BlockArguments, OverloadedStrings, RankNTypes #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilies, FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wall -Wextra -Wno-name-shadowing #-}
 module Main (main) where
 
 import Control.Monad.Error.Class
 import Control.Monad.IO.Class
 import Control.Monad.Writer
-import Control.Concurrent
-import Control.Monad
 
 import qualified Data.ByteString.Lazy as LazyBS
 import qualified Data.Text.Encoding as Text
@@ -39,9 +38,7 @@ import Data.Traversable
 import Data.Digest.Pure.SHA
 import Data.Map.Lazy (Map)
 import Data.Generics
-import Data.Function (on)
 import Data.Foldable
-import Data.Either
 import Data.Maybe
 import Data.Text (Text)
 import Data.List
@@ -53,9 +50,6 @@ import Development.Shake
 import Network.URI.Encode (decodeText)
 
 import qualified System.Directory as Dir
-import System.IO.Unsafe
-import System.Console.GetOpt
-import System.Process (callCommand)
 
 import Text.HTML.TagSoup
 import Text.DocTemplates
@@ -66,12 +60,9 @@ import Text.Pandoc
 import Text.Printf
 
 import Agda.Syntax.Translation.AbstractToConcrete (abstractToConcrete_)
-import Agda.Interaction.FindFile (SourceFile(..), rootNameModule)
-import Agda.TypeChecking.Pretty (PrettyTCM(prettyTCM))
+import Agda.Interaction.FindFile (SourceFile(..))
 import Agda.Syntax.Translation.InternalToAbstract ( Reify(reify) )
 import Agda.Syntax.Internal (Type, Dom, domName)
-import Agda.TypeChecking.Serialise (decodeFile)
-import qualified Agda.Interaction.FindFile as Agda
 import qualified Agda.Utils.Maybe.Strict as S
 import qualified Agda.Syntax.Concrete as Con
 import Agda.TypeChecking.Monad.Options
@@ -88,39 +79,263 @@ import Agda.Syntax.Common
 import Agda.Utils.Pretty
 import Agda.Syntax.Info
 
-newtype LatexEquation = LatexEquation (Bool, Text) -- TODO: Less lazy instance
-  deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
+{-
+  Welcome to the Horror That Is 1Lab's Build Script.
 
-type instance RuleResult LatexEquation = Text
+  Building 1Lab comprises of (roughly) the following steps:
+-}
+main :: IO ()
+main = shakeArgs shakeOptions{shakeFiles="_build", shakeChange=ChangeDigest} $ do
+  fileIdMap <- newCache parseFileIdents
+  fileTyMap <- newCache parseFileTypes
+  gitCommit <- newCache gitCommit
+  gitAuthors <- newCache (gitAuthors (gitCommit ()))
 
-data Reference
-  = Reference { refHref :: Text
-              , refClasses :: [Text]
-              }
-  deriving (Eq, Show)
+  {-
+    Write @_build/all-pages.agda@. This imports every module in the source tree
+    (causing Agda to compile them) as well as importing all builtin modules
+    (which is required for fetching type information).
 
+    Once the file is produced, compile them and write the resulting HTML (for
+    @.agda@) and markdown (for @.lagda.md@) files to @_build/html0@.
+  -}
+  "_build/all-pages.agda" %> \out -> do
+    files <- sort <$> getDirectoryFiles "src" ["**/*.agda", "**/*.lagda.md"]
+    need (map ("src" </>) files)
+    let
+      toOut x | takeExtensions x == ".lagda.md"
+              = moduleName (dropExtensions x) ++ " -- (text page)"
+      toOut x = moduleName (dropExtensions x) ++ " -- (code only)"
+
+    writeFileLines out $ "{-# OPTIONS --cubical #-}"
+                       : ["open import " ++ toOut x | x <- files]
+                      ++ ["import " ++ x ++ " -- (builtin)" | x <- builtinModules]
+
+    command [] "agda"
+      [ "--html"
+      , "--html-dir=_build/html0"
+      , "--html-highlight=auto"
+      , "--highlight-occurrences" -- We don't use the script, but it loads in highlight-hover.js for us.
+      , "--local-interfaces"
+      , "--css=/css/agda-cats.css"
+      , out
+      ]
+
+  {-
+    For each 1Lab module, read the emitted file from @_build/html0@. If its
+    HTML, we just copy it to @_build/html1@. Otherwise we compile the markdown
+    to HTML with some additional post-processing steps (see 'buildMarkdown')
+
+    Finally we emit the HTML using the @support/web/template.html@ template
+    and run @agda-fold_equations@ on the output.
+  -}
+  "_build/html1/*.html" %> \out -> do
+    need ["_build/all-pages.agda"]
+
+    let
+      modname = dropExtension (takeFileName out)
+      input = "_build/html0" </> modname
+
+    ismd <- liftIO $ Dir.doesFileExist (input <.> ".md")
+
+    gitCommit <- gitCommit ()
+
+    if ismd
+      then buildMarkdown gitCommit gitAuthors (input <.> ".md") out
+      else liftIO $ Dir.copyFile (input <.> ".html") out
+
+  {-
+    @_build/html1@ now contains all processed 1Lab modules in HTML form. We now
+    'just' need to do some additional post-processing before copying them into
+    our final @_build/html@ output folder.
+
+     - Try to determine the type for each Agda identifier and annotate the HTML
+       with those types ('addLinkType').
+     - Replace @agda://xyz@ links with a link to the actual definition
+       ('parseAgdaLink').
+     - Check the markup for raw <!-- or -->, which indicates a misplaced
+       comment ('checkMarkup').
+  -}
+  "_build/html/*.html" %> \out -> do
+    let input = "_build/html1" </> takeFileName out
+    need [input]
+
+    text <- liftIO $ Text.readFile input
+    tags <- traverse (addLinkType fileTyMap <=< parseAgdaLink fileIdMap) (parseTags text)
+    traverse_ (checkMarkup (takeFileName out)) tags
+    liftIO $ Text.writeFile out (renderHTML5 tags)
+
+  "_build/html/static/links.json" %> \out -> do
+    need ["_build/html1/all-pages.html"]
+    (start, act) <- runWriterT $ findLinks (tell . Set.singleton) . parseTags
+      =<< liftIO (readFile "_build/html1/all-pages.html")
+    need (Set.toList act)
+    liftIO . withFile out WriteMode $ \h -> do
+      hPutStrLn h "["
+      crawlLinks
+        (\x o -> liftIO $ hPrintf h "[%s, %s],"
+          (show (dropExtension x))
+          (show (dropExtension o)))
+        (const (pure ()))
+        start
+      hPutStrLn h "null]"
+
+  -- Compile Quiver to SVG. This is used by 'buildMarkdown'.
+  "_build/html/*.svg" %> \out -> do
+    let inp = "_build/diagrams" </> takeFileName out -<.> "tex"
+    need [inp]
+    command_ [Traced "build-diagram"] "sh"
+      ["support/build-diagram.sh", out, inp]
+    removeFilesAfter "." ["rubtmp*"]
+
+  latexRules
+
+  "_build/html/css/*.css" %> \out -> do
+    let inp = "support/web/" </> takeFileName out -<.> "scss"
+    need [inp, "support/web/vars.scss", "support/web/mixins.scss"]
+    command_ [] "sassc" [inp, out]
+
+  "_build/html/favicon.ico" %> \out -> do
+    need ["support/favicon.ico"]
+    copyFile' "support/favicon.ico" out
+
+  "_build/html/static/**/*" %> \out -> do
+    let inp = "support/" </> dropDirectory1 (dropDirectory1 out)
+    need [inp]
+    traced "copying" $ Dir.copyFile inp out
+
+  "_build/html/*.js" %> \out -> do
+    let inp = "support/web" </> takeFileName out
+    need [inp]
+    traced "copying" $ Dir.copyFile inp out
+
+  {-
+    The final build step. This basically just finds all the files we actually
+    need and kicks off the above job to build them.
+  -}
+  phony "all" do
+    need ["_build/all-pages.agda"]
+    files <- filter ("open import" `isPrefixOf`) . lines <$> readFile' "_build/all-pages.agda"
+    need $ "_build/html/all-pages.html"
+         : [ "_build/html" </> (words file !! 2) <.> "html"
+           | file <- files
+           ]
+
+    f1 <- getDirectoryFiles "support" ["**/*.scss"] >>= \files -> pure ["_build/html/css/" </> takeFileName f -<.> "css" | f <- files]
+    f2 <- getDirectoryFiles "support" ["**/*.js"] >>= \files -> pure ["_build/html/" </> takeFileName f | f <- files]
+    f3 <- getDirectoryFiles "support/static/" ["**/*"] >>= \files ->
+      pure ["_build/html/static" </> f | f <- files]
+    f4 <- getDirectoryFiles "_build/html0" ["Agda.*.html"] >>= \files ->
+      pure ["_build/html/" </> f | f <- files]
+    need $ [ "_build/html/favicon.ico", "_build/html/static/links.json" ] ++ f1 ++ f2 ++ f3 ++ f4
+
+  -- ???
+
+  phony "clean" do
+    removeFilesAfter "_build" ["html0/*", "html/*", "diagrams/*", "*.agda", "*.md", "*.html"]
+
+  phony "really-clean" do
+    need ["clean"]
+    removeFilesAfter "_build" ["**/*.agdai", "*.lua"]
+
+  -- Profit!
+
+-- | Determine the name of a module from a file like @1Lab/HIT/Torus@.
 moduleName :: FilePath -> String
 moduleName = intercalate "." . splitDirectories
 
-findModule :: MonadIO m => String -> m FilePath
-findModule modname = do
-  let toPath '.' = '/'
-      toPath c = c
-  let modfile = "src" </> map toPath modname
+-- | Write a HTML file, correctly handling the closing of some tags.
+renderHTML5 :: [Tag Text] -> Text
+renderHTML5 = renderTagsOptions renderOptions{ optMinimize = min } where
+  min = flip elem ["br", "meta", "link", "img", "hr"]
 
-  exists <- liftIO $ Dir.doesFileExist (modfile <.> "lagda.md")
-  pure $ if exists
-    then modfile <.> "lagda.md"
-    else modfile <.> "agda"
+--------------------------------------------------------------------------------
+-- Various oracles
+--------------------------------------------------------------------------------
 
+-- | A link to an identifier in an emitted Agda file of the form @1Lab.Module#1234@.
+newtype Reference = Reference Text deriving (Eq, Show)
+
+-- | Parse an Agda module in @_build/html1@ and build a map of all its definitions
+-- to their link.
+parseFileIdents :: Text -> Action (Map Text Reference, Map Text Text)
+parseFileIdents mod =
+  do
+    let path = "_build/html1" </> Text.unpack mod <.> "html"
+    need [ path ]
+    traced ("parsing " ++ Text.unpack mod) do
+      go mempty mempty . parseTags <$> Text.readFile path
+  where
+    go fwd rev (TagOpen "a" attrs:TagText name:TagClose "a":xs)
+      | Just id <- lookup "id" attrs, Just href <- lookup "href" attrs
+      , mod `Text.isPrefixOf` href, id `Text.isSuffixOf` href
+      = go (Map.insert name (Reference href) fwd)
+           (Map.insert href name rev) xs
+      | Just classes <- lookup "class" attrs, Just href <- lookup "href" attrs
+      , "Module" `elem` Text.words classes, mod `Text.isPrefixOf` href
+      = go (Map.insert name (Reference href) fwd)
+           (Map.insert href name rev) xs
+    go fwd rev (_:xs) = go fwd rev xs
+    go fwd rev [] = (fwd, rev)
+
+
+-- | Get the current git commit.
+gitCommit :: () -> Action String
+gitCommit () = do
+  Stdout t <- command [] "git" ["rev-parse", "--verify", "HEAD"]
+  pure (head (lines t))
+
+-- | Get the authors for a particular commit.
+gitAuthors :: Action String -> FilePath -> Action [Text]
+gitAuthors commit path = do
+  _commit <- commit -- We depend on the commit, but don't actually need it.
+
+  -- Sort authors list and make it unique.
+  Stdout authors <- command [] "git" ["log", "--format=%aN", "--", path]
+  let authorSet = Set.fromList . Text.lines . Text.decodeUtf8 $ authors
+
+  Stdout coauthors <-
+    command [] "git" ["log", "--format=%(trailers:key=Co-authored-by,valueonly)", "--", path]
+
+  let
+    coauthorSet = Set.fromList
+      . map dropEmail
+      . filter (not . Text.null . Text.strip)
+      . Text.lines
+      . Text.decodeUtf8 $ coauthors
+
+    dropEmail = Text.unwords . init . Text.words
+
+  pure . Set.toList $ authorSet <> coauthorSet
+
+--------------------------------------------------------------------------------
+-- Markdown Compilation
+--------------------------------------------------------------------------------
+
+{-| Convert a markdown file to templated HTML.
+
+After parsing the markdown, we perform the following post-processing steps:
+  - Run @agda-reference-filter@ on the parsed Markdown.
+  - Put inline equations (@$...$@) in a special @<span>@ to avoid word wrapping.
+  - Add header links to each header.
+  - For each quiver diagram, write its contents to @_build/diagrams/DIGEST.tex@
+    and depend on @_build/html/DIGEST.svg@. This kicks off another build step
+    which runs @support/build-diagram.sh@ to build the SVG.
+  - For each equation, invoke katex to compile them to HTML. This is cached
+    between runs (search for 'LatexEquation' in 'main').
+  - Fetch all git authors for this file and add it to the template info.
+
+Finally, we emit the markdown to HTML using the @support/web/template.html@
+template, pipe the output of that through @agda-fold-equations@, and write
+the file.
+-}
 buildMarkdown :: String
               -> (FilePath -> Action [Text])
-              -> (Text -> Action (Map Text Reference, Map Text Text))
               -> FilePath -> FilePath -> Action ()
-buildMarkdown gitCommit gitAuthors moduleIds input output = do
+buildMarkdown gitCommit gitAuthors input output = do
   let
     templateName = "support/web/template.html"
-    modname = moduleName (dropDirectory1 (dropDirectory1 (dropExtension input)))
+    modname = dropDirectory1 (dropDirectory1 (dropExtension input))
 
   need [templateName, input]
 
@@ -202,154 +417,56 @@ buildMarkdown gitCommit gitAuthors moduleIds input output = do
                     , writerExtensions = getDefaultExtensions "html" }
     writeHtml5String options markdown
 
-  tags <- traverse (parseAgdaLink moduleIds) (parseTags text)
-  liftIO $ Text.writeFile output (renderHTML5 tags)
+  liftIO $ Text.writeFile output text
 
   command_ [] "agda-fold-equations" [output]
 
-renderHTML5 :: [Tag Text] -> Text
-renderHTML5 = renderTagsOptions renderOptions{ optMinimize = min } where
-  min = flip elem ["br", "meta", "link", "img", "hr"]
+-- | Find the original Agda file from a 1Lab module name.
+findModule :: MonadIO m => String -> m FilePath
+findModule modname = do
+  let toPath '.' = '/'
+      toPath c = c
+  let modfile = "src" </> map toPath modname
 
-main :: IO ()
-main = shakeArgs shakeOptions{shakeFiles="_build", shakeChange=ChangeDigest} $ do
-  fileIdMap <- newCache parseFileIdents
-  fileTyMap <- newCache parseFileTypes
-  gitCommit <- newCache gitCommit
-  gitAuthors <- newCache (gitAuthors (gitCommit ()))
+  exists <- liftIO $ Dir.doesFileExist (modfile <.> "lagda.md")
+  pure $ if exists
+    then modfile <.> "lagda.md"
+    else modfile <.> "agda"
 
-  "_build/all-pages.agda" %> \out -> do
-    files <- sort <$> getDirectoryFiles "src" ["**/*.agda", "**/*.lagda.md"]
-    need (map ("src" </>) files)
-    let
-      toOut x | takeExtensions x == ".lagda.md"
-              = moduleName (dropExtensions x) ++ " -- (text page)"
-      toOut x = moduleName (dropExtensions x) ++ " -- (code only)"
+newtype LatexEquation = LatexEquation (Bool, Text) -- TODO: Less lazy instance
+  deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
 
-    writeFileLines out $ "{-# OPTIONS --cubical #-}"
-                       : ["open import " ++ toOut x | x <- files]
-                      ++ ["import " ++ x ++ " -- (builtin)" | x <- builtinModules]
+type instance RuleResult LatexEquation = Text
 
-    command [] "agda"
-      [ "--html"
-      , "--html-dir=_build/html0"
-      , "--html-highlight=auto"
-      , "--local-interfaces"
-      , "--css=/css/agda-cats.css"
-      , out
-      ]
+-- | Compile a latex equation to a HTML string.
+latexRules :: Rules ()
+latexRules = versioned 1 do
+  _ <- addOracleCache \(LatexEquation (display, tex)) -> do
+    need [".macros"]
 
-  "_build/html1/*.html" %> \out -> do
-    need ["_build/all-pages.agda"]
+    let args = ["-f", ".macros", "-t"] ++ ["-d" | display]
+        stdin = LazyBS.fromStrict $ Text.encodeUtf8 tex
+    Stdout out <- command [StdinBS stdin] "katex" args
+    pure . Text.stripEnd . Text.decodeUtf8 $ out
 
-    let
-      modname = dropExtension (takeFileName out)
-      input = "_build/html0" </> modname
+  pure ()
 
-    ismd <- liftIO $ Dir.doesFileExist (input <.> ".md")
-
-    gitCommit <- gitCommit ()
-
-    if ismd
-      then buildMarkdown gitCommit gitAuthors fileIdMap (input <.> ".md") out
-      else liftIO $ Dir.copyFile (input <.> ".html") out
-
-  "_build/html/*.html" %> \out -> do
-    let input = "_build/html1" </> takeFileName out
-    need [input]
-
-    text <- liftIO $ Text.readFile input
-    tags <- traverse (addLinkType fileIdMap fileTyMap) (parseTags text)
-    traverse_ (checkMarkup (takeFileName out)) tags
-    liftIO $ Text.writeFile out (renderHTML5 tags)
-
-  "_build/html/static/links.json" %> \out -> do
-    need ["_build/html1/all-pages.html"]
-    (start, act) <- runWriterT $ findLinks (tell . Set.singleton) . parseTags
-      =<< liftIO (readFile "_build/html1/all-pages.html")
-    need (Set.toList act)
-    liftIO . withFile out WriteMode $ \h -> do
-      hPutStrLn h "["
-      crawlLinks
-        (\x o -> liftIO $ hPrintf h "[%s, %s],"
-          (show (dropExtension x))
-          (show (dropExtension o)))
-        (const (pure ()))
-        start
-      hPutStrLn h "null]"
-
-  "_build/html/*.svg" %> \out -> do
-    let inp = "_build/diagrams" </> takeFileName out -<.> "tex"
-    need [inp]
-    command_ [Traced "build-diagram"] "sh"
-      ["support/build-diagram.sh", out, inp]
-    removeFilesAfter "." ["rubtmp*"]
-
-  "_build/html/css/*.css" %> \out -> do
-    let inp = "support/web/" </> takeFileName out -<.> "scss"
-    need [inp]
-    command_ [] "sassc" [inp, out]
-
-  "_build/html/favicon.ico" %> \out -> do
-    need ["support/favicon.ico"]
-    copyFile' "support/favicon.ico" out
-
-  "_build/html/static/**/*" %> \out -> do
-    let inp = "support/" </> dropDirectory1 (dropDirectory1 out)
-    need [inp]
-    traced "copying" $ Dir.copyFile inp out
-
-  "_build/html/*.js" %> \out -> do
-    let inp = "support/web" </> takeFileName out
-    need [inp]
-    traced "copying" $ Dir.copyFile inp out
-
-  phony "all" do
-    need ["_build/all-pages.agda"]
-    files <- filter ("open import" `isPrefixOf`) . lines <$> readFile' "_build/all-pages.agda"
-    need $ "_build/html/all-pages.html"
-         : [ "_build/html" </> (words file !! 2) <.> "html"
-           | file <- files
-           ]
-
-    f1 <- getDirectoryFiles "support" ["**/*.scss"] >>= \files -> pure ["_build/html/css/" </> takeFileName f -<.> "css" | f <- files]
-    f2 <- getDirectoryFiles "support" ["**/*.js"] >>= \files -> pure ["_build/html/" </> takeFileName f | f <- files]
-    f3 <- getDirectoryFiles "support/static/" ["**/*"] >>= \files ->
-      pure ["_build/html/static" </> f | f <- files]
-    f4 <- getDirectoryFiles "_build/html0" ["Agda.*.html"] >>= \files ->
-      pure ["_build/html/" </> f | f <- files]
-    need $ [ "_build/html/favicon.ico", "_build/html/static/links.json" ] ++ f1 ++ f2 ++ f3 ++ f4
-
-  phony "clean" do
-    removeFilesAfter "_build" ["html0/*", "html/*", "diagrams/*", "*.agda", "*.md", "*.html"]
-
-  phony "really-clean" do
-    need ["clean"]
-    removeFilesAfter "_build" ["**/*.agdai", "*.lua"]
-
-  versioned 1 do
-    _ <- addOracleCache \(LatexEquation (display, tex)) -> do
-      need [".macros"]
-
-      let args = ["-f", ".macros", "-t"] ++ ["-d" | display]
-          stdin = LazyBS.fromStrict $ Text.encodeUtf8 tex
-      Stdout out <- command [StdinBS stdin] "katex" args
-      pure . Text.stripEnd . Text.decodeUtf8 $ out
-
-    pure ()
+--------------------------------------------------------------------------------
+-- Additional HTML post-processing
+--------------------------------------------------------------------------------
 
 -- | Possibly interpret an <a href="agda://"> link to be a honest-to-god
 -- link to the definition.
 parseAgdaLink :: (Text -> Action (Map Text Reference, Map Text Text))
-                 -> Tag Text -> Action (Tag Text)
-parseAgdaLink fileIds tag@(TagOpen "a" attrs)
+              -> Tag Text -> Action (Tag Text)
+parseAgdaLink fileIds (TagOpen "a" attrs)
   | Just href <- lookup "href" attrs, Text.pack "agda://" `Text.isPrefixOf` href = do
     href <- pure $ Text.splitOn "#" (Text.drop (Text.length "agda://") href)
     let
       cont mod ident = do
         (idMap, _) <- fileIds mod
         case Map.lookup ident idMap of
-          Just (Reference href classes) -> do
+          Just (Reference href) -> do
             pure (TagOpen "a" (emplace [("href", href)] attrs))
           _ -> error $ "Could not compile Agda link: " ++ show href
     case href of
@@ -364,21 +481,18 @@ emplace [] ys = ys
 
 -- | Lookup an identifier given a module name and ID within that module,
 -- returning its type.
-addLinkType :: (Text -> Action (Map Text Reference, Map Text Text)) -- ^ Lookup an ident from a module name and location
-             -> (() -> Action (Map Text Text)) -- ^ Lookup a type from a module name and ident
-             -> Tag Text -> Action (Tag Text)
-addLinkType fileIds fileTys tag@(TagOpen "a" attrs)
+addLinkType :: (() -> Action (Map Text Text)) -- ^ Lookup a type from a module name and ident
+            -> Tag Text -> Action (Tag Text)
+addLinkType fileTys tag@(TagOpen "a" attrs)
   | Just href <- lookup "href" attrs
-  , [mod, _] <- Text.splitOn ".html#" href = do
-    ty <- resolveId mod href <$> fileIds mod <*> fileTys ()
+  , Text.any (=='#') href = do
+    ty <- Map.lookup href <$> fileTys ()
     pure case ty of
       Nothing -> tag
       Just ty -> TagOpen "a" (emplace [("data-type", ty)] attrs)
+addLinkType _ x = pure x
 
-    where
-      resolveId mod href (_, ids) types = Map.lookup href types
-addLinkType _ _ x = pure x
-
+-- | Check HTML markup is well-formed.
 checkMarkup :: FilePath -> Tag Text -> Action ()
 checkMarkup file (TagText txt)
   |  "<!--" `Text.isInfixOf` txt || "<!–" `Text.isInfixOf` txt
@@ -386,57 +500,9 @@ checkMarkup file (TagText txt)
   = fail $ "[WARN] " ++ file ++ " contains misplaced <!-- or -->"
 checkMarkup _ _ = pure ()
 
-
--- | Parse an Agda module (in the final build directory) to find a list
--- of its definitions.
-parseFileIdents :: Text -> Action (Map Text Reference, Map Text Text)
-parseFileIdents mod =
-  do
-    let path = "_build/html1" </> Text.unpack mod <.> "html"
-    need [ path ]
-    traced ("parsing " ++ Text.unpack mod) do
-      go mempty mempty . parseTags <$> Text.readFile path
-  where
-    go fwd rev (TagOpen "a" attrs:TagText name:TagClose "a":xs)
-      | Just id <- lookup "id" attrs, Just href <- lookup "href" attrs
-      , Just classes <- lookup "class" attrs
-      , mod `Text.isPrefixOf` href, id `Text.isSuffixOf` href
-      = go (Map.insert name (Reference href (Text.words classes)) fwd)
-           (Map.insert href name rev) xs
-      | Just classes <- lookup "class" attrs, Just href <- lookup "href" attrs
-      , "Module" `elem` Text.words classes, mod `Text.isPrefixOf` href
-      = go (Map.insert name (Reference href (Text.words classes)) fwd)
-           (Map.insert href name rev) xs
-    go fwd rev (_:xs) = go fwd rev xs
-    go fwd rev [] = (fwd, rev)
-
-
-gitCommit :: () -> Action String
-gitCommit () = do
-  Stdout t <- command [] "git" ["rev-parse", "--verify", "HEAD"]
-  pure (head (lines t))
-
-gitAuthors :: Action String -> FilePath -> Action [Text]
-gitAuthors commit path = do
-  _commit <- commit -- We depend on the commit, but don't actually need it.
-
-  -- Sort authors list and make it unique.
-  Stdout authors <- command [] "git" ["log", "--format=%aN", "--", path]
-  let authorSet = Set.fromList . Text.lines . Text.decodeUtf8 $ authors
-
-  Stdout coauthors <-
-    command [] "git" ["log", "--format=%(trailers:key=Co-authored-by,valueonly)", "--", path]
-
-  let
-    coauthorSet = Set.fromList
-      . map dropEmail
-      . filter (not . Text.null . Text.strip)
-      . Text.lines
-      . Text.decodeUtf8 $ coauthors
-
-    dropEmail = Text.unwords . init . Text.words
-
-  pure . Set.toList $ authorSet <> coauthorSet
+--------------------------------------------------------------------------------
+-- Loading types from .agdai files
+--------------------------------------------------------------------------------
 
 --  Loads our type lookup table into memory
 parseFileTypes :: () -> Action (Map Text Text)
@@ -555,6 +621,10 @@ builtinModules =
   , "Agda.Primitive.Cubical"
   , "Agda.Primitive"
   ]
+
+--------------------------------------------------------------------------------
+-- Generate all edges between pages
+--------------------------------------------------------------------------------
 
 findLinks :: MonadIO m => (String -> m ()) -> [Tag String] -> m [String]
 findLinks cb (TagOpen "a" attrs:xs)

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
-{- stack --resolver lts-18.18 script
+{- stack --resolver lts-19.5 script
          --package aeson
          --package Agda
          --package bytestring
@@ -56,7 +56,6 @@ import qualified System.Directory as Dir
 import System.IO.Unsafe
 import System.Console.GetOpt
 import System.Process (callCommand)
-import System.IO
 
 import Text.HTML.TagSoup
 import Text.DocTemplates

--- a/support/web/agda-cats.scss
+++ b/support/web/agda-cats.scss
@@ -1,4 +1,5 @@
 @import "vars.scss";
+@import "mixins.scss";
 
 div.diagram-container {
   width: 100%;
@@ -87,6 +88,37 @@ hr {
   color: #ABB2BF;
   margin-top: 1em;
   margin-bottom: 1em;
+}
+
+code, pre, .sourceCode {
+  font-family: 'Iosevka', 'Fantasque Sans Mono', Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
+  font-weight: 500;
+}
+
+div.sourceCode, pre {
+  background-color: $code-bg;
+  color: $code-fg;
+  flex-grow: 0;
+
+  @include material;
+
+  overflow-x: auto;
+  line-height: 1.2;
+
+  code {
+    display: block;
+  }
+
+  > pre {
+    padding: unset;
+    margin-top: unset;
+    margin-bottom: unset;
+    box-shadow: unset;
+
+    margin: 0;
+
+    overflow-y: clip;
+  }
 }
 
 pre.Agda {
@@ -180,4 +212,13 @@ a[href].hover-highlight {
 
 span.qed {
   float: right;
+}
+
+.typeTooltip {
+  position: absolute;
+  z-index: 100;
+
+  font-size: 0.8em;
+  color: $code-fg;
+  background: $code-bg;
 }

--- a/support/web/default.scss
+++ b/support/web/default.scss
@@ -1,4 +1,5 @@
 @import "vars.scss";
+@import "mixins.scss";
 
 @mixin centered-contents {
   display: flex;
@@ -75,17 +76,6 @@ body {
   padding-bottom: 0.2em;
 
   border-left: 5px dashed $color;
-}
-
-@mixin material {
-  padding: 1em;
-
-  margin-top: 1em;
-  margin-bottom: 1em;
-
-  box-shadow: 2px 2px 6px black;
-
-  border-radius: 10px;
 }
 
 main {
@@ -244,37 +234,6 @@ div.columns {
     padding-bottom: 0.2em;
 
     border: 0;
-  }
-}
-
-code, pre, .sourceCode {
-  font-family: 'Iosevka', 'Fantasque Sans Mono', Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace;
-  font-weight: 500;
-}
-
-div.sourceCode, pre {
-  background-color: $code-bg;
-  color: $code-fg;
-  flex-grow: 0;
-
-  @include material;
-
-  overflow-x: auto;
-  line-height: 1.2;
-
-  code {
-    display: block;
-  }
-
-  > pre {
-    padding: unset;
-    margin-top: unset;
-    margin-bottom: unset;
-    box-shadow: unset;
-
-    margin: 0;
-
-    overflow-y: clip;
   }
 }
 
@@ -512,16 +471,6 @@ code.at, span.at { color: $code-green; } /* Attribute */
 code.do, span.do { color: $code-red; } /* Documentation */
 code.an, span.an { color: $code-red; } /* Annotation */
 code.cv, span.cv { color: $code-red; } /* CommentVar */
-
-.typeTooltip {
-  position: absolute;
-  z-index: 100;
-
-  font-size: 0.8em;
-  color: $code-fg;
-  background: $code-bg;
-}
-
 
 div.profile {
   &.pfp-left {

--- a/support/web/mixins.scss
+++ b/support/web/mixins.scss
@@ -1,0 +1,10 @@
+@mixin material {
+  padding: 1em;
+
+  margin-top: 1em;
+  margin-bottom: 1em;
+
+  box-shadow: 2px 2px 6px black;
+
+  border-radius: 10px;
+}


### PR DESCRIPTION
 - Document the main build steps, grouping the definitions together a little better.
 - Run the agda:// step later on, allowing for cyclic references.
 - Include the highlight-hover.js script in raw Agda files. Also move some CSS around so type tooltips work.