### PR TITLE
Determine anchor using module name instead

### DIFF
--- a/src/1Lab/Prim/Type.lagda.md
+++ b/src/1Lab/Prim/Type.lagda.md
@@ -1,9 +1,3 @@
-pattern [_] z = z ∷ []
-pattern [_,_] y z = y ∷ z ∷ []
-pattern [_,_,_] x y z = x ∷ y ∷ z ∷ []
-pattern [_,_,_,_] w x y z = w ∷ x ∷ y ∷ z ∷ []
-pattern [_,_,_,_,_] v w x y z = v ∷ w ∷ x ∷ y ∷ z ∷ []
-pattern [_,_,_,_,_,_] u v w x y z = u ∷ v ∷ w ∷ x ∷ y ∷ z ∷ []
 ```agda
 module 1Lab.Prim.Type where
 ```

--- a/support/shake/app/HTML/Backend.hs
+++ b/support/shake/app/HTML/Backend.hs
@@ -254,11 +254,9 @@ definitionAnchor htmlenv def = f =<< go where
   go :: Maybe FilePath
   go = do
     let name = defName def
-    case rangeFile (nameBindingSite (qnameName name)) of
-      S.Just (rangeFilePath -> f) -> do
-        let f' = moduleName $ dropExtensions (makeRelative basepn (filePath f))
-        pure (f' <.> "html")
-      S.Nothing -> Nothing
+    case rangeModule (nameBindingSite (qnameName name)) of
+      Just f -> Just (modToFile f "html")
+      Nothing -> Nothing
   f modn =
     case rStart (nameBindingSite (qnameName (defName def))) of
       Just pn -> pure $ Text.pack (modn <> "#" <> show (posPos pn))


### PR DESCRIPTION
When running `agda-typed-html _build/all-pages.agda`, the base path is determined to be `_build` instead. This means `makeRelative` doesn't do anything, and so we end up generating module names like `.home.squid.Documents.software.cubical-1lab.src.1Lab.Path`.

