### PR TITLE
chore: fix the Nix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # we need the commit history for authors
 
       - name: Get Shakefile version
         run: sha256sum /bin/1lab-shake | cut -d' ' -f1 > .shake-version
@@ -28,8 +28,6 @@ jobs:
       - name: Build 🛠️
         run: |
           echo "$mailmap" > .mailmap
-          ln -sf $NODE_DEPS_PATH .
-          git config --global --add safe.directory /__w/1lab/1lab
           1lab-shake all -j
           ./support/make-site.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ src/wip/
 *.agdai
 /result
 .shake
+/.envrc
+/.direnv
+/dist-newstyle

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ development which supports compilation of the HTML and SVG files, in
 addition to the Agda.
 
 You can then use Nix to compile the project as usual. As a quick point
-of reference, `nix build` will type-check and compile the entire thing,
+of reference, `nix-build` will type-check and compile the entire thing,
 and copy the necessary assets (TeX Gyre Pagella and KaTeX css/fonts) to
 the right locations. The result will be linked as `./result`, which can
 then be used to serve a website:
 
 ```bash
-$ nix build
+$ nix-build
 $ python -m http.server --directory result
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -9,8 +9,6 @@ let
     fsnotify
   ]);
 
-  static-agda = import ./support/nix/static-agda.nix;
-
   our-texlive = texlive.combine {
     inherit (texlive)
       collection-basic
@@ -22,10 +20,9 @@ let
       varwidth xkeyval standalone;
   };
 
-  shakefile = import ./support/nix/build-shake.nix
+  shakefile = callPackage ./support/nix/build-shake.nix
     {
       inherit our-ghc haskellPackages;
-      inherit (pkgs) removeReferencesTo stdenv upx lua5_3 gmp;
       name = "1lab-shake";
       main = "Main.hs";
     };
@@ -56,15 +53,15 @@ in
     '';
 
     installPhase = ''
-    mkdir -p $out{,/css/,/lib/};
+    mkdir -p $out{,/css/}
 
     # Copy our build artifacts
-    cp -Lrv _build/html/* $out;
+    cp -Lrvf _build/html/* $out
 
     # Copy KaTeX CSS and fonts
-    cp -Lrv --no-preserve=mode ${nodePackages.katex}/lib/node_modules/katex/dist/{katex.min.css,fonts} $out/css/;
+    cp -Lrvf --no-preserve=mode ${nodePackages.katex}/lib/node_modules/katex/dist/{katex.min.css,fonts} $out/css/
     mkdir -p $out/static/ttf/
-    cp -Lrv --no-preserve=mode ${pkgs.julia-mono}/share/fonts/truetype/JuliaMono-Regular.ttf $out/static/ttf/julia-mono.ttf
+    cp -Lrvf --no-preserve=mode ${pkgs.julia-mono}/share/fonts/truetype/JuliaMono-Regular.ttf $out/static/ttf/julia-mono.ttf
     '';
 
     passthru = {
@@ -81,10 +78,9 @@ in
       texlive = our-texlive;
       ghc = our-ghc;
       inherit fonts shakefile;
-      agda-typed-html = import ./support/nix/build-shake.nix
+      agda-typed-html = callPackage ./support/nix/build-shake.nix
         {
           inherit our-ghc haskellPackages;
-          inherit (pkgs) removeReferencesTo stdenv upx lua5_3 gmp;
           main = "Wrapper.hs";
           name = "agda-typed-html";
         };

--- a/support/make-site.sh
+++ b/support/make-site.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 rm -rf _build/site
-cp _build/html _build/site -rv
+cp _build/html _build/site -rvf
 mkdir -p _build/site/static/ _build/site/css
-cp /root/static/* _build/site/static/ -rv
-cp -L /lib/node_modules/katex/dist/katex.min.css _build/site/css -rv
-cp -L /lib/node_modules/katex/dist/fonts _build/site/css -rv
+cp /root/static/* _build/site/static/ -rvf
+cp /root/css/* _build/site/css -rvf

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -2,7 +2,7 @@ with import ./nixpkgs.nix;
 haskellPackages.override {
   overrides = self: super: {
     Agda = (self.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
-      owner = "plt-amy";
+      owner = "agda";
       repo = "agda";
       rev = "a52fc3ca191b58e552626988b663bf76c6e8cc42";
       sha256 = "sha256-pkaefBrZDr/1cP7G+uoCtyPDFprFCA6sixJdFNIvuqw=";

--- a/support/shake/app/Main.hs
+++ b/support/shake/app/Main.hs
@@ -140,7 +140,7 @@ rules = do
     getDirectoryFiles "support/web/js" ["**/*.ts", "**/*.tsx"] >>= \files -> need ["support/web/js" </> f | f <- files]
 
     let inp = "support/web/js" </> takeFileName out -<.> "ts"
-    command_ [] "node_modules/.bin/esbuild"
+    command_ [] "esbuild"
       [ "--bundle", inp
       , "--outfile=" ++ out
       , "--target=es2017"
@@ -178,7 +178,7 @@ rules = do
 
   phony "typecheck-ts" do
     getDirectoryFiles "support/web/js" ["**/*.ts", "**/*.tsx"] >>= \files -> need ["support/web/js" </> f | f <- files]
-    command_ [] "node_modules/.bin/tsc" ["--noEmit", "-p", "tsconfig.json"]
+    command_ [] "tsc" ["--noEmit", "-p", "tsconfig.json"]
 
   -- Profit!
 

--- a/support/shake/app/Shake/KaTeX.hs
+++ b/support/shake/app/Shake/KaTeX.hs
@@ -37,7 +37,7 @@ katexRules = versioned 1 do
 
     let args = ["-f", ".macros", "-t"] ++ ["-d" | display]
         stdin = LazyBS.fromStrict $ Text.encodeUtf8 tex
-    Stdout out <- command [StdinBS stdin] "node" ("node_modules/.bin/katex":args)
+    Stdout out <- command [StdinBS stdin] "katex" args
     pure . Text.stripEnd . Text.decodeUtf8 $ out
 
   pure ()


### PR DESCRIPTION
Makes `1lab-shake` more self-sufficient by wrapping it with its Node dependencies so we don't have to link node_modules into the current directory.

Also sets `--git-dir` explicitly on git calls to avoid the `safe.directory` hack.

Subsumes https://github.com/plt-amy/1lab/pull/66.

I would have liked to use [flakes](https://nixos.wiki/wiki/Flakes) to make dependency management easier, but this is pretty much dead in the water because of https://github.com/NixOS/nix/issues/6900. That's no big deal though.

I'd also like to convert the CI to use Nix instead of a Docker container. We'd still be caching `_build` of course, and only using Nix to build the shakefile. The main advantage of this (apart from the obvious "yeeting Docker") is that we could easily set up a [binary cache](https://www.cachix.org/) so that users don't need to build Agda locally after it's been built by CI.

However this isn't quite ready yet: my tests pull a lot more paths from caches than the size of the docker image, so there are probably some runtime dependencies that aren't properly getting killed. I'll look into it later.

(CI failing expectedly because it's still using the old docker image)