### PR TITLE
Fixes some broken links

### DIFF
--- a/src/Cat/Diagram/Coequaliser.lagda.md
+++ b/src/Cat/Diagram/Coequaliser.lagda.md
@@ -71,8 +71,8 @@ record Coequaliser (f g : Hom A B) : Type (o ⊔ ℓ) where
 ## Coequalisers are epic
 
 Dually to the situation with [equalisers], coequaliser arrows are always
-[epic]:
 
+[equalisers]: Cat.Diagram.Equaliser
 [epic]: Cat.Morphism.html#epis
 
 ```agda

--- a/src/Cat/Diagram/Coequaliser.lagda.md
+++ b/src/Cat/Diagram/Coequaliser.lagda.md
@@ -72,7 +72,7 @@ record Coequaliser (f g : Hom A B) : Type (o ⊔ ℓ) where
 
 Dually to the situation with [equalisers], coequaliser arrows are always
 
-[equalisers]: Cat.Diagram.Equaliser
+[equalisers]: Cat.Diagram.Equaliser.html
 [epic]: Cat.Morphism.html#epis
 
 ```agda

--- a/src/Cat/Diagram/Pushout.lagda.md
+++ b/src/Cat/Diagram/Pushout.lagda.md
@@ -22,7 +22,7 @@ subobject of the [product], the pushout is a quotient object of the
 [coproduct]. The maps $f$ and $g$ tell us which parts of the [coproduct]
 to identify.
 
-[pullback]: Cat.Diagram.Product.html
+[pullback]: Cat.Diagram.Pullback.html
 [product]: Cat.Diagram.Product.html
 [coproduct]: Cat.Diagram.Coproduct.html
 
@@ -80,5 +80,3 @@ record Pushout (f : Hom X Y) (g : Hom X Z) : Type (o ⊔ ℓ) where
 
   open is-pushout has-is-po public
 ```
-
-


### PR DESCRIPTION
# Description

Fixes some broken links on the cat Pushout and Coequaliser pages

## Checklist

Before submitting a merge request, please check the items below:

- [X] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [X] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [X] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [X] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [X] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [X] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".
