### PR TITLE
chore: no need for `src` in nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ interactive ? true }:
+{ # Is this a nix-shell invocation?
+  inNixShell ? false
+  # Do we want the full Agda package for interactive use? Set to false in CI
+, interactive ? true
+}:
 let
   pkgs = import ./support/nix/nixpkgs.nix;
   inherit (pkgs) lib;
@@ -49,13 +53,14 @@ let
   ]);
 in
   pkgs.stdenv.mkDerivation rec {
-    name = "cubical-1lab";
+    name = "1lab";
 
-    src = with pkgs.nix-gitignore; gitignoreFilterSourcePure (_: _: true) [
-      # Keep .git around for extracting page authors
-      (compileRecursiveGitignore ./.)
-      ".github"
-    ] ./.;
+    src = if inNixShell then null else
+      with pkgs.nix-gitignore; gitignoreFilterSourcePure (_: _: true) [
+        # Keep .git around for extracting page authors
+        (compileRecursiveGitignore ./.)
+        ".github"
+      ] ./.;
 
     nativeBuildInputs = deps;
 


### PR DESCRIPTION
Don't copy the 1lab source to the Nix store in nix-shell invocations.

This also avoids uselessly pushing ~60 MiB to Cachix at the end of every CI run.

`inNixShell` is a special argument set by Nix.