### PR TITLE
Fix typo in path diagram for 1Lab.Equiv.FromPath

### DIFF
--- a/src/1Lab/Equiv/FromPath.lagda.md
+++ b/src/1Lab/Equiv/FromPath.lagda.md
@@ -81,7 +81,7 @@ square below (this is the `comp`{.Agda} term):
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-  y && {g(y)} \\
+  {g(y)} && {g(y)} \\
   \\
   {f(g(y))} && y
   \arrow["{v(j,y)}", from=1-3, to=3-3]


### PR DESCRIPTION
The top left corner should be `g(y)` and not `y` to match the rest of the diagram.

Was:
```
               g(y)
        y --------------> g(y)
        |                  |
        |                  |
        |                  |
u(j,g y)|                  | v(j,y)
        |                  |
        |                  |
        |                  |
    f(g(y)) - - - - - - -> g(y)

 ```
  Should be:
```
               g(y)
      g(y) -------------> g(y)
        |                  |
        |                  |
        |                  |
u(j,g y)|                  | v(j,y)
        |                  |
        |                  |
        |                  |
    f(g(y)) - - - - - - -> g(y)

 ```