### PR TITLE
Refactor Subcategory APIs

### DIFF
--- a/src/Algebra/Group/Cat/Monadic.lagda.md
+++ b/src/Algebra/Group/Cat/Monadic.lagda.md
@@ -156,7 +156,7 @@ Group-is-monadic = is-precat-iso→is-equivalence
   k₁inv hom .hom = hom .morphism
   k₁inv hom .preserves .Group-hom.pres-⋆ x y = happly (hom .commutes) (inc x ◆ inc y)
 
-  ff : is-fully-faithful K
+  ff : is-ff K
   ff = is-iso→is-equiv $ iso k₁inv (λ x → Algebra-hom-path (Sets ℓ) refl)
                                    (λ x → Grp.Forget-is-faithful refl)
 ```

--- a/src/Algebra/Lattice.lagda.md
+++ b/src/Algebra/Lattice.lagda.md
@@ -206,7 +206,7 @@ A tiny calculation shows that this functor is fully faithful, and
 essential surjectivity is immediate:
 
 ```agda
-    ff : is-fully-faithful (covariant-order-map l)
+    ff : is-ff (covariant-order-map l)
     ff {x} {y} .is-eqv p .centre .fst =
       x               ≡⟨ sym ∧-absorbs-∨ ⟩
       x L∧ ⌜ x L∨ y ⌝ ≡˘⟨ ap¡ p ⟩

--- a/src/Algebra/Monoid/Category.lagda.md
+++ b/src/Algebra/Monoid/Category.lagda.md
@@ -232,7 +232,7 @@ Monoid-is-monadic {ℓ} = ff+split-eso→is-equivalence it's-ff it's-eso where
   comparison = Comparison (Free⊣Forget {ℓ})
   module comparison = Functor comparison
 
-  it's-ff : is-fully-faithful comparison
+  it's-ff : is-ff comparison
   it's-ff {x} {y} = is-iso→is-equiv (iso from from∘to to∘from) where
     module x = Monoid-on (x .snd)
     module y = Monoid-on (y .snd)

--- a/src/Cat/Displayed/Instances/Family.lagda.md
+++ b/src/Cat/Displayed/Instances/Family.lagda.md
@@ -112,7 +112,7 @@ module _ {ℓ} (X : Set ℓ) where
   Families→functors .F-∘ f g =
     ap (Families→functors .F₁) (transport-refl _) ∙ Nat-path λ x → refl
 
-  Families→functors-is-ff : is-fully-faithful Families→functors
+  Families→functors-is-ff : is-ff Families→functors
   Families→functors-is-ff = is-iso→is-equiv
     (iso η (λ x → Nat-path λ _ → refl) λ x → refl)
 

--- a/src/Cat/Displayed/Instances/Slice.lagda.md
+++ b/src/Cat/Displayed/Instances/Slice.lagda.md
@@ -150,7 +150,7 @@ Fibre→slice .F₁ f ./-Hom.commutes = sym (f .commute) ∙ eliml refl
 Fibre→slice .F-id = /-Hom-path refl
 Fibre→slice .F-∘ f g = /-Hom-path (transport-refl _)
 
-Fibre→slice-is-ff : ∀ {x} → is-fully-faithful (Fibre→slice {x = x})
+Fibre→slice-is-ff : ∀ {x} → is-ff (Fibre→slice {x = x})
 Fibre→slice-is-ff {_} {x} {y} = is-iso→is-equiv isom where
   isom : is-iso (Fibre→slice .F₁)
   isom .is-iso.inv hom =

--- a/src/Cat/Functor/Adjoint/Reflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Reflective.lagda.md
@@ -62,7 +62,7 @@ $\ca{D}$.
 
 ```agda
 is-reflective : F ⊣ G → Type _
-is-reflective {G = G} adj = is-fully-faithful G
+is-reflective {G = G} adj = is-ff G
 ```
 
 The first thing we will prove is that the counit map $\eps : FGo \to o$
@@ -93,18 +93,18 @@ module
     morp = D.make-iso (counit.ε _) (g-ff.from (unit.η _)) invl invr
       where abstract
       invl : counit.ε o D.∘ g-ff.from (unit.η (G.₀ o)) ≡ D.id
-      invl = fully-faithful→faithful {F = G} g-ff (
+      invl = ff→faithful G g-ff $
         G.₁ (counit.ε o D.∘ _)                 ≡⟨ G.F-∘ _ _ ⟩
         G.₁ (counit.ε o) C.∘ G.₁ (g-ff.from _) ≡⟨ C.refl⟩∘⟨  g-ff.ε _ ⟩
         G.₁ (counit.ε o) C.∘ unit.η (G.₀ o)    ≡⟨ zag ∙ sym G.F-id ⟩
-        G.₁ D.id                               ∎)
+        G.₁ D.id                               ∎
 
       invr : g-ff.from (unit.η (G.₀ o)) D.∘ counit.ε o ≡ D.id
-      invr = fully-faithful→faithful {F = G} g-ff (ap G.₁ (
+      invr = ff→faithful G g-ff $ ap G.₁ $
         g-ff.from _ D.∘ counit.ε _             ≡˘⟨ counit.is-natural _ _ _ ⟩
         counit.ε _ D.∘ F.₁ (G.₁ (g-ff.from _)) ≡⟨ D.refl⟩∘⟨ F.⟨ g-ff.ε _ ⟩ ⟩
         counit.ε _ D.∘ F.₁ (unit.η _)          ≡⟨ zig ⟩
-        D.id                                   ∎))
+        D.id                                   ∎
 
   is-reflective→counit-iso : (F F∘ G) DD.≅ Id
   is-reflective→counit-iso = DD.invertible→iso counit invs where
