### PR TITLE
🐋 → ❄️

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: pltamy/1lab:latest
 
     env:
       mailmap: ${{ secrets.MAILMAP }}
@@ -14,36 +13,44 @@ jobs:
         with:
           fetch-depth: 0 # we need the commit history for authors
 
-      - name: Get Shakefile version
-        run: sha256sum /bin/1lab-shake | cut -d' ' -f1 > .shake-version
+      - name: Install Nix ❄️
+        uses: cachix/install-nix-action@v17
 
-      - name: Cache _build
-        id: cache-build
+      - name: Set up Cachix ♻️
+        uses: cachix/cachix-action@v10
+        with:
+          name: 1lab
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build the Shakefile 🧰
+        run: |
+          hash=$(nix-build -A shakefile --no-out-link)
+          hash=${hash#/nix/store/} hash=${hash%%-*}
+          echo "shake_version=$hash" >> "$GITHUB_ENV"
+
+      - name: Cache _build ♻️
         uses: actions/cache@v3
         with:
           path: _build
-          key: shake-${{ hashFiles('.shake-version' )}}-${{ github.run_id }}
-          restore-keys: shake-${{ hashFiles('.shake-version' )}}-
+          key: shake-${{ env.shake_version }}-${{ github.run_id }}
+          restore-keys: shake-${{ env.shake_version }}-
 
       - name: Build 🛠️
         run: |
           echo "$mailmap" > .mailmap
-          1lab-shake all -j
-          ./support/make-site.sh
-
-      - name: Archive site 📦
-        run: |
-          tar \
-            --dereference --hard-dereference \
-            --directory _build/site \
-            -cvf archive.tar \
-            .
+          nix-shell --arg interactive false --run "$build_command"
+        env:
+          NIX_BUILD_SHELL: bash
+          build_command: |
+            set -eu
+            1lab-shake -j all
+            export out=_build/site
+            eval "$installPhase"
 
       - name: Upload site ⬆️
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: github-pages
-          path: archive.tar
+          path: _build/site
           retention-days: 1
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Here's how you can build --- and work on --- the web parts of the 1lab.
 
 ## Using Docker
 
-An Arch Linux-based Docker container is provided which contains all the
+A Docker container is provided which contains all the
 dependencies necessary for building the 1lab, including the font files
 required for a complete deployment. Since this container is on the
 registry, we can do a one-line build of the 1Lab as follows:
 
 ```bash
 % docker run -it -v $PWD:/workspace docker.io/pltamy/1lab:latest /bin/sh -i
-$ 1lab-shake all -j       # build everything
-$ sh support/make-site.sh # copy everything into place
+$ 1lab-shake all -j    # build everything
+$ support/make-site.sh # copy everything into place
 ```
 
 After this, the directory `_build/site` will have everything in place
@@ -53,10 +53,9 @@ $ nix-build
 $ python -m http.server --directory result
 ```
 
-For interactive development, keep in mind that the `buildInputs` to
-`default.nix` _don't_ include Stack or `ghc`. However, just like the
-Docker container, a pre-built version of the Shakefile is included as
-`1lab-shake`:
+For interactive development, `nix-shell` will give you a shell with
+everything you need to hack on the 1Lab, including Agda and the pre-built
+Shakefile as `1lab-shake`:
 
 ```bash
 $ 1lab-shake all -j
@@ -68,7 +67,8 @@ into place:
 
 ```bash
 $ export out=_build/site
-$ echo "${installPhase}" | bash
+$ eval "${installPhase}"
+$ python -m http.server --directory "$out"
 ```
 
 ## Directly

--- a/docker.nix
+++ b/docker.nix
@@ -1,25 +1,18 @@
-with import ./support/nix/nixpkgs.nix;
-with haskell.lib;
 let
-  the-lab = import ./default.nix;
-  haskellPackages = import ./support/nix/haskell-packages.nix;
+  pkgs = import ./support/nix/nixpkgs.nix;
+  inherit (pkgs) lib;
+  the-lab = import ./. { interactive = false; };
 in
-  dockerTools.streamLayeredImage {
+  pkgs.dockerTools.streamLayeredImage {
     name = "pltamy/1lab";
     tag = "latest";
 
-    contents = the-lab.deps ++ [
-      pkgs.pkgsStatic.busybox # Need a shell, so go with static busybox
-      pkgs.nodejs-slim-14_x
-      the-lab.texlive
-
-      # Need to include Agda data files for the primitive modules:
-      haskellPackages.Agda.data
-      haskellPackages.pandoc.data
+    contents = with pkgs; the-lab.deps ++ [
+      pkgsStatic.busybox # Need a shell, so go with static busybox
 
       # Needed for Github Actions:
-      gnutar
-      rsync
+      # gnutar
+      # rsync
     ];
 
     config = {
@@ -28,24 +21,24 @@ in
         "LANG=C.UTF-8" # Needed for GHC to set the correct encoding on handles
 
         # Needed for Github Actions:
-        "LD_LIBRARY_PATH=${lib.makeLibraryPath [ pkgs.stdenv.cc.cc ]}"
-        "GIT_SSL_CAINFO=${cacert}/etc/ssl/certs/ca-bundle.crt"
-        "SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt"
+        # "LD_LIBRARY_PATH=${lib.makeLibraryPath [ pkgs.stdenv.cc.cc ]}"
+        # "GIT_SSL_CAINFO=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+        # "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
       ];
     };
 
     fakeRootCommands = ''
-    mkdir -p ./tmp ./lib64 ./usr/bin ./root/static ./etc
-    echo "ID=nixos" > ./etc/os-release
-    cp ./bin/env ./usr/bin/
+      mkdir -p ./tmp ./lib64 ./usr/bin ./root/static ./etc
+      echo "ID=nixos" > ./etc/os-release
+      cp ./bin/env ./usr/bin/
 
-    # Copy static assets to /root so that make-site.sh can find them
-    mkdir -p ./root/static/ttf/ ./root/css/
-    cp -Lrv --no-preserve=mode ${nodePackages.katex}/lib/node_modules/katex/dist/{katex.min.css,fonts} ./root/css/;
-    cp -Lrv --no-preserve=mode ${pkgs.julia-mono}/share/fonts/truetype/JuliaMono-Regular.ttf ./root/static/ttf/julia-mono.ttf
+      # Copy static assets to /root so that make-site.sh can find them
+      mkdir -p ./root/static/ttf/ ./root/css/
+      cp -Lrv --no-preserve=mode ${pkgs.nodePackages.katex}/lib/node_modules/katex/dist/{katex.min.css,fonts} ./root/css/;
+      cp -Lrv --no-preserve=mode ${pkgs.julia-mono}/share/fonts/truetype/JuliaMono-Regular.ttf ./root/static/ttf/julia-mono.ttf
 
-    # Needed for Github Actions
-    ln -s ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 ./lib64/ld-linux-x86-64.so.2
-    ln -sf ${pkgs.gnutar}/bin/tar ./bin/tar
+      # Needed for Github Actions
+      # ln -s ''${pkgs.glibc}/lib/ld-linux-x86-64.so.2 ./lib64/ld-linux-x86-64.so.2
+      # ln -sf ''${pkgs.gnutar}/bin/tar ./bin/tar
     '';
   }

--- a/support/nix/build-shake.nix
+++ b/support/nix/build-shake.nix
@@ -6,8 +6,8 @@
 , stdenv
 , upx
 , lua5_3
-, name
 , gmp
+, name
 , main
 }:
 let

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -1,13 +1,14 @@
-with import ./nixpkgs.nix;
-haskellPackages.override {
-  overrides = self: super: {
-    Agda = (self.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
-      owner = "agda";
-      repo = "agda";
-      rev = "a52fc3ca191b58e552626988b663bf76c6e8cc42";
-      sha256 = "sha256-pkaefBrZDr/1cP7G+uoCtyPDFprFCA6sixJdFNIvuqw=";
-    }) {}).overrideAttrs (old: { doCheck = false; });
+pkgs: super: {
+  haskell = super.haskell // {
+    packageOverrides = hpkgs: hsuper: {
+      Agda = (hpkgs.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
+        owner = "agda";
+        repo = "agda";
+        rev = "a52fc3ca191b58e552626988b663bf76c6e8cc42";
+        sha256 = "sha256-pkaefBrZDr/1cP7G+uoCtyPDFprFCA6sixJdFNIvuqw=";
+      }) {}).overrideAttrs (old: { doCheck = false; });
 
-    vector-hashtables = haskell.lib.dontCheck super.vector-hashtables;
+      vector-hashtables = pkgs.haskell.lib.dontCheck hsuper.vector-hashtables;
+    };
   };
 }

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -1,14 +1,12 @@
 pkgs: super: {
   haskell = super.haskell // {
     packageOverrides = hpkgs: hsuper: {
-      Agda = (hpkgs.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
+      Agda = pkgs.haskell.lib.dontCheck (hpkgs.callCabal2nix "Agda" (pkgs.fetchFromGitHub {
         owner = "agda";
         repo = "agda";
         rev = "a52fc3ca191b58e552626988b663bf76c6e8cc42";
         sha256 = "sha256-pkaefBrZDr/1cP7G+uoCtyPDFprFCA6sixJdFNIvuqw=";
-      }) {}).overrideAttrs (old: { doCheck = false; });
-
-      vector-hashtables = pkgs.haskell.lib.dontCheck hsuper.vector-hashtables;
+      }) {});
     };
   };
 }

