### PR TITLE
LaTeX equation not rendering

### DIFF
--- a/src/1Lab/intro.lagda.md
+++ b/src/1Lab/intro.lagda.md
@@ -1279,8 +1279,8 @@ A section of this fibration --- that is, a dependent function like $f$
 --- is then a _continuous_ function $A \times A \to A^\bb{I}$, with
 the property that $(d_0,d_1) \circ f = \id{id}$. Now assume that our
 space $A$ is pointed, say with a point $y_0 : A$, and that we have a
-section $f$. We can then define the homotopy $ (x,t) \mapsto f(x,y_0,t)
-$, mapping between the identity function on $A$ and the constant
+section $f$. We can then define the homotopy $(x,t) \mapsto f(x,y_0,t)$,
+mapping between the identity function on $A$ and the constant
 function at $y_0$, exhbiting the space $A$ as contractible.
 
 If you assume the law of excluded middle, every space is either pointed


### PR DESCRIPTION
Hey! I was reading this to prepare for the HoTT summer school and noticed an equation wasn't rendering properly. Kind of a bummer since it was the very last equation which the whole page was building up to lol. I figured it's probably because of the line break in between the dollar signs, so I went and removed it. I'm not sure it works because I can't test it right now but thought I should let you know.

# Description

Fixed a bug where a latex equation wasn't rendering (I think)

## Checklist

Before submitting a merge request, please check the items below:

- [x] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [x] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [x] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".
