### PR TITLE
Watch mode

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ let
     shake directory tagsoup
     text containers uri-encode
     process aeson Agda pandoc SHA
+    fsnotify
   ]);
 
   static-agda = import ./support/nix/static-agda.nix;

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,6 @@ packages:
 - support/shake
 
 extra-deps:
-  - url: https://github.com/agda/agda/archive/d36cfd1fbf88c49d2169fa5fafc762d64c985a72.tar.gz
-    sha256: 46f132aed9df4fd211653328b15ed556b5e9b3298c0b8f8829381535042c7cb5
+  - url: https://github.com/agda/agda/archive/41b2f45dbe83acda7e28d4e150ca8548f04b92fb.tar.gz
+    sha256: 6f3bd2413bca62706fbb3cdeb4ba30be54dd4e2003af39dc6721318c069b8950
+  - vector-hashtables-0.1.1.1@sha256:cb4ba4af6b83b6956278bbfe8d0f779a40928728e82977e566c0103fe8d6c867,2725

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -1,11 +1,13 @@
 with import ./nixpkgs.nix;
 haskellPackages.override {
   overrides = self: super: {
-    Agda = (haskellPackages.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
+    Agda = (self.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
       owner = "agda";
       repo = "agda";
-      rev = "d36cfd1fbf88c49d2169fa5fafc762d64c985a72";
-      sha256 = sha256:0bkw3gh58kpixr0f7h60b0x3yzhinxbnzv9jmrzrdrivb9jvf7si;
+      rev = "41b2f45dbe83acda7e28d4e150ca8548f04b92fb";
+      sha256 = "sha256-jBvyp5jlwNAEtwe+n7kJp3cRib+n7r1vsBlTlJolhRs=";
     }) {}).overrideAttrs (old: { doCheck = false; });
+
+    vector-hashtables = haskell.lib.dontCheck super.vector-hashtables;
   };
 }

--- a/support/nix/nixpkgs.nix
+++ b/support/nix/nixpkgs.nix
@@ -2,4 +2,4 @@ import (builtins.fetchTarball {
   name = "1lab-nixpkgs-nixos-22.05";
   url = "https://github.com/nixos/nixpkgs/archive/7c1e79e294fe1be3cacb6408e3983bf2836c818e.tar.gz";
   sha256 = sha256:07p29mfxfw5820r4xak70mh5yijll5gkafv871519zrh6kqyr1wd;
-}) {}
+}) { config.allowBroken = true; }

--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -59,6 +59,8 @@ executable shake
       , Timer
     default-language: Haskell2010
     ghc-options: -Wextra -Wall -Wno-name-shadowing -Wno-implicit-prelude
+                 -j -threaded -with-rtsopts -A128M -rtsopts
+
 
 executable agda-typed-html
     main-is:          Wrapper.hs

--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -22,7 +22,9 @@ executable shake
       deepseq,
       directory,
       doctemplates,
+      extra,
       filepath,
+      fsnotify,
       mtl,
       pandoc,
       pandoc-types,
@@ -30,6 +32,7 @@ executable shake
       SHA,
       shake,
       split,
+      stm,
       syb,
       tagsoup,
       text,
@@ -51,6 +54,7 @@ executable shake
       , Shake.LinkReferences
       , Shake.Markdown
       , Shake.Modules
+      , Shake.Options
       , Shake.SearchData
       , Timer
     default-language: Haskell2010

--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -42,6 +42,7 @@ executable shake
       , HTML.Backend
       , HTML.Base
       , HTML.Emit
+      , Shake.AgdaCompile
       , Shake.AgdaRefs
       , Shake.Diagram
       , Shake.Git
@@ -49,6 +50,7 @@ executable shake
       , Shake.LinkGraph
       , Shake.LinkReferences
       , Shake.Markdown
+      , Shake.Modules
       , Shake.SearchData
       , Timer
     default-language: Haskell2010

--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -50,6 +50,7 @@ executable shake
       , Shake.LinkReferences
       , Shake.Markdown
       , Shake.SearchData
+      , Timer
     default-language: Haskell2010
     ghc-options: -Wextra -Wall -Wno-name-shadowing -Wno-implicit-prelude
 

--- a/support/shake/app/Main.hs
+++ b/support/shake/app/Main.hs
@@ -38,13 +38,15 @@ import Shake.Diagram
 import Shake.KaTeX
 import Shake.Git
 
+import Timer
+
 {-
   Welcome to the Horror That Is 1Lab's Build Script.
 
   Building 1Lab comprises of (roughly) the following steps:
 -}
