### PR TITLE
refactor: Restore shared square for Equiv.FromPath

### DIFF
--- a/src/1Lab/Equiv/FromPath.lagda.md
+++ b/src/1Lab/Equiv/FromPath.lagda.md
@@ -153,18 +153,16 @@ look at, so focus on the diagram: It connects `β₀`{.Agda} and
 ~~~
 
 ```agda
-    square : A → ∀ j i → PartialP (~ j ∨ j) (λ _ → P (~ i))
-    square x j i (j = i0) = v (~ i) y
-    square x j i (j = i1) = u (~ i) x
+    square : ∀ (x : A) (β : f x ≡ y) j i → PartialP (∂ j ∨ ~ i) (λ _ → P (~ i))
+    square x β j i (j = i0) = v (~ i) y
+    square x β j i (j = i1) = u (~ i) x
+    square x β j i (i = i0) = β (~ j)
 
     ω₀ : g y ≡ x₀
-    ω₀ j = primComp (λ i → P (~ i)) (square x₀ j) (β₀ (~ j))
+    ω₀ j = comp (λ i → P (~ i)) (∂ j) (square x₀ β₀ j)
 
     θ₀ : SquareP (λ i j → P (~ j)) (sym β₀) (λ i → v (~ i) y) (λ i → u (~ i) x₀) ω₀
-    θ₀ j i = fill ~P (∂ j) i λ where
-      i (j = i0) → v (~ i) y
-      i (j = i1) → u (~ i) x₀
-      i (i = i0) → β₀ (~ j)
+    θ₀ j i = fill ~P (∂ j) i (square x₀ β₀ j)
 ```
 
 Analogously, we have `ω₁`{.Agda} and `θ₁`{.Agda} connecting `β₁`{.Agda}
@@ -184,13 +182,10 @@ and that, as the dashed line and filler of the square below:
 
 ```agda
     ω₁ : g y ≡ x₁
-    ω₁ j = primComp (λ i → P (~ i)) (square x₁ j) (β₁ (~ j))
+    ω₁ j = comp (λ i → P (~ i)) (∂ j) (square x₁ β₁ j)
 
     θ₁ : SquareP (λ i j → P (~ j)) (sym β₁) (λ i → v (~ i) y) (λ i → u (~ i) x₁) ω₁
-    θ₁ j i = fill ~P (∂ j) i λ where
-      i (j = i0) → v (~ i) y
-      i (j = i1) → u (~ i) x₁
-      i (i = i0) → β₁ (~ j)
+    θ₁ j i = fill ~P (∂ j) i (square x₁ β₁ j)
 ```
 
 Now, we are almost done. Like a magic trick, the paths `ω₀` and


### PR DESCRIPTION
# Description

Use the same square for all of `ω₀`/`θ₀` and
`ω₁`/`θ₁`, as it was before switching to using cooltt-like hcomp/hfill/comp/fill. Now as a bonus, the top side is also shared among the components of the proof.

## Checklist

(Most of the items on the checklist are irrelevant to a minor refactor, so I removed them)

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

If a commit affects many files without adding any content and you don't
want your name to appear on those pages (for example, treewide refactorings
or reformattings), include the word `NOAUTHOR` in the commit message.
