### PR TITLE
Publish site using the new GH action instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,35 @@ jobs:
           1lab-shake all -j
           ./support/make-site.sh
 
-      - name: Deploy 🚀
-        if: ${{ github.ref_name == 'main' }}
-        uses: JamesIves/github-pages-deploy-action@4.1.7
+      - name: Archive site 📦
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory _build/html \
+            -cvf archive.tar \
+            .
+
+      - name: Upload site ⬆️
+        uses: actions/upload-artifact@v3
         with:
-          branch: gh-pages
-          folder: _build/site
+          name: github-pages
+          path: archive.tar
+          retention-days: 1
+
+  deploy:
+    needs: build
+    if: ${{ github.ref_name == 'main' }}
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy 🚀
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: support/shake/1lab-shake.cabal
+
+source-repository-package
+    type: git
+    location: https://github.com/agda/agda.git
+    tag: 5d2d77abbc0c97f5b23d7089797c3ef8796508dc

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ packages:
 - support/shake
 
 extra-deps:
-  - url: https://github.com/agda/agda/archive/41b2f45dbe83acda7e28d4e150ca8548f04b92fb.tar.gz
-    sha256: 6f3bd2413bca62706fbb3cdeb4ba30be54dd4e2003af39dc6721318c069b8950
+  - url: https://github.com/agda/agda/archive/5d2d77abbc0c97f5b23d7089797c3ef8796508dc.tar.gz
+    sha256: f36802907c1e2ae68aabd5a3f009f8ce1dc6b14de2830b06a06a61320826ccf3
   - vector-hashtables-0.1.1.1@sha256:cb4ba4af6b83b6956278bbfe8d0f779a40928728e82977e566c0103fe8d6c867,2725

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -4,8 +4,8 @@ haskellPackages.override {
     Agda = (self.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
       owner = "agda";
       repo = "agda";
-      rev = "41b2f45dbe83acda7e28d4e150ca8548f04b92fb";
-      sha256 = "sha256-jBvyp5jlwNAEtwe+n7kJp3cRib+n7r1vsBlTlJolhRs=";
+      rev = "5d2d77abbc0c97f5b23d7089797c3ef8796508dc";
+      sha256 = "sha256-Bo0vJ+en2ajs4RLJk0EQ4rDFFR/xlZvQxz5TdRrL16s=";
     }) {}).overrideAttrs (old: { doCheck = false; });
 
     vector-hashtables = haskell.lib.dontCheck super.vector-hashtables;


### PR DESCRIPTION
[As documented here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). It feels nicer than pushing to the gh-pages branch each time, but no clue how well it will work!