-main :: IO ()
-main = shakeArgs shakeOptions{shakeFiles="_build", shakeChange=ChangeDigest} $ do
+rules :: Rules ()
+rules = do
   agdaRefs <- getAgdaRefs
   gitRules
   katexRules
@@ -204,3 +206,8 @@ compileAgda path _ = do
     (htmlBackend (filePath basepn) defaultHtmlOptions{htmlOptGenTypes = not skipTypes}:)
   callBackend "HTML" IsMain cr
 
+
+main :: IO ()
+main = do
+  shakeArgs shakeOptions{shakeFiles="_build", shakeChange=ChangeDigest} rules
+  reportTimes

--- a/support/shake/app/Shake/AgdaCompile.hs
+++ b/support/shake/app/Shake/AgdaCompile.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE BlockArguments, ScopedTypeVariables, TupleSections #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, TypeFamilies #-}
+module Shake.AgdaCompile (agdaRules) where
+
+import qualified System.Directory as Dir
+import System.FilePath
+
+import qualified Data.List.NonEmpty as List1
+import qualified Data.HashMap.Strict as Hm
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Data.Aeson (eitherDecodeFileStrict', encodeFile)
+import Data.Maybe
+
+import Development.Shake.Classes
+import Development.Shake
+
+import Agda.Compiler.Backend hiding (getEnv)
+import Agda.Compiler.Common
+import Agda.Interaction.FindFile (SourceFile(..))
+import Agda.Interaction.Imports
+import Agda.Interaction.Options
+import Agda.Syntax.Common (Cubical(CFull))
+import Agda.Syntax.Concrete.Name (TopLevelModuleName(..))
+import Agda.Syntax.Position (noRange)
+import Agda.Utils.FileName
+import Agda.Utils.Hash (Hash)
+import Agda.Utils.Pretty
+import Agda.Utils.Lens ((^.))
+
+import HTML.Backend
+import HTML.Base
+
+------------------------------------------------------------------------
+-- Oracles
+------------------------------------------------------------------------
+
+-- | A non-serialisable compile "answer".
+data CompileA = CompileA
+  { _cState  :: TCState
+  , _cResult :: CheckResult
+  , cHash   :: Hash
+  }
+  deriving Typeable
+
+instance Show CompileA where
+  show CompileA{} = "CompileA"
+
+instance Eq CompileA where
+  a == b = cHash a == cHash b
+
+instance Hashable CompileA where
+  hashWithSalt salt x = hashWithSalt salt (cHash x)
+
+instance Binary CompileA where
+  put _ = error "Cannot encode CompileA"
+  get = fail "Cannot decode CompileA"
+
+instance NFData CompileA where
+  rnf x = cHash x `seq` ()
+
+newtype MainCompileQ = MainCompileQ ()
+  deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
+
+type instance RuleResult MainCompileQ = CompileA
+
+newtype ModuleCompileQ = ModuleCompileQ String
+  deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
+
+type instance RuleResult ModuleCompileQ = CompileA
+
+------------------------------------------------------------------------
+-- Rules and actual compilation
+------------------------------------------------------------------------
+
+agdaRules :: Rules ()
+agdaRules = do
+  -- Add an oracle to compile Agda
+  _ <- addOracleHash \(MainCompileQ ()) -> compileAgda
+
+  -- Add a 'projection' oracle which compiles Agda and then uses the per-module
+  -- hash instead. This ensures we only rebuild HTML/types when the module
+  -- changes.
+  _ <- addOracleHash \(ModuleCompileQ m) -> do
+    (CompileA state result _) <- askOracle (MainCompileQ ())
+
+    let hash = iFullHash . getInterface state $ toTopLevel m
+    pure (CompileA state result hash)
+
+  -- Create a cache for the per-module type information.
+  getTypes <- newCache \modName -> do
+    let path = "_build/html0" </> modName <.> ".json"
+    need [path]
+
+    result :: Either String (Hm.HashMap T.Text Identifier) <-
+      quietly . traced "read types" $ eitherDecodeFileStrict' path
+    either fail pure result
+
+  -- In order to write the JSON, we first compile the required module (which
+  -- gives us the TC environment) and then emit the HTML/Markdown and type JSON.
+  "_build/html0/*.json" %> \file -> do
+    let modName = dropExtension (takeFileName file)
+    compileResult <- askOracle (ModuleCompileQ modName)
+    emitAgda compileResult getTypes modName
+
+  -- Add a couple of forwarding rules for emitting the actual HTML/MD
+  "_build/html0/*.html" %> \file -> need [file -<.> "json"]
+  "_build/html0/*.md" %> \file -> need [file -<.> "json"]
+
+  -- We generate the all-types JSON from the all-pages types JSON - it's just a
+  -- schema change.
+  "_build/all-types.json" %> \file -> do
+    types <- getTypes "all-pages"
+    liftIO $ encodeFile file (Hm.elems types)
+
+-- | Compile the top-level Agda file.
+compileAgda :: Action CompileA
+compileAgda = do
+  files <- map ("src" </>) <$> getDirectoryFiles "src" ["**/*.agda", "**/*.lagda.md"]
+  need $ "_build/all-pages.agda":files
+
+  traced "agda" do
+    baseDir <- absolute "_build"
+    absPath <- absolute "_build/all-pages.agda"
+
+    (result, state) <- runTCM initEnv initState do
+      -- Force Cubical even if we've not got a --cubical header.
+      stPragmaOptions `modifyTCLens` \ o -> o { optCubical = Just CFull }
+      setCommandLineOptions' baseDir defaultOptions
+
+      source <- parseSource (SourceFile absPath)
+      typeCheckMain TypeCheck source
+
+    -- TODO: Catch errors and pretty-print failures
+
+    let hash = iFullHash . miInterface . crModuleInfo $ result
+    pure (CompileA state result hash)
+
+
+-- | Emit an Agda file as HTML or Markdown.
+emitAgda
+  :: CompileA
+  -> (String -> Action (Hm.HashMap T.Text Identifier))
+  -> String -> Action ()
+emitAgda (CompileA tcState checkResult _) getTypes modName = do
+  liftIO $ Dir.createDirectoryIfMissing True "_build/html0"
+
+  basepn <- filePath <$> liftIO (absolute "src/")
+
+  let tlModName = toTopLevel modName
+      iface = getInterface tcState tlModName
+
+  types <- parallel . map (getTypes . render . pretty . toTopLevelModuleName . fst) $ iImportedModules iface
+
+  skipTypes <- fmap isJust . getEnv $ "SKIP_TYPES"
+  ((), _) <- quietly . traced "agda html"
+    . runTCM initEnv tcState
+    . inCompilerEnv checkResult
+    . locallyTC eActiveBackendName (const $ Just "HTML") $ do
+      compileOneModule basepn defaultHtmlOptions { htmlOptGenTypes = not skipTypes }
+        (mconcat types)
+        iface
+
+  pure ()
+
+toTopLevel :: String -> TopLevelModuleName
+toTopLevel = TopLevelModuleName noRange . List1.fromList . split where
+  split "" = []
+  split ('.':xs) = split xs
+  split xs =
+    let (here, there) = span (/= '.') xs in
+    here:split there
+
+getInterface :: TCState -> TopLevelModuleName -> Interface
+getInterface tcState name = miInterface . fromJust . Map.lookup name $ tcState ^. stVisitedModules

--- a/support/shake/app/Shake/Modules.hs
+++ b/support/shake/app/Shake/Modules.hs
@@ -1,0 +1,45 @@
+-- | Rules for working with our Agda modules.
+
+{-# LANGUAGE BlockArguments #-}
+module Shake.Modules
+  ( ModName
+  , ModKind(..)
+  , moduleRules
+  ) where
+
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
+
+import Development.Shake.FilePath
+import Development.Shake
+
+import HTML.Backend (moduleName, builtinModules)
+
+type ModName = String
+
+-- | The kind of a module.
+data ModKind = WithText | CodeOnly deriving (Eq, Ord, Show)
+
+-- | Get all modules used within 1Lab
+moduleRules :: Rules
+  ( Action (Map ModName ModKind) -- ^ Get all 1Lab modules
+  , Action (Map ModName ModKind) -- ^ Get all Agda modules used within the project.
+  )
+moduleRules = do
+  getOurModules <- newCache \() -> do
+    let
+      toOut x | takeExtensions x == ".lagda.md"
+              = (moduleName (dropExtensions x), WithText)
+      toOut x = (moduleName (dropExtensions x), CodeOnly)
+
+    Map.fromList . map toOut <$> getDirectoryFiles "src" ["**/*.agda", "**/*.lagda.md"]
+
+  let
+    getAllModules :: Action (Map ModName ModKind)
+    getAllModules = do
+      our <- getOurModules ()
+      pure $ Map.singleton "all-pages" CodeOnly
+          <> Map.fromList [(x, CodeOnly) | x <- builtinModules]
+          <> our
+
+  pure (getOurModules (), getAllModules)

--- a/support/shake/app/Shake/Options.hs
+++ b/support/shake/app/Shake/Options.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE BlockArguments, ScopedTypeVariables, TupleSections #-}
+{-# LANGUAGE DeriveGeneric, TypeFamilies #-}
+
+-- | Global build options.
+module Shake.Options
+  ( Option(..)
+  , setOptions
+  , getSkipTypes
+  , getWatching
+  ) where
+
+import Development.Shake.Classes
+import Development.Shake
+
+import GHC.Generics (Generic)
+
+data Option
+  = SkipTypes -- ^ Skip generating types when emitting HTML.
+  | Watching -- ^ Launch in watch mode. Prevents some build tasks running.
+  deriving (Show, Typeable, Eq, Generic)
+
+instance Hashable Option where
+instance Binary Option where
+instance NFData Option where
+
+type instance RuleResult Option = Bool
+
+-- | Set which option flags are enabled.
+setOptions :: [Option] -> Rules ()
+setOptions options = do
+  _ <- addOracle (pure . getOption)
+  pure ()
+  where
+    getOption SkipTypes = SkipTypes `elem` options || Watching `elem` options
+    getOption Watching = Watching `elem` options
+
+getSkipTypes, getWatching :: Action Bool
+getSkipTypes = askOracle SkipTypes
+getWatching = askOracle Watching

--- a/support/shake/app/Timer.hs
+++ b/support/shake/app/Timer.hs
@@ -1,0 +1,71 @@
+-- | A basic profiling library, for timing how long it takes to evaluate an
+-- expression.
+--
+-- This works a little like Haskell's SCC (Set Cost Center): one uses `timed' or
+-- `timedM' to give an expression a label. That expression is then timed and
+-- added to the total time for each label.
+{-# LANGUAGE BlockArguments #-}
+module Timer
+  ( timedM
+  , timed
+  , reportTimes
+  ) where
+
+import qualified Data.Map.Strict as Map
+import Data.Foldable
+import Data.Maybe
+import Data.IORef
+import Data.Text (Text)
+
+import Control.Monad.IO.Class
+import Control.DeepSeq
+import Control.Monad
+
+import System.IO.Unsafe (unsafePerformIO)
+import System.CPUTime
+
+import Text.Printf
+
+totalTimers :: IORef (Map.Map Text Integer)
+totalTimers = unsafePerformIO (newIORef mempty)
+{-# NOINLINE totalTimers #-}
+
+
+-- | Time how long a computation takes to run, forcing the returned expression.
+timedM :: (MonadIO m, NFData a) => Text -> m a -> m a
+timedM label val = do
+  start <- liftIO getCPUTime
+  val <- val
+  val `deepseq` pure ()
+  end <- liftIO getCPUTime
+
+  let duration = end - start
+  liftIO $ atomicModifyIORef totalTimers \timers ->
+    let total = duration + fromMaybe 0 (Map.lookup label timers)
+    in (Map.insert label total timers, ())
+
+  pure val
+
+-- | Time how long an expression takes to fully evaluate.
+timed :: NFData a => Text -> a -> a
+timed label val = unsafePerformIO (timedM label (pure val))
+{-# NOINLINE timed #-}
+
+
+-- | Print a table of all timings.
+reportTimes :: MonadIO m => m ()
+reportTimes = liftIO do
+  times <- readIORef totalTimers
+  unless (Map.null times) (reportTimes times)
+
+  where
+    formatPico :: Integer -> Float
+    formatPico x = fromIntegral x * 1e-12
+
+    reportTimes :: Map.Map Text Integer -> IO ()
+    reportTimes times = do
+      printf "%30s | %10s\n" "Label" "Time (s)"
+      printf "%30s | %10s\n" (replicate 30 '=') (replicate 10 '=')
+
+      for_ (Map.toList times) \(label, time) ->
+        printf "%30s | %10.2f\n" label (formatPico time)


### PR DESCRIPTION
Closes #98, see commit messages for details.

 - Adds a `--watch` flag, which launches a persistent process:

   ![A screenshot of a terminal showing a single 1Lab module being compiled in 0.2s!](https://user-images.githubusercontent.com/4346137/176969927-e7c6a63d-a45b-4aac-b318-e2b9917fa091.png)

 - Agda now does incremental HTML builds, meaning if you change something like `index.lagda.md`, you don't need to rebuild the whole source tree.

I don't think this is worth merging yet, as there's still some deficiencies. However, any testing/dogfooding would be appreciated!

 - [x] We now run Agda on every startup, even if no files have changed. This is painfully slow right now (15s) - possibly worth waiting until my Agda PRs have been merged, which should bring it down to 6-7s (painful, but less bad!)
 - [x] Generating HTML (or rather, pretty-printing types) is still painfully slow, possibly worse than what it was before. I'd like to look into speeding this up, but haven't found a good way yet - the slow bit is deep in Agda internals.

   **Edit:** Fixed! Turns out adding `-threaded` helps a lot :D. HTML now generates in ~3s on my machine.