@@ -165,7 +165,7 @@ observe that it's always faithful; The fullness comes from the
 assumption that $G$ is ff.
 
 ```agda
-  comp-ff : is-fully-faithful Comp
+  comp-ff : is-ff Comp
   comp-ff {x} {y} = is-iso→is-equiv isom where
     open is-iso
     isom : is-iso _

--- a/src/Cat/Functor/Base.lagda.md
+++ b/src/Cat/Functor/Base.lagda.md
@@ -162,6 +162,9 @@ is-split-eso F = ∀ y → Essential-fibre F y
 
 is-eso : Functor C D → Type _
 is-eso F = ∀ y → ∥ Essential-fibre F y ∥
+
+split-eso→eso : ∀ (F : Functor C D) → is-split-eso F → is-eso F
+split-eso→eso F split-eso y = inc (split-eso y)
 ```
 
 <!--

--- a/src/Cat/Functor/Dense.lagda.md
+++ b/src/Cat/Functor/Dense.lagda.md
@@ -64,7 +64,7 @@ the induced [nerve] functor is fully faithful.
 [nerve]: Cat.Functor.Kan.Nerve.html
 
 ```agda
-  is-dense→nerve-is-ff : is-dense → is-fully-faithful (Nerve F)
+  is-dense→nerve-is-ff : is-dense → is-ff (Nerve F)
   is-dense→nerve-is-ff is-colim = is-iso→is-equiv $ iso inv invr invl where
     nt→cone : ∀ {x y} → (Nerve F .F₀ x => Nerve F .F₀ y) → Cocone _
     nt→cone {x} {y} nt .coapex = y
@@ -97,6 +97,6 @@ enough to tell morphisms (and so objects) in the ambient category apart.
     → (∀ {Z} (h : D.Hom (F.₀ Z) X) → f D.∘ h ≡ g D.∘ h)
     → f ≡ g
   dense→separating dense h =
-    fully-faithful→faithful {F = Nerve F} (is-dense→nerve-is-ff dense) $
+    ff→faithful (Nerve F) (is-dense→nerve-is-ff dense) $
       Nat-path λ x → funext λ g → h g
 ```

--- a/src/Cat/Functor/Equivalence.lagda.md
+++ b/src/Cat/Functor/Equivalence.lagda.md
@@ -129,7 +129,7 @@ d$.
 [eso]: Cat.Functor.Base.html#essential-fibres
 
 ```agda
-module _ {F : Functor C D} (ff : is-fully-faithful F) (eso : is-split-eso F) where
+module _ {F : Functor C D} (ff : is-ff F) (eso : is-split-eso F) where
   import Cat.Reasoning C as C
   import Cat.Reasoning D as D
   private module di = D._≅_
@@ -175,7 +175,7 @@ by faithfulness.
     where open Σ (eso x) renaming (fst to f*x ; snd to f*x-iso)
 
   ff+split-eso→inverse .F-∘ {x} {y} {z} f g =
-    fully-faithful→faithful {F = F} ff (
+    ff→faithful F ff (
       F₁ F (ff⁻¹ (ffz D.∘ (f D.∘ g) D.∘ ftx))      ≡⟨ ff.ε _ ⟩
       ffz D.∘ (f D.∘ g) D.∘ ftx                    ≡⟨ cat! D ⟩
       ffz D.∘ f D.∘ ⌜ D.id ⌝ D.∘ g D.∘ ftx         ≡˘⟨ ap¡ (f*y-iso .di.invl) ⟩
@@ -230,7 +230,7 @@ essential fibre $F^*F(x)$ comes equipped with an isomorphism $FF^*F(x)
 
 ```agda
   ff+split-eso→unit .is-natural x y f =
