### PR TITLE
chore: make Pandoc shut up about missing translations

### DIFF
--- a/support/nix/build-shake.nix
+++ b/support/nix/build-shake.nix
@@ -42,16 +42,16 @@ stdenv.mkDerivation {
   installPhase = ''
   mkdir -p $out/bin
   strip ${main}
+  remove-references-to -t ${haskellPackages.pandoc-types} ${main}
+  remove-references-to -t ${haskellPackages.pandoc}       ${main}
+  remove-references-to -t ${haskellPackages.Agda}         ${main}
+  remove-references-to -t ${haskellPackages.shake}        ${main}
+  remove-references-to -t ${haskellPackages.HTTP}         ${main}
+  remove-references-to -t ${haskellPackages.js-flot}      ${main}
+  remove-references-to -t ${haskellPackages.js-jquery}    ${main}
+  remove-references-to -t ${haskellPackages.js-dgtable}   ${main}
   upx ${main}
   cp ${main} $out/bin/${name}
-  remove-references-to -t ${haskellPackages.pandoc-types} $out/bin/${name}
-  remove-references-to -t ${haskellPackages.pandoc}       $out/bin/${name}
-  remove-references-to -t ${haskellPackages.Agda}         $out/bin/${name}
-  remove-references-to -t ${haskellPackages.shake}        $out/bin/${name}
-  remove-references-to -t ${haskellPackages.HTTP}         $out/bin/${name}
-  remove-references-to -t ${haskellPackages.js-flot}      $out/bin/${name}
-  remove-references-to -t ${haskellPackages.js-jquery}    $out/bin/${name}
-  remove-references-to -t ${haskellPackages.js-dgtable}   $out/bin/${name}
   wrapProgram $out/bin/${name} \
     --prefix PATH : ${nodeDependencies}/bin \
     --prefix NODE_PATH : ${nodeDependencies}/lib/node_modules

--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -37,6 +37,7 @@ executable shake
       tagsoup,
       text,
       transformers,
+      unicode-collation,
       unordered-containers,
       uri-encode
     hs-source-dirs:   app
@@ -81,6 +82,7 @@ executable agda-typed-html
       syb,
       text,
       transformers,
+      unicode-collation,
       unordered-containers,
       uri-encode
     hs-source-dirs:   app

--- a/support/shake/app/Shake/Markdown.hs
+++ b/support/shake/app/Shake/Markdown.hs
@@ -30,6 +30,7 @@ import qualified Citeproc as Cite
 import Text.DocTemplates
 import Text.HTML.TagSoup
 
+import Text.Collate.Lang (Lang (..))
 import Text.Pandoc.Builder (Inlines)
 import Text.Pandoc.Citeproc
 import Text.Pandoc.Walk
@@ -220,6 +221,7 @@ renderMarkdown authors references modname markdown = do
                   , writerTableOfContents = True
                   , writerVariables = context
                   , writerExtensions = getDefaultExtensions "html" }
+  setTranslations (Lang "en" Nothing Nothing [] [] [])
   writeHtml5String options markdown
 
 


### PR DESCRIPTION
Sets the default translation language to English to avoid warnings like "The term Abstract has no translation defined."

And removes references before compressing the executable, otherwise hashes can [escape](https://github.com/NixOS/nixpkgs/pull/188299).