### PR TITLE
add explanation of `ap-comp-path` as a uniqueness property

### DIFF
--- a/src/1Lab/Path/Groupoid.lagda.md
+++ b/src/1Lab/Path/Groupoid.lagda.md
@@ -183,33 +183,10 @@ equal to `sym (sym p)`. In that case, we show that `sym p ∙ sym (sym p)
 
 In addition to the groupoid identities for paths in a type, it has been
 established that functions behave like functors: These are the lemmas
-`ap-refl`{.Agda} and `ap-sym`{.Agda} in the [1Lab.Path] module.
+`ap-refl`{.Agda}, `ap-comp-path`{.Agda} and `ap-sym`{.Agda} in the
+[1Lab.Path] module.
 
-[1Lab.Path]: 1Lab.Path.html#the-action-on-paths
-
-There, a proof that functions preserve path composition wasn't included,
-because it needs `hcomp`{.Agda} to be defined. We fill a cube where the
-left face is defined to be `ap f (p ∙ q)` (that's the `(i = i0)` face in
-the `hcomp`{.Agda} below), and the remaining structure of the proof
-mimics the definition of `_∙_`{.Agda}, so that we indeed get `ap f p ∙
-ap f q` as the right face.
-
-<!--
-```
-  _ = ap-refl
-  _ = ap-sym
-```
--->
-
-```agda
-  ap-comp-path : (f : A → B) {x y z : A} (p : x ≡ y) (q : y ≡ z)
-               → ap f (p ∙ q) ≡ ap f p ∙ ap f q
-  ap-comp-path f {x} p q i j = hcomp (∂ j ∨ ~ i) λ where
-    k (i = i0) → f (∙-filler p q k j)
-    k (j = i0) → f x
-    k (j = i1) → f (q k)
-    k (k = i0) → f (p j)
-```
+[1Lab.Path]: 1Lab.Path.html#functorial-action
 
 ### Convenient helpers
 

--- a/src/Cat/Diagram/Coend/Formula.lagda.md
+++ b/src/Cat/Diagram/Coend/Formula.lagda.md
@@ -29,7 +29,7 @@ Using the [twisted arrow category] as a mediating notion, we show how to
 compute [coends] as ordinary [colimits]. The calculation is actually a
 bit more straightforward than it might seem at first. The first thing we
 note is that any functor $F : C\op \times C \to D$ generates a functor
-from thw twisted arrow category of $\ca{C}\op$:
+from the twisted arrow category of $\ca{C}\op$:
 
 $$
 \id{Tw}(\ca{C}\op)\op \xto{\pi_t} C\op \times C \xto{F} D


### PR DESCRIPTION
# Description

An alternative explanation for the proof of `ap f (p ∙ q) ≡ ap f p ∙ ap f q`.

Also, could you please add `Naïm Favier <n@monade.li>` to the mailmap? (I've been using my full name inconsistently which makes me appear twice on some pages)

## Checklist

Before submitting a merge request, please check the items below:

- [X] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [X] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [X] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".