--- a/support/nix/nixpkgs.nix
+++ b/support/nix/nixpkgs.nix
@@ -1,8 +1,7 @@
 import (builtins.fetchTarball {
-  name = "1lab-nixpkgs-nixos-22.05";
-  url = "https://github.com/nixos/nixpkgs/archive/7c1e79e294fe1be3cacb6408e3983bf2836c818e.tar.gz";
-  sha256 = sha256:07p29mfxfw5820r4xak70mh5yijll5gkafv871519zrh6kqyr1wd;
+  name = "1lab-nixpkgs";
+  url = "https://github.com/nixos/nixpkgs/archive/6c6409e965a6c883677be7b9d87a95fab6c3472e.tar.gz";
+  sha256 = "sha256:0l1py0rs1940wx76gpg66wn1kgq2rv2m9hzrhq5isz42hdpf4q6r";
 }) {
-  config.allowBroken = true;
   overlays = [ (import ./haskell-packages.nix) ];
 }

--- a/support/nix/nixpkgs.nix
+++ b/support/nix/nixpkgs.nix
@@ -2,4 +2,7 @@ import (builtins.fetchTarball {
   name = "1lab-nixpkgs-nixos-22.05";
   url = "https://github.com/nixos/nixpkgs/archive/7c1e79e294fe1be3cacb6408e3983bf2836c818e.tar.gz";
   sha256 = sha256:07p29mfxfw5820r4xak70mh5yijll5gkafv871519zrh6kqyr1wd;
-}) { config.allowBroken = true; }
+}) {
+  config.allowBroken = true;
+  overlays = [ (import ./haskell-packages.nix) ];
+}


### PR DESCRIPTION
Changes the build workflow to use Nix instead of a Docker container, and refactors things a bit. The most important change is that `default.nix` now takes an `interactive` argument which, when enabled (the default), adds the full `ghcWithPackages` to the environment (which includes Agda binaries). This is disabled in CI and in the Docker image.

The non-Nix build methods still work.

When everything is cached, a [trivial run](https://github.com/ncfavier/1lab/runs/7895145982?check_suite_focus=true) finishes in 2m30s and fetches about 300 MB of data, which seems acceptable.

To get caching working, you (Amy) will need to create a (free) binary cache at https://www.cachix.org/ (this PR assumes it's named `1lab`), select "API tokens" for the access method, generate an authentication token and add it as an action secret named `CACHIX_AUTH_TOKEN`.

To *use* the cache, Nix users can run `cachix use 1lab` if they have Cachix installed, or add the cache to `substituters` and `trusted-public-keys` manually in their Nix config. No more building Agda!