-    fully-faithful→faithful {F = F} ff (
+    ff→faithful F ff (
       F₁ F (ff⁻¹ ffy C.∘ f)                                    ≡⟨ F-∘ F _ _ ⟩
       ⌜ F₁ F (ff⁻¹ ffy) ⌝ D.∘ F₁ F f                           ≡⟨ ap! (ff.ε _) ⟩
       ffy D.∘ ⌜ F₁ F f ⌝                                       ≡⟨ ap! (sym (D.idr _) ∙ ap (F₁ F f D.∘_) (sym (f*x-iso .di.invl))) ⟩
@@ -315,7 +315,7 @@ The `zag`{.Agda} identity needs an appeal to faithfulness:
 
 ```agda
   ff+split-eso→F⊣inverse .zag {x} =
-    fully-faithful→faithful {F = F} ff (
+    ff→faithful F ff (
       F₁ F (ff⁻¹ (ffx D.∘ ftx D.∘ fftx) C.∘ ff⁻¹ fffx)        ≡⟨ F-∘ F _ _ ⟩
       F₁ F (ff⁻¹ (ffx D.∘ ftx D.∘ fftx)) D.∘ F₁ F (ff⁻¹ fffx) ≡⟨ ap₂ D._∘_ (ff.ε _) (ff.ε _) ⟩
       (ffx D.∘ ftx D.∘ fftx) D.∘ fffx                         ≡⟨ cat! D ⟩
@@ -362,13 +362,13 @@ needs an appeal to faithfulness (two, actually):
   ff+split-eso→is-equivalence .unit-iso x = record
     { inv      = ff⁻¹ (f*x-iso .di.to)
     ; inverses = record
-      { invl = fully-faithful→faithful {F = F} ff (
+      { invl = ff→faithful F ff (
           F₁ F (ff⁻¹ ffx C.∘ ff⁻¹ ftx)        ≡⟨ F-∘ F _ _ ⟩
           F₁ F (ff⁻¹ ffx) D.∘ F₁ F (ff⁻¹ ftx) ≡⟨ ap₂ D._∘_ (ff.ε _) (ff.ε _) ⟩
           ffx D.∘ ftx                         ≡⟨ f*x-iso .di.invr ⟩
           D.id                                ≡˘⟨ F-id F ⟩
           F₁ F C.id                           ∎)
-      ; invr = fully-faithful→faithful {F = F} ff (
+      ; invr = ff→faithful F ff (
           F₁ F (ff⁻¹ ftx C.∘ ff⁻¹ ffx)        ≡⟨ F-∘ F _ _ ⟩
           F₁ F (ff⁻¹ ftx) D.∘ F₁ F (ff⁻¹ ffx) ≡⟨ ap₂ D._∘_ (ff.ε _) (ff.ε _) ⟩
           ftx D.∘ ffx                         ≡⟨ f*x-iso .di.invl ⟩
@@ -405,7 +405,7 @@ to go through.
 ```agda
 module
   _ (F : Functor C D) (ccat : is-category C) (dcat : is-category D)
-    (ff : is-fully-faithful F)
+    (ff : is-ff F)
   where
   private
     module C = Cat.Reasoning C
@@ -436,7 +436,7 @@ sends back to $i \circ j^{-1}$.
     Fx≅Fy = i D.∘Iso (j D.Iso⁻¹)
 
     x≅y : x C.≅ y
-    x≅y = is-ff→essentially-injective {F = F} ff Fx≅Fy
+    x≅y = is-ff→essentially-injective F ff Fx≅Fy
 ```
 
 Furthermore, since we're working with categories, these isomorphisms
@@ -473,7 +473,7 @@ _are_ indeed the same path:
       square : ap (F₀ F) x≡y ≡ Fx≡Fy
       square =
         ap (F₀ F) x≡y                     ≡⟨ F-map-path F x≅y ccat dcat ⟩
-        dcat .to-path ⌜ F-map-iso F x≅y ⌝ ≡⟨ ap! (equiv→counit (is-ff→F-map-iso-is-equiv {F = F} ff) _)  ⟩
+        dcat .to-path ⌜ F-map-iso F x≅y ⌝ ≡⟨ ap! (equiv→counit (is-ff→F-map-iso-is-equiv F ff) _)  ⟩
         dcat .to-path Fx≅Fy               ∎
 
     over : PathP (λ i → F₀ F (x≡y i) D.≅ z) i j
@@ -514,7 +514,7 @@ record is-precat-iso (F : Functor C D) : Type (adj-level C D) where
   no-eta-equality
   constructor iso
   field
-    has-is-ff  : is-fully-faithful F
+    has-is-ff  : is-ff F
     has-is-iso : is-equiv (F₀ F)
 ```
 

--- a/src/Cat/Functor/Equivalence/Path.lagda.md
+++ b/src/Cat/Functor/Equivalence/Path.lagda.md
@@ -260,7 +260,7 @@ module
     module F = Fr F
   open _=>_
 
-  is-equivalence→is-ff : is-fully-faithful F
+  is-equivalence→is-ff : is-ff F
   is-equivalence→is-ff = is-iso→is-equiv λ where
     .is-iso.inv x → unit⁻¹ .η _ C.∘ L-adjunct F⊣F⁻¹ x
     .is-iso.rinv x →

--- a/src/Cat/Functor/FullSubcategory.lagda.md
+++ b/src/Cat/Functor/FullSubcategory.lagda.md
@@ -107,7 +107,7 @@ the image of $F$.
 [fully faithful]: Cat.Functor.Base.html#ff-functors
 
 ```agda
-module _ {o' h'} {D : Precategory o' h'} {F : Functor D C} (ff : is-fully-faithful F) where
+module _ {o' h'} {D : Precategory o' h'} {F : Functor D C} (ff : is-ff F) where
   open Functor F
 
   Full-inclusion→Full-subcat : Precategory _ _
@@ -128,8 +128,8 @@ functor from $\ca{D}$. This functor is actually just $F$ again:
   Ff-domain→Full-subcat .Functor.F-id = F-id
   Ff-domain→Full-subcat .Functor.F-∘ = F-∘
 
-  is-fully-faithful-domain→Full-subcat : is-fully-faithful Ff-domain→Full-subcat
-  is-fully-faithful-domain→Full-subcat = ff
+  is-ff-domain→Full-subcat : is-ff Ff-domain→Full-subcat
+  is-ff-domain→Full-subcat = ff
 
   is-eso-domain→Full-subcat : is-eso Ff-domain→Full-subcat
   is-eso-domain→Full-subcat yo =
@@ -150,6 +150,6 @@ module _ {P : C.Ob → Type ℓ} where
   Forget-full-subcat .Functor.F-id = refl
   Forget-full-subcat .Functor.F-∘ f g i = f C.∘ g
 
-  is-fully-faithful-Forget-full-subcat : is-fully-faithful Forget-full-subcat
-  is-fully-faithful-Forget-full-subcat = id-equiv
+  is-ff-Forget-full-subcat : is-ff Forget-full-subcat
+  is-ff-Forget-full-subcat = id-equiv
 ```

--- a/src/Cat/Functor/Hom.lagda.md
+++ b/src/Cat/Functor/Hom.lagda.md
@@ -116,8 +116,8 @@ natural transformation with the identity map; Hence, the Yoneda
 embedding functor is fully faithful.
 
 ```agda
-よ-is-fully-faithful : is-fully-faithful よ
-よ-is-fully-faithful = is-iso→is-equiv isom where
+よ-is-ff : is-ff よ
+よ-is-ff = is-iso→is-equiv isom where
   open is-iso
 
   isom : is-iso よ₁
@@ -340,7 +340,7 @@ private module _ where private
     → (∀ {Z} (h : Hom Z X) → f ∘ h ≡ g ∘ h)
     → f ≡ g
   よ-cancelr sep =
-    fully-faithful→faithful {F = よ} よ-is-fully-faithful $
+    ff→faithful よ よ-is-ff $
       Representables-generate-presheaf λ h → Nat-path λ x → funext λ a →
         sep (h .η x a)
 ```

--- a/src/Cat/Functor/Hom/Cocompletion.lagda.md
+++ b/src/Cat/Functor/Hom/Cocompletion.lagda.md
@@ -84,5 +84,5 @@ extend-cocontinuous
 extend-cocontinuous F = left-adjoint-colimit (Realisation⊣Nerve colim F)
 
 extend-factors : (F : Functor C D) → (extend F F∘ よ C) ≅ F
-extend-factors F = ff-lan-ext colim (よ C) F (よ-is-fully-faithful C)
+extend-factors F = ff-lan-ext colim (よ C) F (よ-is-ff C)
 ```

--- a/src/Cat/Functor/Hom/Representable.lagda.md
+++ b/src/Cat/Functor/Hom/Representable.lagda.md
@@ -73,7 +73,7 @@ morphisms in the same way must be isomorphic.
 representation-unique : {F : Functor (C ^op) (Sets κ)} (X Y : Representation F)
                       → X .rep C.≅ Y .rep
 representation-unique X Y =
-  is-ff→essentially-injective {F = よ C} (よ-is-fully-faithful C) よX≅よY
+  is-ff→essentially-injective (よ C) (よ-is-ff C) よX≅よY
   where
     よX≅よY : よ₀ C (X .rep) C^.≅ よ₀ C (Y .rep)
     よX≅よY = (X .represents C^.Iso⁻¹) C^.∘Iso Y .represents

--- a/src/Cat/Functor/Kan.lagda.md
+++ b/src/Cat/Functor/Kan.lagda.md
@@ -374,7 +374,7 @@ extension along a fully-faithful functor does actually _extend_.
   private module Fn = Cat Cat[ C , E ]
   open _=>_
 
-  ff-lan-ext : is-fully-faithful K → cocomplete→lan .Ext F∘ K Fn.≅ F
+  ff-lan-ext : is-ff K → cocomplete→lan .Ext F∘ K Fn.≅ F
   ff-lan-ext ff = Fn._Iso⁻¹ (Fn.invertible→iso (cocomplete→lan .eta) inv) where
     module ff {x} {y} = Equiv (_ , ff {x} {y})
     inv′ : ∀ x → E.is-invertible (cocomplete→lan .eta .η x)
@@ -383,7 +383,7 @@ extension along a fully-faithful functor does actually _extend_.
       cocone′ .coapex = F.₀ x
       cocone′ .ψ ob = F.₁ (ff.from (ob .map))
       cocone′ .commutes {x = y} {z} f =
-        F.collapse (fully-faithful→faithful {F = K} ff
+        F.collapse (ff→faithful K ff
           ( K .Functor.F-∘  _ _
           ∙ ap₂ D._∘_ (ff.ε _) refl
           ∙ f .sq
@@ -404,7 +404,7 @@ extension along a fully-faithful functor does actually _extend_.
 
       invr : to E.∘ cocomplete→lan .eta .η x ≡ E.id
       invr = colim _ .has⊥ cocone′ .centre .commutes _
-           ∙ F.elim (fully-faithful→faithful {F = K} ff
+           ∙ F.elim (ff→faithful K ff
                       (ff.ε _ ∙ sym K.F-id))
 
     inv : Fn.is-invertible (cocomplete→lan .eta)

--- a/src/Cat/Functor/Slice.lagda.md
+++ b/src/Cat/Functor/Slice.lagda.md
@@ -68,7 +68,7 @@ faithful.
   Sliced-faithful : is-faithful F → is-faithful (Sliced F X)
   Sliced-faithful faith p = /-Hom-path (faith (ap map p))
 
-  Sliced-ff : is-fully-faithful F → is-fully-faithful (Sliced F X)
+  Sliced-ff : is-ff F → is-ff (Sliced F X)
   Sliced-ff eqv = is-iso→is-equiv isom where
     isom : is-iso _
     isom .is-iso.inv sh = record

--- a/src/Cat/Instances/Karoubi.lagda.md
+++ b/src/Cat/Instances/Karoubi.lagda.md
@@ -89,11 +89,11 @@ Embed .F-∘ f g = KH≡ {ai = C.idl _} {bi = C.idl _} refl
 
 An elementary argument shows that the morphism part of `Embed`{.Agda}
 has an inverse given by projecting the first component of the pair;
-Hence, `Embed` is `fully faithful`{.Agda ident=is-fully-faithful}.
+Hence, `Embed` is `fully faithful`{.Agda ident=is-ff}.
 
 ```agda
-Embed-is-fully-faithful : is-fully-faithful Embed
-Embed-is-fully-faithful = is-iso→is-equiv $
+Embed-is-ff : is-ff Embed
+Embed-is-ff = is-iso→is-equiv $
   iso fst (λ _ → Σ-prop-path (λ _ → hlevel 1) refl) λ _ → refl
 ```
 

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -428,14 +428,14 @@ projection map $\id{fst} : \sum F \to I$.
 ```
 
 To prove that the `Total-space`{.Agda} functor is `fully faithful`{.Agda
-ident=is-fully-faithful}, we will exhibit a quasi-inverse to its action
+ident=is-ff}, we will exhibit a quasi-inverse to its action
 on morphisms. Given a fibre-preserving map between $\id{fst} : \sum
 F \to I$ and $\id{fst} : \sum G \to I$, we recover a natural
 transformation between $F$ and $G$. The hardest part is showing
 naturality, where we use path induction.
 
 ```agda
-  Total-space-is-ff : is-fully-faithful Total-space
+  Total-space-is-ff : is-ff Total-space
   Total-space-is-ff {f1} {f2} = is-iso→is-equiv
     (iso from linv (λ x → Nat-path (λ x → funext (λ _ → transport-refl _))))
     where

--- a/src/Cat/Instances/Slice/Presheaf.lagda.md
+++ b/src/Cat/Instances/Slice/Presheaf.lagda.md
@@ -133,7 +133,7 @@ without comment.
     func .F-id    = Nat-path (λ x → funext λ y → Σ-prop-path (λ _ → P.₀ _ .is-tr _ _) refl)
     func .F-∘ f g = Nat-path (λ x → funext λ y → Σ-prop-path (λ _ → P.₀ _ .is-tr _ _) refl)
 
-  slice→total-is-ff : is-fully-faithful slice→total
+  slice→total-is-ff : is-ff slice→total
   slice→total-is-ff {x} {y} = is-iso→is-equiv (iso inv rinv linv) where
     inv : Hom Cat[ ∫ C P ^op , Sets _ ] _ _
         → Slice Cat[ C ^op , Sets _ ] P .Hom _ _

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -139,7 +139,7 @@ itself, then it is an isomorphism:
 module
   _ {o ℓ o′ ℓ′} {C : Precategory o ℓ} {D : Precategory o′ ℓ′}
     {r : Functor C D} {ι : Functor D C}
-    (r⊣ι : r ⊣ ι) (ι-ff : is-fully-faithful ι)
+    (r⊣ι : r ⊣ ι) (ι-ff : is-ff ι)
   where
   private
     module C = Cr C

--- a/src/Cat/Subcategory.lagda.md
+++ b/src/Cat/Subcategory.lagda.md
@@ -1,0 +1,167 @@
+```agda
+module Cat.Subcategory where
+
+open import Cat.Prelude
+open import Cat.Displayed.Base
+```
+
+# Subcategories
+
+```agda
+record is-subcategory {o ℓ o′ ℓ′} {B : Precategory o ℓ} (E : Displayed B o′ ℓ′) :
+  Type (o ⊔ ℓ ⊔ o′ ⊔ ℓ′) where
+
+  open Displayed E
+
+  field
+    prop-obj : ∀ X → is-prop Ob[ X ]
+    prop-hom : ∀ {X Y} f (X′ : Ob[ X ]) (Y′ : Ob[ Y ]) → is-prop (Hom[ f ] X′ Y′)
+
+
+record Subcategory {o ℓ} (B : Precategory o ℓ) (o′ ℓ′ : Level) :
+  Type (o ⊔ ℓ ⊔ lsuc o′ ⊔ lsuc ℓ′) where
+  field
+    Subcat : Displayed B o′ ℓ′
+    has-is-subcategory : is-subcategory Subcat
+
+  open is-subcategory has-is-subcategory public
+```
+
+## Constructing Subcategories
+
+```agda
+record make-subcategory {o ℓ} (B : Precategory o ℓ) (o′ ℓ′ : Level) :
+  Type (o ⊔ ℓ ⊔ lsuc o′ ⊔ lsuc ℓ′) where
+  open Precategory B
+  field
+    Ob? : Ob → Prop o′
+    Hom? : ∀ {X Y} → Hom X Y → ∣ Ob? X ∣ → ∣ Ob? Y ∣ → Prop ℓ′
+    hom?-id : ∀ {X} → (PX : ∣ Ob? X ∣) → ∣ Hom? id PX PX ∣
+    hom?-∘  : ∀ {X Y Z f g}
+              → (PX : ∣ Ob? X ∣) → (PY : ∣ Ob? Y ∣) → (PZ : ∣ Ob? Z ∣)
+              → ∣ Hom? f PY PZ ∣ → ∣ Hom? g PX PY ∣ → ∣ Hom? (f ∘ g) PX PZ ∣ 
+
+to-subcategory : ∀ {o ℓ o′ ℓ′} {B : Precategory o ℓ}
+                 → make-subcategory B o′ ℓ′ → Subcategory B o′ ℓ′
+to-subcategory mk-subcat = subcat
+  where
+    open make-subcategory mk-subcat
+    open Subcategory
+    open Displayed
+
+    subcat : Subcategory _ _ _
+    subcat .Subcat .Ob[_] X = ∣ Ob? X ∣
+    subcat .Subcat .Hom[_] f PX PY = ∣ Hom? f PX PY ∣
+    subcat .Subcat .Hom[_]-set f PX PY = is-prop→is-set (is-tr (Hom? f PX PY))
+    subcat .Subcat .id′ = hom?-id _
+    subcat .Subcat ._∘′_ f g = hom?-∘ _ _ _ f g
+    subcat .Subcat .idr′ f = is-prop→pathp (λ _ → is-tr (Hom? _ _ _)) _ _
+    subcat .Subcat .idl′ f = is-prop→pathp (λ _ → is-tr (Hom? _ _ _)) _ _
+    subcat .Subcat .assoc′ f g h = is-prop→pathp (λ _ → is-tr (Hom? _ _ _)) _ _
+    subcat .has-is-subcategory .is-subcategory.prop-obj _ = is-tr (Ob? _)
+    subcat .has-is-subcategory .is-subcategory.prop-hom _ _ _ = is-tr (Hom? _ _ _)
+```
+
+# Wide Subcategories
+
+```agda
+record is-wide-subcategory {o ℓ o′ ℓ′} {B : Precategory o ℓ} (E : Displayed B o′ ℓ′) :
+  Type (o ⊔ ℓ ⊔ o′ ⊔ ℓ′) where
+  open Displayed E
+  field
+    contr-obj : ∀ X → is-contr Ob[ X ]
+    prop-hom : ∀ {X Y} f (X′ : Ob[ X ]) (Y′ : Ob[ Y ]) → is-prop (Hom[ f ] X′ Y′)
+
+  has-is-subcategory : is-subcategory E
+  has-is-subcategory .is-subcategory.prop-obj X = is-contr→is-prop (contr-obj X)
+  has-is-subcategory .is-subcategory.prop-hom = prop-hom
+
+record Wide-subcategory {o ℓ} (B : Precategory o ℓ) (o′ ℓ′ : Level) :
+  Type (o ⊔ ℓ ⊔ lsuc o′ ⊔ lsuc ℓ′) where
+  field
+    Subcat : Displayed B o′ ℓ′
+    has-is-wide-subcategory : is-wide-subcategory Subcat
+
+  open is-wide-subcategory has-is-wide-subcategory public
+```
+
+## Constructing Wide Subcategories
+
+```agda
+record make-wide-subcategory {o ℓ} (B : Precategory o ℓ) (ℓ′ : Level) :
+  Type (o ⊔ ℓ ⊔ lsuc ℓ′) where
+  open Precategory B
+  field
+    Hom? : ∀ {X Y} → Hom X Y → Prop ℓ′
+    hom?-id : ∀ {X} → ∣ Hom? (id {X}) ∣
+    hom?-∘  : ∀ {X Y Z} {f : Hom Y Z} {g : Hom X Y} → ∣ Hom? f ∣ → ∣ Hom? g ∣ → ∣ Hom? (f ∘ g) ∣ 
+
+to-wide-subcategory : ∀ {o ℓ ℓ′} {B : Precategory o ℓ}
+                      → make-wide-subcategory B ℓ′ → Wide-subcategory B lzero ℓ′
+to-wide-subcategory mk-subcat = subcat
+  where
+    open make-wide-subcategory mk-subcat
+    open Wide-subcategory
+    open is-wide-subcategory
+    open Displayed
+
+    subcat : Wide-subcategory _ _ _
+    Ob[ subcat .Subcat ] X = ⊤
+    subcat .Subcat .Hom[_] f _ _ = ∣ Hom? f ∣
+    subcat .Subcat .Hom[_]-set f _ _ = is-prop→is-set (is-tr (Hom? f))
+    subcat .Subcat .id′ = hom?-id
+    subcat .Subcat ._∘′_ = hom?-∘
+    subcat .Subcat .idr′ _ = is-prop→pathp (λ _ → is-tr (Hom? _)) _ _
+    subcat .Subcat .idl′ _ = is-prop→pathp (λ _ → is-tr (Hom? _)) _ _
+    subcat .Subcat .assoc′ _ _ _ = is-prop→pathp (λ _ → is-tr (Hom? _)) _ _
+    subcat .has-is-wide-subcategory .contr-obj _ = hlevel 0
+    subcat .has-is-wide-subcategory .prop-hom _ _ _ = is-tr (Hom? _)
+```
+
+# Full Subcategories
+
+```agda
+record is-full-subcategory {o ℓ o′ ℓ′} {B : Precategory o ℓ} (E : Displayed B o′ ℓ′) :
+  Type (o ⊔ ℓ ⊔ o′ ⊔ ℓ′) where
+  open Displayed E
+  field
+    prop-obj : ∀ X → is-prop Ob[ X ]
+    contr-hom : ∀ {X Y} f (X′ : Ob[ X ]) (Y′ : Ob[ Y ]) → is-contr (Hom[ f ] X′ Y′)
+
+  has-is-subcategory : is-subcategory E
+  has-is-subcategory .is-subcategory.prop-obj = prop-obj
+  has-is-subcategory .is-subcategory.prop-hom f PX PY = is-contr→is-prop (contr-hom f PX PY)
+
+record Full-subcategory {o ℓ} (B : Precategory o ℓ) (o′ ℓ′ : Level) :
+  Type (o ⊔ ℓ ⊔ lsuc o′ ⊔ lsuc ℓ′) where
+  field
+    Subcat : Displayed B o′ ℓ′
+    has-is-full-subcategory : is-full-subcategory Subcat
+
+  open is-full-subcategory has-is-full-subcategory public
+```
+
+## Constructing Full Subcategories
+
+```agda
+to-full-subcategory : ∀ {o ℓ o′} {B : Precategory o ℓ}
+                      → (Precategory.Ob B → Prop o′)
+                      → Full-subcategory B o′ lzero
+to-full-subcategory Ob? = subcat
+  where
+    open Full-subcategory
+    open is-full-subcategory
+    open Displayed
+
+    subcat : Full-subcategory _ _ _
+    subcat .Subcat .Ob[_] X = ∣ Ob? X ∣
+    subcat .Subcat .Hom[_] f PX PY = ⊤
+    subcat .Subcat .Hom[_]-set _ _ _ = hlevel 2
+    subcat .Subcat .id′ = tt
+    subcat .Subcat ._∘′_ _ _ = tt
+    subcat .Subcat .idr′ _ = refl
+    subcat .Subcat .idl′ _ = refl
+    subcat .Subcat .assoc′ _ _ _ = refl
+    subcat .has-is-full-subcategory .prop-obj X = is-tr (Ob? X)
+    subcat .has-is-full-subcategory .contr-hom _ _ _ = hlevel 0
+```

--- a/src/Cat/Subcategory.lagda.md
+++ b/src/Cat/Subcategory.lagda.md
@@ -1,9 +1,11 @@
 ```agda
 module Cat.Subcategory where
 
-open import Cat.Prelude
 open import Cat.Displayed.Base
+open import Cat.Displayed.Total
 open import Cat.Displayed.Univalence
+open import Cat.Functor.Base
+open import Cat.Prelude
 
 import Cat.Reasoning
 ```
@@ -55,7 +57,7 @@ record Subcategory {o ℓ} (B : Precategory o ℓ) (o′ ℓ′ : Level) :
   open is-subcategory has-is-subcategory public
 ```
 
-## Properties of Subcategories
+## Subcategories are Univalent
 
 One interesting fact is that subcategories $\ca{E}$ of $\ca{B}$
 are _always_ univalent displayed categories, _regardless of whether or
@@ -83,6 +85,28 @@ module _ {o ℓ o′ ℓ′} {B : Precategory o ℓ} {E : Displayed B o′ ℓ�
           ((Hom[ _ ]-prop _ _) _ _)
           ((Hom[ _ ]-prop _ _) _ _))
 ```
+
+## Faithfulness of the Projection Functor
+
+Given a subcategory $E$ of $B$, the projection functor `πᶠ`{.Agda} from the total
+category is faithful. This follows rather directly from the characterization of
+path spaces in the total category: these consist of paths between the base homs,
+along with a `PathP`{.Agda} over the displayed homs. We have the first path by
+our hypotheses, and the `PathP` is trivial, as the space of homs is a proposition.
+
+```agda
+module _ {o ℓ o′ ℓ′} {B : Precategory o ℓ} {E : Displayed B o′ ℓ′}
+  (is-subcat : is-subcategory E) where
+    
+  open Cat.Reasoning B
+  open is-subcategory is-subcat
+  open Total-hom
+
+  πᶠ-subcategory-faithful : is-faithful (πᶠ E)
+  πᶠ-subcategory-faithful p =
+    total-hom-path E p (is-prop→pathp (λ _ → Hom[ _ ]-prop _ _) _ _)
+```
+
 
 ## Constructing Subcategories
 
@@ -159,6 +183,27 @@ record Wide-subcategory {o ℓ} (B : Precategory o ℓ) (o′ ℓ′ : Level) :
   open is-wide-subcategory has-is-wide-subcategory public
 ```
 
+## Essential Surjectivity of the Projection Functor.
+
+If $E$ is a wide subcategory of $B$, then the projection functor `πᶠ`{.Agda}
+from the total category of $E$ is _split_ essentially surjective.
+The space of objects in $E$ is contractible, so we can always lift
+$X : \ca{B}$ to the pair of $X$ and the unique $X' : Ob_{X}$  in the total category, which projects down to $X$
+by `πᶠ`{.Agda}.
+
+```agda
+module _ {o ℓ o′ ℓ′} {B : Precategory o ℓ} {E : Displayed B o′ ℓ′}
+  (is-wide-subcat : is-wide-subcategory E) where
+    
+  open Cat.Reasoning B
+  open is-wide-subcategory is-wide-subcat
+  open Total-hom
+
+  πᶠ-wide-subcategory-split-eso : is-split-eso (πᶠ E)
+  πᶠ-wide-subcategory-split-eso Y = ((Y , Ob[ Y ]-contr .centre) , id-iso)
+```
+
+
 ## Constructing Wide Subcategories
 
 We also provide an API for constructing wide subcategories from the normal
@@ -206,11 +251,11 @@ record is-full-subcategory {o ℓ o′ ℓ′} {B : Precategory o ℓ} (E : Disp
   Type (o ⊔ ℓ ⊔ o′ ⊔ ℓ′) where
   open Displayed E
   field
-    prop-obj : ∀ X → is-prop Ob[ X ]
+    Ob[_]-prop : ∀ X → is-prop Ob[ X ]
     Hom[_]-contr : ∀ {X Y} f (X′ : Ob[ X ]) (Y′ : Ob[ Y ]) → is-contr (Hom[ f ] X′ Y′)
 
   has-is-subcategory : is-subcategory E
-  has-is-subcategory .is-subcategory.Ob[_]-prop = prop-obj
+  has-is-subcategory .is-subcategory.Ob[_]-prop = Ob[_]-prop
   has-is-subcategory .is-subcategory.Hom[_]-prop f PX PY = is-contr→is-prop (Hom[_]-contr f PX PY)
 ```
 
@@ -250,6 +295,107 @@ to-full-subcategory Ob? = subcat
     subcat .Subcat .idr′ _ = refl
     subcat .Subcat .idl′ _ = refl
     subcat .Subcat .assoc′ _ _ _ = refl
-    subcat .has-is-full-subcategory .prop-obj X = is-tr (Ob? X)
+    subcat .has-is-full-subcategory .Ob[_]-prop X = is-tr (Ob? X)
     subcat .has-is-full-subcategory .Hom[_]-contr _ _ _ = hlevel 0
+```
+
+## Full Inclusions, and Full Faithfulness of the Projection Functor
+
+If $\ca{E}$ is a full subcategory of $\ca{B}$, then the projection functor
+`πᶠ`{.Agda} from the total category of $\ca{E}$ to $\ca{B}$ is fully faithful.
+To see this, consider some morphism $f$ in $\ca{B}$. We need to show that the space
+of fibres of `πᶠ`{.Agda} at $f$ is contractible. To construct the centre of this
+contraction, we can use contractibility of hom spaces in $\ca{E}$ to obtain a
+morphism $f'$ in $\ca{E}$ that lives above $f$. This then gets us an element
+$(f, f')$ of the total category, which obviously lives in the fibre of `πᶠ`{.Agda}
+over $f$.
+
+To show contractibility, we can ignore any homotopical content of the equivalence,
+as all of the hom spaces are sets. This means that we need to show that $(f , f')$
+is the only element of the fibre of `πᶠ` at `f`, which follows directly from
+contractibility of hom spaces in $\ca{E}$.
+
+```agda
+module _ {o ℓ o′ ℓ′} {B : Precategory o ℓ} {E : Displayed B o′ ℓ′}
+  (is-full-subcat : is-full-subcategory E) where
+
+  open Precategory B
+  open is-full-subcategory is-full-subcat
+  open Total-hom
+
+  πᶠ-full-subcategory-ff : is-ff (πᶠ E)
+  πᶠ-full-subcategory-ff .is-eqv f .centre =
+    total-hom f (Hom[ f ]-contr _ _ .centre) , refl
+  πᶠ-full-subcategory-ff .is-eqv f .paths (pf , eq) =
+    Σ-prop-path
+      (λ _ → Hom-set _ _ _ _)
+      (total-hom-path E
+        (sym eq)
+        (is-prop→pathp (λ _ → is-contr→is-prop (Hom[ _ ]-contr _ _)) _ _))
+```
+
+We can also go the other direction: given a fully faithful functor
+$F : \ca{D} \to \ca{C}$, we can construct a full subcategory on $\ca{C}$
+that consists of only those objects that are _essentially_ in the
+image of $F$.
+
+```agda
+module _ {o ℓ o′ ℓ′} {C : Precategory o ℓ} {D : Precategory o′ ℓ′}
+         {F : Functor D C} (ff : is-ff F) where
+
+  private
+    module D = Cat.Reasoning D
+    module C = Cat.Reasoning C
+
+    open Full-subcategory
+    open is-full-subcategory
+    open Functor F
+    open Total-hom
+
+  Essential-image : Full-subcategory C (ℓ ⊔ o′) lzero
+  Essential-image =
+    to-full-subcategory λ X → el! (∃[ Y ∈ D.Ob ] (F₀ Y C.≅ X))
+```
+
+Notably, the total category of this full subcategory is equivalent to
+$\ca{D}$! To start, we first construct a functor from $\ca{D}$ to the
+total category of the constructed full subcategory that takes objects in
+$\ca{D}$ to their image in $\ca{C}$, and equips them with the identity
+isomorphism.
+
+```agda
+  Embed-essential-image : Functor D (∫ (Essential-image .Subcat))
+  Embed-essential-image .Functor.F₀ X = (F₀ X) , inc (X , C.id-iso)
+  Embed-essential-image .Functor.F₁ f = total-hom (F₁ f) tt
+  Embed-essential-image .Functor.F-id = total-hom-path _ F-id refl
+  Embed-essential-image .Functor.F-∘ f g = total-hom-path _ (F-∘ f g) refl
+```
+
+To see that this functor is fully faithful, recall that if both
+$F \circ G$  and $F$ are fully faithful, then so is $G$.
+The action of morphisms of `πᶠ F∘ Embed-essential-image` is `F.F₁`{.Agda},
+which is fully faithful by our hypotheses. `πᶠ`{.Agda} is fully faithful
+when the displayed category is a full subcategory, which `Essential-image`{.Agda}
+is, so we can conclude that `Embed-essential-image`{.Agda} is also fully faithful.
+
+```agda
+  Embed-essential-image-ff : is-ff Embed-essential-image
+  Embed-essential-image-ff =
+    ff-cancel-l (πᶠ _) Embed-essential-image
+      ff
+      (πᶠ-full-subcategory-ff (Essential-image .has-is-full-subcategory))
+```
+
+Furthermore, `Embed-essential-image`{.Agda} is essential surjective, as
+`πᶠ`{.Agda} is fully faithful, and fully faithful functors are essential injective,
+which allows us to lift the isomorphism in question.
+
+```agda
+  Embed-essential-image-eso : is-eso Embed-essential-image
+  Embed-essential-image-eso yo = do
+    (preimg , isom) ← yo .snd
+    pure $ preimg , is-ff→essentially-injective (πᶠ _) πᶠ-ff isom
+    where
+      open C._≅_
+      πᶠ-ff = πᶠ-full-subcategory-ff (Essential-image .has-is-full-subcategory)
 ```

--- a/src/Cat/Thin/Completion.lagda.md
+++ b/src/Cat/Thin/Completion.lagda.md
@@ -142,9 +142,9 @@ fully faithful. It exhibits $\ca{C}$ as a full subproset of
 $\widehat{\ca{C}}$.
 
 ```agda
-Complete-is-fully-faithful
-  : ∀ {o h} {X : Proset o h} → is-fully-faithful (Complete {X = X})
-Complete-is-fully-faithful = id-equiv
+Complete-is-ff
+  : ∀ {o h} {X : Proset o h} → is-ff (Complete {X = X})
+Complete-is-ff = id-equiv
 ```
 
 ## Lifting functors

--- a/src/Cat/Univalent/Rezk.lagda.md
+++ b/src/Cat/Univalent/Rezk.lagda.md
@@ -51,7 +51,7 @@ sea of theory has risen to the point where our result is trivial:
 
 ```agda
 Rezk-completion : Precategory o h → Precategory (o ⊔ lsuc h) (o ⊔ h)
-Rezk-completion A = Full-inclusion→Full-subcat {F = よ A} (よ-is-fully-faithful A)
+Rezk-completion A = Full-inclusion→Full-subcat {F = よ A} (よ-is-ff A)
 
 Rezk-completion-is-category
   : ∀ {A : Precategory o h} → is-category (Rezk-completion A)

--- a/src/Topoi/Base.lagda.md
+++ b/src/Topoi/Base.lagda.md
@@ -95,7 +95,7 @@ record Topos {o} κ (𝓣 : Precategory o κ) : Type (lsuc (o ⊔ κ)) where
     site : Precategory κ κ
 
     ι : Functor 𝓣 (PSh κ site)
-    has-ff : is-fully-faithful ι
+    has-ff : is-ff ι
 
     L : Functor (PSh κ site) 𝓣
     L-lex : is-lex L
@@ -493,7 +493,7 @@ module _ {o ℓ} {C : Precategory o ℓ} (ct : Topos ℓ C) where
       → f C.∘ h ≡ g C.∘ h )
     → f ≡ g
   Representables-generate {f = f} {g} sep =
-    fully-faithful→faithful {F = ct.ι} ct.has-ff $
+    ff→faithful ct.ι ct.has-ff $
       Representables-generate-presheaf ct.site λ h →
         ι.₁ f PSh.∘ h                                     ≡⟨ mangle ⟩
         ι.₁ ⌜ f C.∘ counit.ε _ C.∘ L.₁ h ⌝ PSh.∘ unit.η _ ≡⟨ ap! (sep _) ⟩
@@ -694,7 +694,7 @@ convenient for this application.
 record Geom[_↪_] (E : Precategory o ℓ) (F : Precategory o′ ℓ′) : Type (lvl E F) where
   field
     morphism : Geom[ E , F ]
-    has-ff : is-fully-faithful Dir[ morphism ]
+    has-ff : is-ff Dir[ morphism ]
 
 Geometric-embeddings-compose : Geom[ F ↪ G ] → Geom[ E ↪ F ] → Geom[ E ↪ G ]
 Geometric-embeddings-compose f g =

--- a/src/Topoi/Classifying/Diaconescu.lagda.md
+++ b/src/Topoi/Classifying/Diaconescu.lagda.md
@@ -169,5 +169,5 @@ fully faithful functor.
 
 ```agda
     Diaconescu-invl : Diaconescu⁻¹ (Diaconescu F flat) DC.≅ F
-    Diaconescu-invl = ff-lan-ext colim (よ D) F (よ-is-fully-faithful D)
+    Diaconescu-invl = ff-lan-ext colim (よ D) F (よ-is-ff D)
 ```

--- a/src/Topoi/Reasoning.lagda.md
+++ b/src/Topoi/Reasoning.lagda.md
@@ -53,7 +53,7 @@ module Sheaf-topos {o ℓ} {𝒯 : Precategory o ℓ} (T : Topos ℓ 𝒯) where
   module ε⁻¹ = _=>_ ε⁻¹
 
   psh-equal : ∀ {X Y} {f g : Hom X Y} → ι.₁ f ≡ ι.₁ g → f ≡ g
-  psh-equal = fully-faithful→faithful {F = T .Topos.ι} (T .Topos.has-ff)
+  psh-equal = ff→faithful {F = T .Topos.ι} (T .Topos.has-ff)
 ```
 
 **Terminology**: We will refer to the objects of $\mathcal{C}$, the


### PR DESCRIPTION
# Description

This PR implements a new subcategory API based off the idea that a subcategory contains the same datum as a displayed category with propositional object and hom spaces. It also contains a refactor of the `Cat.Functor.Base`, which renames `is-fully-faithful` to `is-ff`, and also updates the names of the relevant functions

## Merge Checklist
- [ ] Remove `Cat.Functor.FullSubcategory`
- [ ] Update index.
