### PR TITLE
web: add navbar inline footnote checkbox (not tested)

### DIFF
--- a/support/web/template.html
+++ b/support/web/template.html
@@ -144,7 +144,7 @@
       </span>
 
       <!-- Navbar footnotes control -->
-      <span class="inline-footnotes" style="display: flex; gap: 0.25em; flex-wrap: nowrap;">
+      <span class="inline-footnotes" style="display: none; gap: 0.25em; flex-wrap: nowrap;">
         <input name=navbar-fns type="checkbox" class="inline-footnotes" id=navbar-fns>
         <label for=navbar-fns>Inline Footnotes</label>
       </span>

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -102,8 +102,8 @@
         </span>
 
         <!-- Sidebar footnotes control -->
-        <span id="footnote-control" style="display: none; align-items: center; gap: 0.25em; flex-wrap: nowrap;">
-          <input name=sidebar-fns type="checkbox" id=sidebar-fns>
+        <span class="inline-footnotes" style="display: none; align-items: center; gap: 0.25em; flex-wrap: nowrap;">
+          <input name=sidebar-fns type="checkbox" class="inline-footnotes" id=sidebar-fns>
           <label for=sidebar-fns>Inline Footnotes</label>
         </span>
       </div>
@@ -137,10 +137,16 @@
       </div>
       $endif$
 
-      <!-- Font toggle checkbox -->
+      <!-- Navbar equations control -->
       <span class="equations" style="display: flex; gap: 0.25em; flex-wrap: nowrap;">
         <input name=navbar-eqns type="checkbox" class="equations" id=navbar-eqns>
         <label for=navbar-eqns>Equations</label>
+      </span>
+
+      <!-- Navbar footnotes control -->
+      <span class="inline-footnotes" style="display: flex; gap: 0.25em; flex-wrap: nowrap;">
+        <input name=navbar-fns type="checkbox" class="inline-footnotes" id=navbar-fns>
+        <label for=navbar-fns>Inline Footnotes</label>
       </span>
     </div>
 

--- a/support/web/unfold.js
+++ b/support/web/unfold.js
@@ -66,14 +66,20 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   if (footnotes) {
-    const fnctl = document.getElementById("footnote-control");
-    fnctl.style.display = "flex";
-    const selected = document.querySelector("span#footnote-control > input");
+    const fnctls = document.querySelectorAll("span.footnote-control");
+    fnctl.forEach(fnctl => fnctl.style.display = "flex");
+    const selecteds = document.querySelectorAll("input.footnote-control");
 
-    selected.checked = unfold_footnotes;
-    selected.onchange = () => {
-      unfold_footnotes = selected.checked;
-      window.localStorage.setItem(fiItem, selected.checked ? "displayed" : "hidden");
-    };
+    selecteds.forEach(selected => {
+      selected.checked = unfold_footnotes;
+      selected.onchange = () => {
+        unfold_footnotes = selected.checked;
+        window.localStorage.setItem(fiItem, selected.checked ? "displayed" : "hidden");
+        selecteds.forEach(selected => {
+          if (selected.checked !== undefined)
+            selected.checked = unfold_footnotes;
+        });
+      };
+    });
   }
 });

--- a/support/web/unfold.js
+++ b/support/web/unfold.js
@@ -67,7 +67,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (footnotes) {
     const fnctls = document.querySelectorAll("span.inline-footnotes");
-    fnctl.forEach(fnctl => fnctl.style.display = "flex");
+    fnctls.forEach(fnctl => fnctl.style.display = "flex");
     const selecteds = document.querySelectorAll("input.inline-footnotes");
 
     selecteds.forEach(selected => {

--- a/support/web/unfold.js
+++ b/support/web/unfold.js
@@ -66,9 +66,9 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   if (footnotes) {
-    const fnctls = document.querySelectorAll("span.footnote-control");
+    const fnctls = document.querySelectorAll("span.inline-footnotes");
     fnctl.forEach(fnctl => fnctl.style.display = "flex");
-    const selecteds = document.querySelectorAll("input.footnote-control");
+    const selecteds = document.querySelectorAll("input.inline-footnotes");
 
     selecteds.forEach(selected => {
       selected.checked = unfold_footnotes;


### PR DESCRIPTION
# Description

Add a footnote checkbox to the navbar so that people with small screens can toggle inline footnotes.

I generalized `unfold.js` to allow for multiple inline footnote checkboxes. However, I did this all from the GitHub web editor and didn't test it, so it may not work. Also, the code is very bad, so maybe it can be improved or made to be more consistent with other code?

## Checklist

Before submitting a merge request, please check the items below:

*(Hopefully? I didn't edit any Agda code.)*

- [ ] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [ ] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [ ] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".
