### PR TITLE
defn: universal propery of the Rezk completion

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -1782,7 +1782,7 @@ sym-∙-filler {A = A} {z = z} p q i j k =
 sym-∙ : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → sym (p ∙ q) ≡ sym q ∙ sym p
 sym-∙ p q i j = sym-∙-filler p q j i i1
 
-infixl -1 _$ₚ_
+infixl 45 _$ₚ_
 
 _$ₚ_ : ∀ {ℓ₁ ℓ₂} {A : Type ℓ₁} {B : A → Type ℓ₂} {f g : ∀ x → B x}
      → f ≡ g → ∀ x → f x ≡ g x

--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -14,6 +14,7 @@ module 1Lab.Reflection where
 open import Prim.Data.String public
 open import Prim.Data.Float public
 open import Prim.Data.Maybe public
+open import Data.Maybe.Base using (maybe→alt) public
 open import Prim.Data.Word public
 open import Meta.Traverse public
 open import Meta.Idiom public
@@ -436,7 +437,7 @@ instance
   Bind-TC .Bind._>>=_ = bindTC
 
   Alt-TC : Alt (eff TC)
-  Alt-TC .Alt.fail = typeError []
+  Alt-TC .Alt.fail′ xs = typeError [ strErr xs ]
   Alt-TC .Alt._<|>_ = catchTC
 ```
 </details>

--- a/src/1Lab/Reflection/Regularity.agda
+++ b/src/1Lab/Reflection/Regularity.agda
@@ -121,7 +121,7 @@ private
   -- then wrap it in a lambda. Nice!
   to-regularity-path : Regularity-precision → Term → TC Term
   to-regularity-path pre tm = do
-    tm ← raise 1 tm
+    tm ← maybe→alt (raise 1 tm) <?> "Failed to raise term in regularity tactic"
     -- Since we'll be comparing terms, Agda really wants them to be
     -- well-scoped. Since we shifted eeeverything up by one, we have to
     -- grow the context, too.
@@ -185,7 +185,7 @@ module Regularity where
     reduct pres tm _ = do
       orig ← wait-for-type =<< normalise tm
       tm ← to-regularity-path pres orig
-      red ← apply-tm tm (argN (con (quote i1) [])) >>= normalise
+      red ← maybe→alt (apply-tm tm (argN (con (quote i1) []))) >>= normalise
       `pres ← quoteTC pres
       typeError $
         "The term\n\n  " ∷ termErr orig ∷ "\n\nreduces modulo " ∷ termErr `pres ∷ " regularity to\n\n  "

--- a/src/Algebra/Group.lagda.md
+++ b/src/Algebra/Group.lagda.md
@@ -281,7 +281,6 @@ set, and it forms the carrier for a group: The _symmetric group_ on $X$.
 Sym : ∀ {ℓ} (X : Set ℓ) → Group-on (∣ X ∣ ≃ ∣ X ∣)
 Sym X = to-group-on group-str where
   open make-group
-  open n-Type X using (H-Level-n-type)
   group-str : make-group (∣ X ∣ ≃ ∣ X ∣)
   group-str .mul g f = f ∙e g
 ```
@@ -298,8 +297,7 @@ assumption), and `being an equivalence is a proposition`{.Agdaa
 ident=is-equiv-is-prop}.
 
 ```agda
-  group-str .group-is-set =
-    hlevel 2
+  group-str .group-is-set = hlevel!
 ```
 
 The associativity and identity laws hold definitionally.

--- a/src/Cat/Allegory/Maps.lagda.md
+++ b/src/Cat/Allegory/Maps.lagda.md
@@ -108,11 +108,11 @@ using those words.
     (subst (id A.≤_) (sym (A.idr _ ∙ dual-id A)) A.≤-refl)
 
   Maps[_] .Precategory._∘_ (f , m) (g , m′) = f A.∘ g , mapping
-    ( (f ∘ g) ∘ (f ∘ g) † A.=⟨ ap (_ ∘_) A.dual-∘ ·· sym (A.assoc _ _ _) ·· ap (f ∘_) (A.assoc _ _ _) ⟩
-      f ∘ (g ∘ g †) ∘ f † A.≤⟨ f ▶ m′ .functional ◀ f † ⟩
-      f ∘ id ∘ f †        A.=⟨ ap (f ∘_) (A.idl _) ⟩
-      f ∘ f †             A.≤⟨ m .functional ⟩
-      id                  A.≤∎ )
+    ( (f ∘ g) ∘ (f ∘ g) †     A.=⟨ A.†-inner refl ⟩
+      f ∘ (g ∘ g †) ∘ f †     A.≤⟨ f ▶ m′ .functional ◀ f † ⟩
+      f ∘ id ∘ f †            A.=⟨ A.refl⟩∘⟨ A.idl _ ⟩
+      f ∘ f †                 A.≤⟨ m .functional ⟩
+      id                      A.≤∎ )
     ( id                   A.≤⟨ m′ .entire ⟩
       g † ∘ g              A.=⟨ ap (g † ∘_) (sym (A.idl _)) ⟩
       g † ∘ id ∘ g         A.≤⟨ g † ▶ m .entire ◀ g ⟩

--- a/src/Cat/Allegory/Reasoning.lagda.md
+++ b/src/Cat/Allegory/Reasoning.lagda.md
@@ -102,3 +102,9 @@ modular′ f g h =
   (g † † ∩ (f † † ∘ h †) †) ∘ f   =⟨ ap₂ _∘_ (ap₂ _∩_ (dual g) (ap _† (ap₂ _∘_ (dual f) refl) ·· dual-∘ ·· ap (_∘ f †) (dual h))) refl ⟩
   (g ∩ h ∘ f †) ∘ f               ≤∎
 ```
+
+```agda
+†-inner : (p : g ∘ g′ † ≡ h) → (f ∘ g) ∘ (f′ ∘ g′) † ≡ f ∘ h ∘ f′ †
+†-inner p = ap₂ _∘_ refl dual-∘ ∙ sym (assoc _ _ _)
+          ∙ ap₂ _∘_ refl (assoc _ _ _ ∙ ap₂ _∘_ p refl)
+```

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -527,4 +527,9 @@ is a proposition:
            → ((x : _) → a .η x ≡ b .η x)
            → a ≡ b
   Nat-path = Nat-pathp refl refl
+
+  _ηₚ_ : ∀ {a b : F => G} → a ≡ b → ∀ x → a .η x ≡ b .η x
+  p ηₚ x = ap (λ e → e .η x) p
+
+  infixl 45 _ηₚ_
 ```

--- a/src/Cat/Bi/Diagram/Monad.lagda.md
+++ b/src/Cat/Bi/Diagram/Monad.lagda.md
@@ -111,13 +111,13 @@ module _ {o ℓ} {C : Precategory o ℓ} where
     monad′ .mult = M.μ
     monad′ .left-ident {x} =
         ap (M.μ .η x C.∘_) (C.intror refl)
-      ∙ ap (λ e → e .η x) M.μ-unitr
+      ∙ M.μ-unitr ηₚ x
     monad′ .right-ident {x} =
         ap (M.μ .η x C.∘_) (C.introl (M.M .Functor.F-id))
-      ∙ ap (λ e → e .η x) M.μ-unitl
+      ∙ M.μ-unitl ηₚ x
     monad′ .mult-assoc {x} =
         ap (M.μ .η x C.∘_) (C.intror refl)
-     ·· ap (λ e → e .η x) M.μ-assoc
+     ·· M.μ-assoc ηₚ x
      ·· ap (M.μ .η x C.∘_) (C.elimr refl ∙ C.eliml (M.M .Functor.F-id))
 
   Monad→bicat-monad : Cat.Monad C → Monad (Cat _ _) C

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -627,7 +627,7 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
       K=>lim′ .hom = K′=>lim .centre .hom
       K=>lim′ .commutes o =
         (morp.to .η o C.∘ f-lim .top .ψ o) C.∘ K=>lim′ .hom ≡⟨ C.pullr (K′=>lim .centre .commutes o) ⟩
-        morp.to .η o C.∘ ψ K′ o                             ≡⟨ C.cancell (ap (λ e → η e o) morp.invl) ⟩
+        morp.to .η o C.∘ ψ K′ o                             ≡⟨ C.cancell (morp.invl ηₚ o) ⟩
         K .ψ o                                              ∎
 
       uniq : ∀ x → K=>lim′ ≡ x
@@ -635,7 +635,7 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
         x′ : Cone-hom F K′ (f-lim .top)
         x′ .hom = x .hom
         x′ .commutes o =
-          f-lim .top .ψ o C.∘ x .hom                                       ≡⟨ C.introl (ap (λ e → η e o) morp.invr) ⟩
+          f-lim .top .ψ o C.∘ x .hom                                       ≡⟨ C.introl (morp.invr ηₚ o) ⟩
           (morp.from .η o C.∘ morp.to .η o) C.∘ f-lim .top .ψ o C.∘ x .hom ≡⟨ C.pullr (C.assoc _ _ _ ∙ x .commutes o) ⟩
           morp.from .η o C.∘ K .ψ o ∎
 ```

--- a/src/Cat/Diagram/Monad/Codensity.lagda.md
+++ b/src/Cat/Diagram/Monad/Codensity.lagda.md
@@ -127,34 +127,35 @@ construct auxilliary natural transformations representing each pair of
 maps we want to compute with.</summary>
 
 ```agda
-  Codensity .left-ident {x = x} = path where
+  Codensity .left-ident {x = x} = path ηₚ x where
     nat₁ : Ext => Ext
     nat₁ .η x = σ mult-nt .η x B.∘ Ext.₁ (σ unit-nt .η x)
     nat₁ .is-natural x y f = Ext.extendr (σ unit-nt .is-natural x y f)
                            ∙ B.pushl (σ mult-nt .is-natural _ _ _)
 
     abstract
-      path : nat₁ .η x ≡ B.id
-      path = ap (λ e → e .η x) $ σ-uniq₂ eps {σ₁′ = nat₁} {σ₂′ = idnt}
+      path : nat₁ ≡ idnt
+      path = σ-uniq₂ eps
         (Nat-path λ x →
-          sym (B.pulll (ap (λ e → e .η x) σ-comm)
-              ∙ Ext.cancelr (ap (λ e → e .η x) σ-comm)))
+          sym (B.pulll (σ-comm ηₚ x)
+             ∙ Ext.cancelr (σ-comm ηₚ x)))
         (Nat-path λ _ → B.intror refl)
 
-  Codensity .right-ident {x = x} = path where
+  Codensity .right-ident {x = x} = path ηₚ x where
     nat₁ : Ext => Ext
     nat₁ .η x = σ mult-nt .η x B.∘ σ unit-nt .η (Ext.₀ x)
     nat₁ .is-natural x y f = B.extendr (σ unit-nt .is-natural _ _ _)
                            ∙ B.pushl (σ mult-nt .is-natural _ _ _)
 
     abstract
-      path : nat₁ .η x ≡ B.id
-      path = ap (λ e → e .η x) $ σ-uniq₂ eps {σ₁′ = nat₁} {σ₂′ = idnt}
-        (Nat-path λ x → sym $ B.pulll (ap (λ e → e .η x) σ-comm)
+      path : nat₁ ≡ idnt
+      path = σ-uniq₂ eps
+        (Nat-path λ x → sym $ B.pulll (σ-comm ηₚ x)
                             ∙ B.pullr (sym (σ unit-nt .is-natural _ _ _))
-                            ∙ B.cancell (ap (λ e → e .η x) σ-comm))
+                            ∙ B.cancell (σ-comm ηₚ x))
         (Nat-path λ _ → B.intror refl)
-  Codensity .mult-assoc {x = x} = path where
+
+  Codensity .mult-assoc {x = x} = path ηₚ x where
     mult′ : (Ext F∘ Ext F∘ Ext) F∘ F => F
     mult′ .η x = eps .η x B.∘ Ext.₁ (mult-nt .η x)
     mult′ .is-natural x y f = Ext.extendr (mult-nt .is-natural _ _ _)
@@ -171,16 +172,14 @@ maps we want to compute with.</summary>
                             ∙ B.pushl (σ mult-nt .is-natural _ _ _)
 
     abstract
-      path : sig₁ .η x ≡ sig₂ .η x
-      path = ap (λ e → e .η x) $ σ-uniq₂ {M = Ext F∘ Ext F∘ Ext} mult′
-          {σ₁′ = sig₁}
-          {σ₂′ = sig₂}
-          (Nat-path λ x → sym (B.pulll (ap (λ e → e .η x) σ-comm)
-                            ∙ Ext.pullr (ap (λ e → e .η x) σ-comm)))
-          (Nat-path λ x → sym (B.pulll (ap (λ e → e .η x) σ-comm)
-                            ∙ B.pullr (sym (σ mult-nt .is-natural _ _ _))
-                            ∙ B.pulll (ap (λ e → e .η x) σ-comm)
-                            ∙ Ext.pullr refl))
+      path : sig₁ ≡ sig₂
+      path = σ-uniq₂ {M = Ext F∘ Ext F∘ Ext} mult′
+        (Nat-path λ x → sym (B.pulll (σ-comm ηₚ x)
+                           ∙ Ext.pullr (σ-comm ηₚ x)))
+        (Nat-path λ x → sym (B.pulll (σ-comm ηₚ x)
+                          ·· B.pullr (sym (σ mult-nt .is-natural _ _ _))
+                          ·· B.pulll (σ-comm ηₚ x)
+                           ∙ Ext.pullr refl))
 ```
 </details>
 

--- a/src/Cat/Diagram/Sieve.lagda.md
+++ b/src/Cat/Diagram/Sieve.lagda.md
@@ -96,5 +96,5 @@ to-presheaf↪よ {S} .mor .η x (f , _) = f
 to-presheaf↪よ {S} .mor .is-natural x y f = refl
 to-presheaf↪よ {S} .monic g h path = Nat-path λ x →
   embedding→monic (Subset-proj-embedding (λ _ → S .arrows _ .is-tr))
-    (g .η x) (h .η x) (ap (λ e → e .η x) path)
+    (g .η x) (h .η x) (path ηₚ x)
 ```

--- a/src/Cat/Functor/Equivalence.lagda.md
+++ b/src/Cat/Functor/Equivalence.lagda.md
@@ -5,6 +5,7 @@ open import Cat.Functor.Base
 open import Cat.Univalent
 open import Cat.Prelude
 
+import Cat.Functor.Reasoning as Fr
 import Cat.Reasoning
 
 module Cat.Functor.Equivalence where
@@ -568,5 +569,40 @@ instance
         {F : Functor C D} {n}
     → H-Level (is-precat-iso F) (suc n)
   H-Level-is-precat-iso = prop-instance (Iso→is-hlevel 1 eqv (hlevel 1))
+
+module
+  _ {o ℓ o′ ℓ′} {C : Precategory o ℓ} {D : Precategory o′ ℓ′}
+    (F : Functor C D) (eqv : is-equivalence F)
+  where
+  private
+    module e = is-equivalence eqv
+    module C = Cat.Reasoning C
+    module D = Cat.Reasoning D
+    module F = Fr F
+
+  is-equivalence→is-ff : is-fully-faithful F
+  is-equivalence→is-ff = is-iso→is-equiv λ where
+    .is-iso.inv x → e.unit⁻¹ .η _ C.∘ L-adjunct e.F⊣F⁻¹ x
+    .is-iso.rinv x →
+      D.invertible→monic (F-map-invertible F (e.unit-iso _)) _ _ $
+        ap₂ D._∘_ refl (F .F-∘ _ _)
+      ·· D.cancell (F.annihilate (e.unit-iso _ .C.is-invertible.invl))
+      ·· D.invertible→monic (e.counit-iso _) _ _
+          (R-L-adjunct e.F⊣F⁻¹ x ∙ sym (D.cancell e.zig))
+    .is-iso.linv x →
+        ap (_ C.∘_) (sym (e.unit .is-natural _ _ _))
+      ∙ C.cancell (e.unit-iso _ .C.is-invertible.invr)
+
+  open is-precat-iso
+  open is-iso
+
+  is-equivalence→is-precat-iso
+    : is-category C → is-category D → is-precat-iso F
+  is-equivalence→is-precat-iso c-cat d-cat = λ where
+    .has-is-ff → is-equivalence→is-ff
+    .has-is-iso → is-iso→is-equiv λ where
+      .inv → e.F⁻¹ .F₀
+      .rinv x → d-cat .to-path (D.invertible→iso _ (e.counit-iso x))
+      .linv x → sym $ c-cat .to-path (C.invertible→iso _ (e.unit-iso x))
 ```
 -->

--- a/src/Cat/Functor/Equivalence/Path.lagda.md
+++ b/src/Cat/Functor/Equivalence/Path.lagda.md
@@ -260,18 +260,6 @@ module
     module F = Fr F
   open _=>_
 
-  is-equivalence→is-ff : is-fully-faithful F
-  is-equivalence→is-ff = is-iso→is-equiv λ where
-    .is-iso.inv x → unit⁻¹ .η _ C.∘ L-adjunct F⊣F⁻¹ x
-    .is-iso.rinv x →
-      D.invertible→monic (F-map-invertible F (unit-iso _)) _ _ $
-        ap₂ D._∘_ refl (F .F-∘ _ _)
-      ·· D.cancell (F.annihilate (unit-iso _ .C.is-invertible.invl))
-      ·· D.invertible→monic (counit-iso _) _ _
-          (R-L-adjunct F⊣F⁻¹ x ∙ sym (D.cancell zig))
-    .is-iso.linv x →
-        ap (_ C.∘_) (sym (unit .is-natural _ _ _))
-      ∙ C.cancell (unit-iso _ .C.is-invertible.invr)
 ```
 -->
 

--- a/src/Cat/Functor/Hom.lagda.md
+++ b/src/Cat/Functor/Hom.lagda.md
@@ -323,9 +323,9 @@ _also_ a cocone homomorphism $X \to Y$; But $X$ is initial, so $f = g$!
 
       g′ : Cocone-hom (よ F∘ El.πₚ C X) (Reassemble X) (Map→cocone-under X f)
       g′ .hom = g
-      g′ .commutes o = Nat-path λ x → ap (λ e → e .η x) $ sym $ sep $
+      g′ .commutes o = Nat-path λ x → sym (sep $
         NT (λ i a → P.₁ a (o .section)) λ x y h →
-          funext λ _ → happly (P.F-∘ _ _) _
+          funext λ a → P.F-∘ _ _ $ₚ o .section) ηₚ x
 ```
 
 An immediate consequence is that, since any pair of maps $f, g : X \to

--- a/src/Cat/Functor/Kan.lagda.md
+++ b/src/Cat/Functor/Kan.lagda.md
@@ -175,7 +175,7 @@ where uniqueness and commutativity follows from the triangle identities
           module M = Func M
 
   adjoint→lan .σ-uniq {M} {α} {σ'} p = Nat-path λ x →
-    M.₁ (counit.ε _) C.∘ α.η _                ≡⟨ ap (_ C.∘_) (ap (λ e → e .η _) p) ⟩
+    M.₁ (counit.ε _) C.∘ α.η _                ≡⟨ ap (_ C.∘_) (p ηₚ _) ⟩
     M.₁ (counit.ε _) C.∘ σ' .η _ C.∘ unit.η _ ≡⟨ C.extendl (sym (σ' .is-natural _ _ _)) ⟩
     σ' .η _ C.∘ G.₁ (counit.ε _) C.∘ unit.η _ ≡⟨ C.elimr zag ⟩
     σ' .η x                                   ∎
@@ -359,7 +359,7 @@ Fair advance warning that the computation here doesn't have any further comments
     lan .σ-uniq {M = M} {α} {σ'} path = Nat-path λ x →
       ap hom $ colim (diagram _) .has⊥ _ .paths
         (cocone-hom _ λ o → sym $
-            ap₂ E._∘_ refl (ap (λ e → e .η _) path)
+            ap₂ E._∘_ refl (path ηₚ ↓Obj.x o)
           ∙ E.pulll (sym (σ' .is-natural _ _ _))
           ∙ E.pullr ( colim _ .has⊥ _ .centre .commutes _
                     ∙ ap (colim (diagram x) .bot .ψ)
@@ -385,11 +385,11 @@ extension along a fully-faithful functor does actually _extend_.
       cocone′ .ψ ob = F.₁ (ff.from (ob .map))
       cocone′ .commutes {x = y} {z} f =
         F.collapse (fully-faithful→faithful {F = K} ff
-          ( K .Functor.F-∘  _ _
-          ∙ ap₂ D._∘_ (ff.ε _) refl
-          ∙ f .sq
-          ∙ D.idl _
-          ∙ sym (ff.ε _)))
+          (  K .Functor.F-∘  _ _
+          ·· ap₂ D._∘_ (ff.ε _) refl
+          ·· f .sq
+          ·· D.idl _
+          ·· sym (ff.ε _)))
 
       to : E.Hom _ (F.₀ x)
       to = colim _ .has⊥ cocone′ .centre .hom

--- a/src/Cat/Functor/Kan/Global.lagda.md
+++ b/src/Cat/Functor/Kan/Global.lagda.md
@@ -59,8 +59,8 @@ module _ (has-lan : (G : Functor C D) → Lan p G) where
   Lan-functor .F-id {x} = has-lan x .σ-uniq (Nat-path λ _ → D.id-comm)
   Lan-functor .F-∘ {x} {y} {z} f g =
     has-lan x .σ-uniq $ Nat-path λ a → sym $
-        D.pullr (ap (λ e -> e .η a) (has-lan x .σ-comm))
-      ∙ D.extendl (ap (λ e → e .η a) (has-lan y .σ-comm))
+        D.pullr   (has-lan x .σ-comm ηₚ a)
+      ∙ D.extendl (has-lan y .σ-comm ηₚ a)
 ```
 
 Functoriality follows, essentially, from the fact that left Kan
@@ -82,12 +82,12 @@ adjoint to the [precomposition] functor $p_!$.
 
     eqv : ∀ {x} {y} → is-iso (f {x} {y})
     eqv {x} {y} .inv θ = has-lan _ .σ θ
-    eqv {x} {y} .rinv θ = Nat-path λ _ → ap (λ e → e .η _) (has-lan x .σ-comm)
+    eqv {x} {y} .rinv θ = has-lan x .σ-comm
     eqv {x} {y} .linv θ = has-lan _ .σ-uniq refl
 
     natural : hom-iso-natural {L = Lan-functor} {p !} f
     natural {b = b} g h x = Nat-path λ a →
-      D.pullr (D.pullr (ap (λ e → e .η a) (has-lan _ .σ-comm)))
+      D.pullr (D.pullr (has-lan _ .σ-comm ηₚ a))
       ∙ ap₂ D._∘_ refl (D.pushr refl)
 ```
 
@@ -108,8 +108,8 @@ adjoint→Lan F F⊣p! G = ext where
   ext .eta = F⊣p!.unit .η G
   ext .σ α = R-adjunct F⊣p! α
   ext .σ-comm {M = M} {α = α} = Nat-path λ a →
-      D.pullr (ap (λ e → e .η a) (sym (F⊣p!.unit .is-natural _ _ _)))
-    ∙ D.cancell (ap (λ e → e .η a) F⊣p!.zag)
+      D.pullr   (sym (F⊣p!.unit .is-natural _ _ _) ηₚ a)
+    ∙ D.cancell (F⊣p!.zag ηₚ a)
   ext .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv F⊣p!)
     (L-R-adjunct F⊣p! _ ∙ x)
 ```

--- a/src/Cat/Functor/Kan/Nerve.lagda.md
+++ b/src/Cat/Functor/Kan/Nerve.lagda.md
@@ -143,9 +143,9 @@ look at the code. Godspeed.
     cocone′ ob .coapex = ob
     cocone′ ob .ψ obj = obj .map .η _ D.id
     cocone′ ob .commutes {x} {y} f =
-      happly (sym (y .map .is-natural _ _ _)) _
-      ∙ ap (y .map .η (x .↓Obj.x)) (sym D.id-comm)
-      ∙ happly (ap (λ e → e .η (x .↓Obj.x)) (f .sq)) _
+        sym (y .map .is-natural _ _ _) $ₚ _
+      ∙ ap (y .map .η (x .↓Obj.x)) D.id-comm-sym
+      ∙ f .sq ηₚ _ $ₚ _
 ```
 
 Before proceeding, take a moment to appreciate the beauty of the
@@ -198,7 +198,7 @@ counit is given by the unique "colimiting" map _from_ that colimit.
         cocone₂ .commutes {x₂} {y₂} f =
           C.pullr ( sym (happly (y₂ .map .is-natural _ _ _) _)
                   ∙ ap (y₂ .map .η _) (sym D.id-comm))
-          ∙ ap (_ C.∘_) (happly (ap (λ e → e .η (x₂ .↓Obj.x)) (f .sq)) D.id)
+          ∙ ap (_ C.∘_) (f .sq ηₚ _ $ₚ D.id)
 
     adj .zig {A} = ap hom $
       is-contr→is-prop (cocompl (F F∘ Dom (よ D) (const! A)) .has⊥ (cocompl _ .bot))

--- a/src/Cat/Functor/Kan/Right.lagda.md
+++ b/src/Cat/Functor/Kan/Right.lagda.md
@@ -93,10 +93,9 @@ module _ (p : Functor C C′) (F : Functor C D) where
       α′ .η x = α .η x
       α′ .is-natural x y f = sym (α .is-natural y x f)
 
-    ran .σ-comm = Nat-path λ x → ap (λ e → e .η _) lan.σ-comm
+    ran .σ-comm = Nat-path λ x → lan.σ-comm ηₚ x
     ran .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → ap (λ e → e .η x) $ lan.σ-uniq {σ′ = σ′op} $ Nat-path λ x →
-        ap (λ e → e .η x) p
+      Nat-path λ x → lan.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
       where
         σ′op : lan.Ext => Functor.op M
         σ′op .η x = σ′ .η x

--- a/src/Cat/Functor/Kan/Unique.lagda.md
+++ b/src/Cat/Functor/Kan/Unique.lagda.md
@@ -89,12 +89,12 @@ for $\sigma'_\eta\sigma_{\eta'}$ is analogous.
   Ext-unique : [C′,D].Isomorphism L₁.Ext L₂.Ext
   Ext-unique = [C′,D].make-iso (L₁.σ L₂.eta) (L₂.σ L₁.eta)
     ( sym (L₂.σ-uniq {α = L₂.eta}
-        (Nat-path λ _ → sym ( D.pullr (ap (λ e → e .η _) L₂.σ-comm)
-                            ∙ ap (λ e → e .η _) L₁.σ-comm)))
+        (Nat-path λ _ → sym ( D.pullr (L₂.σ-comm ηₚ _)
+                            ∙ L₁.σ-comm ηₚ _)))
     ∙ L₂.σ-uniq (Nat-path λ _ → D.introl refl))
     ( sym (L₁.σ-uniq {α = L₁.eta}
-        (Nat-path λ _ → sym ( D.pullr (ap (λ e → e .η _) L₁.σ-comm)
-                            ∙ ap (λ e → e .η _) L₂.σ-comm)))
+        (Nat-path λ _ → sym ( D.pullr (L₁.σ-comm ηₚ _)
+                            ∙ L₂.σ-comm ηₚ _)))
     ∙ L₁.σ-uniq (Nat-path λ _ → D.introl refl))
 
   Ext-uniqueₚ : L₁.Ext ≡ L₂.Ext
@@ -111,7 +111,7 @@ for $\sigma$.
 ```agda
   eta-uniqueₚ : PathP (λ i → F => Ext-uniqueₚ i F∘ p) L₁.eta L₂.eta
   eta-uniqueₚ = Nat-pathp refl _ λ _ →
-    Univalent.Hom-pathp-reflr-iso dcat (ap (λ e → e .η _) L₁.σ-comm)
+    Univalent.Hom-pathp-reflr-iso dcat (L₁.σ-comm ηₚ _)
 ```
 
 <details>
@@ -130,8 +130,8 @@ also identified.</summary>
 
       lemma : ∀ {x} → L₁.σ f .η x D.∘ L₂.σ (L₁.eta) .η x ≡ L₂.σ f .η x
       lemma {x = x} = sym $ ap (λ e → e .η x) {y = σ′} $
-        L₂.σ-uniq $ Nat-path λ _ →
-          sym (D.pullr (ap (λ e → e .η _) L₂.σ-comm) ∙ ap (λ e → e .η _) L₁.σ-comm)
+        L₂.σ-uniq $ Nat-path λ _ → sym (
+          D.pullr (L₂.σ-comm ηₚ _) ∙ L₁.σ-comm ηₚ _)
 ```
 </details>
 

--- a/src/Cat/Functor/Reasoning.lagda.md
+++ b/src/Cat/Functor/Reasoning.lagda.md
@@ -43,7 +43,7 @@ module _ (a≡id : a ≡ 𝒞.id) where
   elim : F₁ a ≡ 𝒟.id
   elim = ap F₁ a≡id ∙ F-id
 
-  eliml : F₁ a 𝒟.∘ f ≡ f 
+  eliml : F₁ a 𝒟.∘ f ≡ f
   eliml = 𝒟.eliml elim
 
   elimr : f 𝒟.∘ F₁ a ≡ f
@@ -81,7 +81,7 @@ module _ (c≡ab : c ≡ a 𝒞.∘ b) where
 
 module _ (p : a 𝒞.∘ c ≡ b 𝒞.∘ d) where
   weave : F₁ a 𝒟.∘ F₁ c ≡ F₁ b 𝒟.∘ F₁ d
-  weave = sym (F-∘ a c) ∙ ap F₁ p ∙ F-∘ b d
+  weave = sym (F-∘ a c) ·· ap F₁ p ·· F-∘ b d
 
   extendl : F₁ a 𝒟.∘ (F₁ c 𝒟.∘ f) ≡ F₁ b 𝒟.∘ (F₁ d 𝒟.∘ f)
   extendl = 𝒟.extendl weave
@@ -92,6 +92,10 @@ module _ (p : a 𝒞.∘ c ≡ b 𝒞.∘ d) where
   extend-inner :
     f 𝒟.∘ F₁ a 𝒟.∘ F₁ c 𝒟.∘ g ≡ f 𝒟.∘ F₁ b 𝒟.∘ F₁ d 𝒟.∘ g
   extend-inner = 𝒟.extend-inner weave
+
+module _ (p : F₁ a 𝒟.∘ F₁ c ≡ F₁ b 𝒟.∘ F₁ d) where
+  swap : F₁ (a 𝒞.∘ c) ≡ F₁ (b 𝒞.∘ d)
+  swap = F-∘ a c ·· p ·· sym (F-∘  b d)
 ```
 
 ## Cancellation
@@ -126,4 +130,3 @@ to make it somewhat cleaner.
 ⟨_⟩ : a ≡ b → F₁ a ≡ F₁ b
 ⟨_⟩ = ap F₁
 ```
-

--- a/src/Cat/Functor/Reasoning/FullyFaithful.lagda.md
+++ b/src/Cat/Functor/Reasoning/FullyFaithful.lagda.md
@@ -1,0 +1,67 @@
+```agda
+open import Cat.Functor.Base
+open import Cat.Prelude hiding (injective)
+
+import Cat.Functor.Reasoning as Fr
+import Cat.Reasoning
+
+module
+  Cat.Functor.Reasoning.FullyFaithful
+  {o ℓ o′ ℓ′} {C : Precategory o ℓ} {D : Precategory o′ ℓ′}
+  (F : Functor C D) (ff : is-fully-faithful F)
+  where
+```
+
+# Reasoning for ff Functors
+
+<!-- TODO [Amy 2022-12-14]
+Write something informative here
+-->
+
+This module contains a few short combinators for reasoning about the
+actions of fully faithful functors on morphisms and isomorphisms.
+
+<!--
+```agda
+open Fr F public
+private
+  module C = Cat.Reasoning C
+  module D = Cat.Reasoning D
+
+private variable
+  a b c d : C.Ob
+  α β γ δ : D.Ob
+  f g g′ h i : C.Hom a b
+  w x x′ y z : D.Hom α β
+
+module _ {a} {b} where
+  open Equiv (F₁ {a} {b} , ff) public
+
+module iso {a} {b} =
+  Equiv (F-map-iso {x = a} {b} F , is-ff→F-map-iso-is-equiv {F = F} ff)
+```
+-->
+
+```agda
+from-id : w ≡ D.id → from w ≡ C.id
+from-id p = injective₂ (ε _ ∙ p) F-id
+
+from-∘ : from (w D.∘ x) ≡ from w C.∘ from x
+from-∘ = injective (ε _ ∙ sym (F-∘ _ _ ∙ ap₂ D._∘_ (ε _) (ε _)))
+
+ipushr : x D.∘ F₁ g ≡ x′ → from (w D.∘ x) C.∘ g ≡ from (w D.∘ x′)
+ipushr p = injective (F-∘ _ _ ·· ap₂ D._∘_ (ε _) refl ·· D.pullr p ∙ sym (ε _))
+
+ε-lswizzle : w D.∘ x ≡ D.id → w D.∘ F₁ (from (x D.∘ y)) ≡ y
+ε-lswizzle = D.lswizzle (ε _)
+
+ε-expand : w D.∘ x ≡ y → F₁ (from w C.∘ from x) ≡ y
+ε-expand p = F-∘ _ _ ·· ap₂ D._∘_ (ε _) (ε _) ·· p
+
+ε-twist : F₁ f D.∘ x ≡ y D.∘ F₁ g → f C.∘ from x ≡ from y C.∘ g
+ε-twist {f = f} {g = g} p = injective $ swap $
+  ap (F₁ f D.∘_) (ε _) ·· p ·· ap (D._∘ F₁ g) (sym (ε _))
+
+inv∘l : x D.∘ F₁ f ≡ y → from x C.∘ f ≡ from y
+inv∘l x = sym (ε-twist (D.eliml F-id ∙ sym x)) ∙ C.idl _
+```

--- a/src/Cat/Instances/Functor.lagda.md
+++ b/src/Cat/Instances/Functor.lagda.md
@@ -38,7 +38,7 @@ $\eta$ and $\theta$.
 ```agda
 _∘nt_ : {F G H : Functor C D} → G => H → F => G → F => H
 _∘nt_ {C = C} {D = D} {F} {G} {H} f g = nat where
-  module D = Precategory D
+  module D = Cat.Reasoning D
 
   nat : F => H
   nat .η x = f .η _ D.∘ g .η _
@@ -47,12 +47,9 @@ _∘nt_ {C = C} {D = D} {F} {G} {H} f g = nat where
 <!--
 ```agda
   nat .is-natural x y h =
-    (f .η y D.∘ g .η y) D.∘ F.₁ h    ≡⟨ sym (D.assoc _ _ _) ⟩
-    f .η y D.∘ (g .η y D.∘ F.₁ h)    ≡⟨ ap (D._∘_ (f .η y)) (g .is-natural _ _ _) ⟩
-    f .η y D.∘ (G.₁ h D.∘ g .η x)    ≡⟨ D.assoc _ _ _ ⟩
-    (f .η y D.∘ G.₁ h) D.∘ (g .η x)  ≡⟨ ap (λ e → e D.∘ (g .η x)) (f .is-natural _ _ _) ⟩
-    (H.₁ h D.∘ f .η x) D.∘ (g .η x)  ≡⟨ sym (D.assoc _ _ _) ⟩
-    H.₁ h D.∘  f .η _ D.∘ g .η  _    ∎
+    (f .η y D.∘ g .η y) D.∘ F.₁ h  ≡⟨ D.pullr (g .is-natural _ _ _) ⟩
+    f .η y D.∘ (G.₁ h D.∘ g .η x)  ≡⟨ D.extendl (f .is-natural _ _ _) ⟩
+    H.₁ h  D.∘ f .η _ D.∘ g .η  _  ∎
     where
       module C = Precategory C
       module F = Functor F
@@ -266,7 +263,7 @@ so that the two halves of the isomorphism annihilate.
       F₁≡G₁ : ∀ {x y} (f : C .Hom x y)
             → PathP (λ i → D.Hom (F₀≡G₀ x i) (F₀≡G₀ y i)) (F .F₁ {x} {y} f) (G .F₁ {x} {y} f)
       F₁≡G₁ {x = x} {y} f = Hom-pathp-iso $
-        (D.extendl (F≅G .to .is-natural x y f) ∙ D.elimr (ap (λ e → e .η x) (F≅G .invl)))
+        (D.extendl (F≅G .to .is-natural x y f) ∙ D.elimr (F≅G .invl ηₚ x))
 
       F≡G : F ≡ G
       F≡G = Functor-path F₀≡G₀ λ f → F₁≡G₁ f
@@ -412,8 +409,8 @@ module
              → F DE.≅ F′ → (F F∘ G) CE.≅ (F′ F∘ G)
     F∘-iso-l {F} {F′} {G} isom =
       CE.make-iso to from
-        (Nat-path λ x → ap (λ e → e .η _) isom.invl)
-        (Nat-path λ x → ap (λ e → e .η _) isom.invr)
+        (Nat-path λ x → isom.invl ηₚ _)
+        (Nat-path λ x → isom.invr ηₚ _)
       where
         module isom = DE._≅_ isom
         to : (F F∘ G) => (F′ F∘ G)

--- a/src/Cat/Instances/Functor/Duality.lagda.md
+++ b/src/Cat/Instances/Functor/Duality.lagda.md
@@ -91,7 +91,7 @@ module _ {o ℓ o′ ℓ′} {C : Precategory o ℓ} {D : Precategory o′ ℓ�
 
   op-natural-iso : F CD.≅ G → (Functor.op F) CopDop.≅ (Functor.op G)
   op-natural-iso isom = CopDop.make-iso (_=>_.op isom.from) (_=>_.op isom.to)
-    (Nat-path (λ x → ap (λ e → e .η x) isom.invl))
-    (Nat-path λ x → ap (λ e → e .η x) isom.invr)
+    (Nat-path λ x → isom.invl ηₚ x)
+    (Nat-path λ x → isom.invr ηₚ x)
     where module isom = CD._≅_ isom
 ```

--- a/src/Cat/Instances/Functor/Limits.lagda.md
+++ b/src/Cat/Instances/Functor/Limits.lagda.md
@@ -93,7 +93,7 @@ as we perform this lifting, we can "adjust" the cone by a map $(x
   Lift-cone {x} {y} K f .ψ z  = F′.second f C.∘ K .ψ z .η _
   Lift-cone {x} {y} K g .commutes f =
     F′.first f C.∘ F′.second g C.∘ K .ψ _ .η x ≡⟨ C.extendl F′.first∘second ⟩
-    F′.second g C.∘ F′.first f C.∘ K .ψ _ .η x ≡⟨ ap (F′.second _ C.∘_) (ap₂ C._∘_ (C.elimr (F-id (F.₀ _))) refl ∙ ap (λ e → e .η x) (K .commutes f)) ⟩
+    F′.second g C.∘ F′.first f C.∘ K .ψ _ .η x ≡⟨ ap (F′.second _ C.∘_) (ap₂ C._∘_ (C.elimr (F-id (F.₀ _))) refl ∙ K .commutes f ηₚ x) ⟩
     F′.second g C.∘ K .ψ _ .η x                ∎
 ```
 
@@ -205,7 +205,7 @@ quite tedious:
         h1 .commutes o =
           lim-for y .ψ o C.∘ map y .hom C.∘ K .apex .F₁ f  ≡⟨ C.pulll (map y .commutes _ ∙ C.eliml F′.second-id) ⟩
           K .ψ _ .η _ C.∘ K .apex .F₁ f                    ≡⟨ K .ψ _ .is-natural _ _ _ ⟩
-          F₁ (F.₀ o) f C.∘ K .ψ o .η x                     ≡⟨ ap (C._∘ K .ψ o .η x) (C.introl (ap (λ e → e .η y) (F-id F))) ⟩
+          F₁ (F.₀ o) f C.∘ K .ψ o .η x                     ≡⟨ ap (C._∘ K .ψ o .η x) (C.introl (F-id F ηₚ y)) ⟩
           F′.second f C.∘ K .ψ o .η x                      ∎
 
         h2 : Cone-hom (F′.Left y) (Lift-cone K f) (lim-for y)
@@ -228,7 +228,7 @@ limit $\lim F$.
     where
       hom' : ∀ {x} → Cone-hom (F′.Left x) _ _
       hom' {x} .hom = h .hom .η x
-      hom' {x} .commutes o = ap (λ e → e .η _) (h .commutes o) ∙ C.introl F′.second-id
+      hom' {x} .commutes o = h .commutes o ηₚ _ ∙ C.introl F′.second-id
 
   functor-limit : Limit F
   functor-limit .top            = functor-cone

--- a/src/Cat/Instances/Slice/Presheaf.lagda.md
+++ b/src/Cat/Instances/Slice/Presheaf.lagda.md
@@ -126,7 +126,7 @@ without comment.
     func : Functor (Slice Cat[ C ^op , Sets κ ] P) Cat[ (∫ C P) ^op , Sets κ ]
     func .F₀ = slice-ob→presheaf
     func .F₁ {x} {y} h .η i arg =
-      h .map .η (i .ob) (arg .fst) , ap (λ e → e .η _ (arg .fst)) (h .commutes) ∙ arg .snd
+      h .map .η (i .ob) (arg .fst) , h .commutes ηₚ _ $ₚ arg .fst ∙ arg .snd
     func .F₁ {x} {y} h .is-natural _ _ _ = funext λ i →
       Σ-prop-path (λ _ → P.₀ _ .is-tr _ _) (happly (h .map .is-natural _ _ _) _)
 

--- a/src/Cat/Monoidal/Base.lagda.md
+++ b/src/Cat/Monoidal/Base.lagda.md
@@ -206,8 +206,8 @@ Endomorphisms B a = mon where
     ni : make-natural-iso _ _
     ni .eta _ = B.α→ _ _ _
     ni .inv _ = B.α← _ _ _
-    ni .eta∘inv _ = ap (λ e → e .η _) (Cr.invl _ B.associator)
-    ni .inv∘eta _ = ap (λ e → e .η _) (Cr.invr _ B.associator)
+    ni .eta∘inv _ = Cr.invl _ B.associator ηₚ _
+    ni .inv∘eta _ = Cr.invr _ B.associator ηₚ _
     ni .natural x y f = sym $ Cr.to B.associator .is-natural _ _ _
   mon .triangle = B.triangle _ _
   mon .pentagon = B.pentagon _ _ _ _

--- a/src/Cat/Monoidal/Diagram/Monoid.lagda.md
+++ b/src/Cat/Monoidal/Diagram/Monoid.lagda.md
@@ -252,10 +252,10 @@ into an identification.
   F .F₀′ o ._⋆_ x y = o .μ (x , y)
   F .F₀′ o .has-is-monoid .Mon.has-is-semigroup =
     record { has-is-magma = record { has-is-set = hlevel! }
-           ; associative  = o .μ-assoc $ₚ _ , _ , _
+           ; associative  = o .μ-assoc $ₚ _
            }
-  F .F₀′ o .has-is-monoid .Mon.idl = o .μ-unitl $ₚ lift tt , _
-  F .F₀′ o .has-is-monoid .Mon.idr = o .μ-unitr $ₚ _ , lift tt
+  F .F₀′ o .has-is-monoid .Mon.idl = o .μ-unitl $ₚ _
+  F .F₀′ o .has-is-monoid .Mon.idr = o .μ-unitr $ₚ _
   F .F₁′ wit .pres-id = wit .pres-η $ₚ _
   F .F₁′ wit .pres-⋆ x y = wit .pres-μ $ₚ _
   F .F-id′ = prop!

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -322,4 +322,10 @@ invertible→epic {f = f} invert g h p =
   h ∎
   where
     open is-invertible invert
+
+iso→monic : (f : a ≅ b) → is-monic (f .to)
+iso→monic f = invertible→monic (iso→invertible f)
+
+iso→epic : (f : a ≅ b) → is-epic (f .to)
+iso→epic f = invertible→epic (iso→invertible f)
 ```

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -114,14 +114,14 @@ module _ (inv : h ∘ i ≡ id) where abstract
   cancell : h ∘ (i ∘ f) ≡ f
   cancell {f = f} =
     h ∘ (i ∘ f) ≡⟨ pulll inv ⟩
-    id ∘ f ≡⟨ idl f ⟩
-    f ∎
+    id ∘ f      ≡⟨ idl f ⟩
+    f           ∎
 
   cancelr : (f ∘ h) ∘ i ≡ f
   cancelr {f = f} =
     (f ∘ h) ∘ i ≡⟨ pullr inv ⟩
-    f ∘ id ≡⟨ idr f ⟩
-    f ∎
+    f ∘ id      ≡⟨ idr f ⟩
+    f           ∎
 
   insertl : f ≡ h ∘ (i ∘ f)
   insertl = sym cancell
@@ -131,6 +131,23 @@ module _ (inv : h ∘ i ≡ id) where abstract
 
   cancel-inner : (f ∘ h) ∘ (i ∘ g) ≡ f ∘ g
   cancel-inner = pulll cancelr
+
+  deleter : (f ∘ g ∘ h) ∘ i ≡ f ∘ g
+  deleter = pullr cancelr
+
+  deletel : h ∘ (i ∘ f) ∘ g ≡ f ∘ g
+  deletel = pulll cancell
+```
+
+We also have a combinator which combines expanding on the right with a
+cancellation on the left:
+
+```agda
+lswizzle : g ≡ h ∘ i → f ∘ h ≡ id → f ∘ g ≡ i
+lswizzle {g = g} {h = h} {i = i} {f = f} p q =
+  f ∘ g     ≡⟨ ap₂ _∘_ refl p ⟩
+  f ∘ h ∘ i ≡⟨ cancell q ⟩
+  i         ∎
 ```
 
 ## Isomorphisms

--- a/src/Cat/Univalent.lagda.md
+++ b/src/Cat/Univalent.lagda.md
@@ -178,32 +178,46 @@ paths in `Hom`{.Agda}-sets.
   path→from-∙ {A = A} p q =
     J (λ B p → ∀ {C} (q : B ≡ C) → path→iso (p ∙ q) .from ≡ path→iso p .from ∘ path→iso q .from)
       (λ q → subst-∙ (λ e → Hom e _) refl q _
-          ∙ ap (subst (λ e → Hom e _) q) (transport-refl id)
-          ∙ sym (idl _) ∙ ap₂ _∘_ (sym (transport-refl id)) refl
+          ·· ap (subst (λ e → Hom e _) q) (transport-refl id)
+          ·· sym (idl _) ∙ ap₂ _∘_ (sym (transport-refl id)) refl
       )
       p q
 
   path→to-sym : ∀ {A B} (p : A ≡ B) → path→iso p .from ≡ path→iso (sym p) .to
   path→to-sym = J (λ B p → path→iso p .from ≡ path→iso (sym p) .to) refl
 
+  from-pathp-to
+    : ∀ {A B C} (p : A ≡ B) {f g}
+    → PathP (λ i → Hom C (p i)) f g
+    → path→iso p .to ∘ f ≡ g
+  from-pathp-to {C = C} p q =
+    J (λ B p → ∀ {f g} → PathP (λ i → Hom C (p i)) f g
+             → path→iso p .to ∘ f ≡ g)
+      (λ q → eliml (transport-refl _) ∙ q) p q
+
+  from-pathp-from
+    : ∀ {A B C} (p : A ≡ B) {f g}
+    → PathP (λ i → Hom C (p i)) f g
+    → path→iso (sym p) .from ∘ f ≡ g
+  from-pathp-from {C = C} p q = ap₂ _∘_ (path→to-sym (sym p)) refl
+                              ∙ from-pathp-to p q
+
 module Univalent {o h} {C : Precategory o h} (r : is-category C) where
   open Univalent′ r public
 
   Hom-pathp-refll-iso :
-    ∀ {A B C} {p : A ≅ C} {h : Hom A B} {h' : Hom C B}
-    → h ∘ p .from ≡ h'
-    → PathP (λ i → Hom (iso→path p i) B) h h'
+    ∀ {A B C} {p : A ≅ C} {h : Hom A B} {h′ : Hom C B}
+    → h ∘ p .from ≡ h′
+    → PathP (λ i → Hom (iso→path p i) B) h h′
   Hom-pathp-refll-iso prf =
     Hom-pathp-refll C (ap₂ _∘_ refl (ap from (iso→path→iso _)) ∙ prf)
 
   Hom-pathp-reflr-iso
-    : ∀ {A B D} {q : B ≅ D} {h : Hom A B} {h' : Hom A D}
-    → q .to ∘ h ≡ h'
-    → PathP (λ i → Hom A (iso→path q i)) h h'
+    : ∀ {A B D} {q : B ≅ D} {h : Hom A B} {h′ : Hom A D}
+    → q .to ∘ h ≡ h′
+    → PathP (λ i → Hom A (iso→path q i)) h h′
   Hom-pathp-reflr-iso prf =
-    Hom-pathp-reflr C (
-      ap₂ _∘_ (ap to (iso→path→iso _)) refl
-      ∙ prf)
+    Hom-pathp-reflr C (ap₂ _∘_ (ap to (iso→path→iso _)) refl ∙ prf)
 
   Hom-pathp-iso
     : ∀ {A B C D} {p : A ≅ C} {q : B ≅ D} {h : Hom A B} {h' : Hom C D}

--- a/src/Cat/Univalent/Rezk/Universal.lagda.md
+++ b/src/Cat/Univalent/Rezk/Universal.lagda.md
@@ -1,17 +1,13 @@
 ```agda
 {-# OPTIONS --lossy-unification #-}
 open import Cat.Instances.Functor.Compose
-open import Cat.Functor.FullSubcategory
 open import Cat.Functor.Equivalence
 open import Cat.Instances.Functor
-open import Cat.Univalent.Rezk
 open import Cat.Functor.Base
-open import Cat.Functor.Hom
 open import Cat.Univalent
 open import Cat.Prelude
 
 import Cat.Functor.Reasoning.FullyFaithful as FfR
-import Cat.Functor.Bifunctor as Bifunctor
 import Cat.Functor.Reasoning as FR
 import Cat.Reasoning
 
@@ -25,7 +21,7 @@ module Cat.Univalent.Rezk.Universal where
 ```agda
 private variable
   o ℓ : Level
-  A B C : Precategory o ℓ
+  A B C C⁺ : Precategory o ℓ
 
 private module _ {o ℓ} {C : Precategory o ℓ} where
   open Cat.Reasoning C using (_≅_)
@@ -49,35 +45,36 @@ and is mostly a calculation.
 
 In generic terms, universality of the Rezk completion follows from
 univalent categories being the class of _local objects_ for the weak
-equivalences: A category $\ca{C}$ is univalent when if any weak
-equivalence $H : \ca{A} \to \ca{B}$ induces an equivalence
-$H_! : [\ca{B},\ca{C}] \to [\ca{A},\ca{C}]$; If there is any weak
-equivalence $R : \ca{C} \to \ca{C}^+$, precomposition with $R$ is an
-equivalence between $\ca{C}$-functors into categories and
-$\ca{C}^+$-functors. Moreover, this equivalence sends the identity to
-$R$.
+equivalences^[a _weak equivalence_ is a fully faithful, essentially
+surjective functor]: A category $\ca{C}$ is univalent _precisely_ if any
+weak equivalence $H : \ca{A} \to \ca{B}$ induces^[by [precomposition]]
+a proper equivalence of categories $H_! : [\ca{B},\ca{C}] \to [\ca{A},\ca{C}]$.
+
+[precomposition]: Cat.Instances.Functor.Compose.html
 
 The high-level overview of the proof is as follows:
 
-- For any eso $H : \ca{A} \to \ca{B}$, and for any $\ca{C}$, all
+- For any \r{eso} $H : \ca{A} \to \ca{B}$, and for any $\ca{C}$, all
 precategories, the functor $H_! : [\ca{A},\ca{B}] \to [\ca{B},\ca{C}]$
 is faithful. This is the least technical part of the proof, so we do it
 first.
 
-- If $H$ is additionally full, then $H_!$ is fully faithful.
+- If $H$ is additionally full, then $H_!$ is \r{fully faithful}.
 
-- If $H$ is a weak equivalence, and $\ca{C}$ is univalent, then $H_!$ is
-essentially surjective. By the principle of unique choice, it is an
-equivalence, and moreover (since both its domain and codomain are
-univalent), an isomorphism.
+- If $H$ is a weak equivalence, and $\ca{C}$ is [univalent], then $H_!$
+is essentially surjective. By the principle of unique choice, it is an
+equivalence, and thus^[since both its domain and codomain are univalent]
+an isomorphism.
+
+[univalent]: Cat.Univalent.html#univalent-categories
 
 ## Faithfulness
 
 The argument here is almost elementary: We're given a witness that
 $\gamma H = \delta H$, so all we have to do is manipulate the expression
 $\gamma_b$ to something which has a $\gamma H$ subexpression. Since $H$
-is eso, given $b : B$, we can find $a : A$ and an iso $m : Ha \cong b$,
-from which we can calculate:
+is eso, given $b : \ca{B}$, we can find $a : \ca{A}$ and an iso $m : Ha
+\cong b$, from which we can calculate:
 
 ```agda
 eso→pre-faithful
@@ -101,10 +98,16 @@ eso→pre-faithful {A = A} {B = B} {C = C} H {F} {G} h-eso γ δ p =
 
 The above is, unfortunately, the simplest result in this module. The
 next two proofs are both _quite_ technical: that's because we're given
-some _mere_ (truncated) data, from the assumption that $H$ is a weak
-equivalence, so to use it as proper data, we need to characterise the
-use up to a contractible space of choices (after which we are free to
-project what we are interested in).
+some _mere_^[truncated] data, from the assumption that $H$ is a weak
+equivalence, so to use it as proper data, we need to show that whatever
+we want lives in a contractible space, after which we are free to
+project only the data we are interested in, and forget about the coherences.
+
+It will turn out, however, that the coherence data necessary to make
+these types contractible is exactly the coherence data we need to show
+that we are indeed building functors, natural transformations, etc. So,
+not only do we need it to use unique choice, we also need it to show
+we're doing category theory.
 
 ## Full-faithfulness
 
@@ -120,10 +123,10 @@ eso-full→pre-ff {A = A} {B = B} {C = C} H H-eso H-full = res where
 ```
 
 We will show that, for every natural transformation $\gamma : FH \to
-GH$, and each $b : B$, there is a contractible type of "component data"
-over $b$.  This data consists of a morphism $g : Fb \to Gb$, together
-with a witness that $g$ is compatible with any way to exhibit $b$ as
-being in the image of $H$.
+GH$, and each $b : \ca{B}$, there is a contractible type of "component
+data" over $b$. These data consist of morphisms $g : Fb \to Gb$,
+each equipped with a witness that $g$ acts naturally when faced with
+isomorphisms $Ha \cong b$.
 
 <!--
 ```agda
@@ -141,9 +144,15 @@ being in the image of $H$.
 ```
 -->
 
-The compatibility condition is: if we're given an essential fibre
-$(a,f)$ of $H$ over $b$, then it must have been the case that our
-_component_ $g$ came from $\gamma$ through an adjustment using $f$.
+In more detail, if we're given an essential fibre $(a,f)$ of $H$ over
+$b$, we can use $f$ to "match up" our component $g$ with the components
+of the natural transformation $\gamma$: since $\gamma_a : FH(a) \to
+FG(a)$, we've claimed to have a $Fb \to Gb$, and someone has just handed
+us a $H(a) \cong b$, then it darn well better be the case that $\gamma$ is
+
+$$
+FH(a) \xto{Ff} Fb \xto{g} Gb \xto{Gf^{-1}} FG(a)\text{.}
+$$
 
 ```agda
     T : B.Ob → Type _
@@ -152,12 +161,13 @@ _component_ $g$ came from $\gamma$ through an adjustment using $f$.
       γ.η a ≡ G.₁ (f .from) C.∘ g C.∘ F.₁ (f .to)
 ```
 
-For starters, assume that we have some $b : B$ and an essential fibre
-$(a_0, h_0)$ over it. Don't concern yourself with actually producing an
-$(a_0, h_0)$ just yet. Given that data, we can directly define $g$ to
-come from $\gamma$ through the inverse of the adjustment described in
-the compatibility condition, and a short calculation establishes that
-defining
+We'll first show that components exist at all. Assume that we have some
+$b : \ca{B}$ and an essential fibre $(a_0, h_0)$ of $H$ over it^[Don't
+worry about actually getting your hands on an $(a_0, h_0)$.]. In this
+situation, guided by the compatibility condiiton (and isomorphisms being
+just the best), we can actually _define_ the component to be "whatever
+satisfies compatibility at $(a_0,h_0)$," and a short calculation
+establishes that defining
 
 <!--
 ```agda
@@ -170,7 +180,7 @@ defining
       g = G.₁ h.to C.∘ γ.η a₀ C.∘ F.₁ h.from
 ```
 
-is indeed a correct option. We present the formalisation below, but do
+is indeed a possible choice. We present the formalisation below, but do
 not comment on the calculation, leaving it to the curious reader to load
 this file in Agda and poke around the proof.
 
@@ -189,12 +199,14 @@ this file in Agda and poke around the proof.
           ·· C.pullr (ap (G.₁ h.to C.∘_) (C.pulll refl) ∙ C.pulll refl)
 ```
 
-The result of having $g$ satisfy this coherence condition is that if we
-have any $g$, $g'$ both satisfying it, then we have $\gamma$ equal to
-both $G(h)gF(h^{-1})$ and $G(h)g'F(h^{-1})$. Since isomorphisms are both
-monic and epic, we can cancel $G(h)$ and $F(h^{-1})$ from these
-equations to conclude $g = g'$. Since the coherence condition is a
-proposition, the type of component data over $b$ is a proposition.
+Anyway, because of how we've phrased the coherence condition, if $g$,
+$g'$ both satisfy it, then we have $\gamma$ equal to both
+$G(h)gF(h^{-1})$ and $G(h)g'F(h^{-1})$.^[I've implicitly used that $H$
+is eso to cough up an $(a,h)$ over $b$, since we're proving a
+proposition] Since isomorphisms are both monic and epic, we can cancel
+$G(h)$ and $F(h^{-1})$ from these equations to conclude $g = g'$.  Since
+the coherence condition is a proposition, the type of component data
+over $b$ is a proposition.
 
 ```agda
     T-prop : ∀ b → is-prop (T b)
@@ -209,8 +221,9 @@ proposition, the type of component data over $b$ is a proposition.
 
 Given any $b$, $H$ being eso means that we _merely_ have an essential
 fibre $(a,h)$ of $H$ over $b$. But since the type of components over $b$
-is a proposition, we can use unique choice to get our hands on an
-$(a,h)$, and thus on a concrete component $g : Fb \to Gb$.
+is a proposition, if we're going to use it to construct a component over
+$b$, then we are granted the honour of actually getting hold of an
+$(a,h)$ pair.
 
 ```agda
     mkT′ : ∀ b → ∥ Essential-fibre H b ∥ → ∥ T b ∥
@@ -526,7 +539,15 @@ give $F$_.
 
     G .F-id = ap fst $ Homs-contr B.id .paths $ C.id , λ a h a′ h′ l w →
       sym (C.idl _ ∙ sym (kcomm (a , h) (a′ , h′) l (w ∙ B.idl _)))
+```
 
+Note that we proved^[in the second `<details>`{.Agda} tag above] that
+$G_1$ is functorial given _choices_ of essential fibres of all three
+objects involved in the composition. Since we're showing an equality in
+a set --- a proposition --- these choices don't matter, so we can use
+essential surjectivity of $H$.
+
+```agda
     G .F-∘ {x} {y} {z} f g = ∥-∥-proj do
       (ax , hx) ← H-eso x
       (ay , hy) ← H-eso y
@@ -534,10 +555,11 @@ give $F$_.
       inc (G∘.commutes f g hx hy hz)
 ```
 
-That is: For any $x : \ca{A}$, the object $F(x)$ can be made into an
-object candidate over $H(x)$, which, since the type of object candidates
-is a proposition, is equal to the centre of contraction --- the value
-$GH(x)$. So that's half done.
+To use the unique charactersation of $G$ as "the functor satisfying $GH
+= F$", observe: for any $x : \ca{A}$, the object $F(x)$ can be made into
+an object candidate over $H(x)$, and since the type of object candidates
+is a proposition, our candidate $F(x)$ is identical to the value of
+$GH(x)$.  That's half of $GH = F$ established right off the bat!
 
 ```agda
     module _ (x : A.Ob) where
@@ -560,11 +582,13 @@ $GH(x)$. So that's half done.
 ```
 -->
 
-_Over that identification_, we can, by the characterisation of paths in
-(pre)categories, show that any map $f : x \to y$ in $\ca{A}$ can be
-extended to a morphism candidate for $H(f)$, which is thus equal ---
-over the identification $GH(x) = F(x)$ we just constructed --- to the
-value of $GF(x)$. So we're done!
+_Over that identification_, we can show that, for any $f : x \to y$ in
+$\ca{A}$, the value $F(f)$ is also a candidate for the morphism $GH(f)$,
+so these are also identical. This proof is a bit hairier, because $F(f)$
+only has the right type if we adjust it by the proof that $GH(x) =
+F(x)$: we have to transport $F(f)$, and then as punishment for our
+hubris, invoke a lot of technical lemmas about the characterisation of
+`PathP`{.Agda} in the morphism spaces of (pre)categories.
 
 ```agda
     module _ {x y} (f : A.Hom x y) where
@@ -587,16 +611,51 @@ value of $GF(x)$. So we're done!
       to-pathp (homp f)
 ```
 
-All that remains after showing that $GH(x) = F(x)$ for every $x$, and
-similarly for morphisms, is appealing to our pre-existing proof that
-$H_!$ is fully faithful, and the proof that fully faithful essentially
-surjective functors between categories are equivalences.
+Since we've shown that $GH = F$, so in particular $GH \cong F$, we've
+now put together proofs that $H_!$ is fully faithful and, since the
+construction above works for any $F$, essentially surjective. Even
+better, since we've actually _constructed_ a functor $G$, we've shown
+that $H_!$ is **split** essentially surjective! Since $[-,\ca{C}]$ is
+univalent whenever $\ca{C}$ is, the splitting would be automatic, but
+this is a nice strengthening.
 
 ```agda
   weak-equiv→pre-equiv : is-equivalence {C = Cat[ B , C ]} (H !)
-  weak-equiv→pre-equiv = ff+eso→is-equivalence (H !)
-    (Functor-is-category c-cat)
-    (Functor-is-category c-cat)
+  weak-equiv→pre-equiv = ff+split-eso→is-equivalence {F = H !}
     (eso-full→pre-ff H H-eso λ g → inc (H.from g , H.ε g))
-    λ F → inc (G F , path→iso (correct F))
+    λ F → G F , path→iso (correct F)
 ```
+
+And since a functor is an equivalence of categories iff. it is an
+isomorphism of categories, we also have that the rule sending $F$ to its
+$G$ is an equivalence of types.
+
+```agda
+  weak-equiv→pre-iso : is-precat-iso {C = Cat[ B , C ]} (H !)
+  weak-equiv→pre-iso = is-equivalence→is-precat-iso (H !) weak-equiv→pre-equiv
+    (Functor-is-category c-cat)
+    (Functor-is-category c-cat)
+```
+
+Restating the result that $H_!$ acts on objects as an equivalence of
+types, we have the following result: If $R : \ca{C} \to \ca{C}^+$ is a
+weak equivalence (a fully faithful and essentially surjective functor),
+then for any category $\ca{D}$ and functor $G : \ca{C} \to \ca{D}$,
+there is a contractible space(!) of extensions $H : \ca{C}^+ \to \ca{D}$
+which factor $G$ through $F$.
+
+```agda
+weak-equiv→reflection
+  : (F : Functor C C⁺) → is-eso F → is-fully-faithful F
+  → {D : Precategory o ℓ} → is-category D
+  → (G : Functor C D)
+  → is-contr (Σ (Functor C⁺ D) λ H → H F∘ F ≡ G)
+weak-equiv→reflection F F-eso F-ff D-cat G =
+  weak-equiv→pre-iso F F-eso F-ff D-cat
+    .is-precat-iso.has-is-iso .is-eqv G
+```
+
+Note that this is only _half_ of the point of the Rezk completion: we
+would also like for $\ca{C}^+$ to be univalent, but that is not
+necessary for $D$ to think that precomposition with $F$ is an
+isomorphism.

--- a/src/Cat/Univalent/Rezk/Universal.lagda.md
+++ b/src/Cat/Univalent/Rezk/Universal.lagda.md
@@ -1,0 +1,602 @@
+```agda
+{-# OPTIONS --lossy-unification #-}
+open import Cat.Instances.Functor.Compose
+open import Cat.Functor.FullSubcategory
+open import Cat.Functor.Equivalence
+open import Cat.Instances.Functor
+open import Cat.Univalent.Rezk
+open import Cat.Functor.Base
+open import Cat.Functor.Hom
+open import Cat.Univalent
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning.FullyFaithful as FfR
+import Cat.Functor.Bifunctor as Bifunctor
+import Cat.Functor.Reasoning as FR
+import Cat.Reasoning
+
+open Functor
+open _=>_
+
+module Cat.Univalent.Rezk.Universal where
+```
+
+<!--
+```agda
+private variable
+  o ℓ : Level
+  A B C : Precategory o ℓ
+
+private module _ {o ℓ} {C : Precategory o ℓ} where
+  open Cat.Reasoning C using (_≅_)
+  open _≅_ public
+
+-- Using ∙/·· over equational reasoning saves ~5k conversion checks
+```
+-->
+
+# Universal property of the Rezk completion
+
+With the [Rezk completion], we defined, for any precategory $\ca{C}$, a
+univalent category $\ca{C}^+$, together with a _weak equivalence_
+functor $R : \ca{C} \to \ca{C}^+$. We also stated, but did not in that
+module _prove_, the universal property of the Rezk completion: The
+functor $R$ is the universal map from $\ca{C}$ to categories. This
+module actually proves it, but be warned: the proof is _very_ technical,
+and is mostly a calculation.
+
+[Rezk completion]: Cat.Univalent.Rezk.html
+
+In generic terms, universality of the Rezk completion follows from
+univalent categories being the class of _local objects_ for the weak
+equivalences: A category $\ca{C}$ is univalent when if any weak
+equivalence $H : \ca{A} \to \ca{B}$ induces an equivalence
+$H_! : [\ca{B},\ca{C}] \to [\ca{A},\ca{C}]$; If there is any weak
+equivalence $R : \ca{C} \to \ca{C}^+$, precomposition with $R$ is an
+equivalence between $\ca{C}$-functors into categories and
+$\ca{C}^+$-functors. Moreover, this equivalence sends the identity to
+$R$.
+
+The high-level overview of the proof is as follows:
+
+- For any eso $H : \ca{A} \to \ca{B}$, and for any $\ca{C}$, all
+precategories, the functor $H_! : [\ca{A},\ca{B}] \to [\ca{B},\ca{C}]$
+is faithful. This is the least technical part of the proof, so we do it
+first.
+
+- If $H$ is additionally full, then $H_!$ is fully faithful.
+
+- If $H$ is a weak equivalence, and $\ca{C}$ is univalent, then $H_!$ is
+essentially surjective. By the principle of unique choice, it is an
+equivalence, and moreover (since both its domain and codomain are
+univalent), an isomorphism.
+
+## Faithfulness
+
+The argument here is almost elementary: We're given a witness that
+$\gamma H = \delta H$, so all we have to do is manipulate the expression
+$\gamma_b$ to something which has a $\gamma H$ subexpression. Since $H$
+is eso, given $b : B$, we can find $a : A$ and an iso $m : Ha \cong b$,
+from which we can calculate:
+
+```agda
+eso→pre-faithful
+  : (H : Functor A B) {F G : Functor B C}
+  → is-eso H → (γ δ : F => G)
+  → (∀ b → γ .η (H .F₀ b) ≡ δ .η (H .F₀ b)) → γ ≡ δ
+eso→pre-faithful {A = A} {B = B} {C = C} H {F} {G} h-eso γ δ p =
+  Nat-path λ b → ∥-∥-proj {ap = C.Hom-set _ _ _ _} do
+  (b′ , m) ← h-eso b
+  ∥_∥.inc $
+    γ .η b                                      ≡⟨ C.intror (F-map-iso F m .invl) ⟩
+    γ .η b C.∘ F.₁ (m .to) C.∘ F.₁ (m .from)    ≡⟨ C.extendl (γ .is-natural _ _ _) ⟩
+    G.₁ (m .to) C.∘ γ .η _ C.∘ F.₁ (m .from)    ≡⟨ ap₂ C._∘_ refl (ap₂ C._∘_ (p b′) refl) ⟩
+    G.₁ (m .to) C.∘ δ .η _ C.∘ F.₁ (m .from)    ≡⟨ C.extendl (sym (δ .is-natural _ _ _)) ⟩
+    δ .η b C.∘ F.₁ (m .to) C.∘ F.₁ (m .from)    ≡⟨ C.elimr (F-map-iso F m .invl) ⟩
+    δ .η b                                      ∎
+  where module C = Cat.Reasoning C
+        module F = Functor F
+        module G = Functor G
+```
+
+The above is, unfortunately, the simplest result in this module. The
+next two proofs are both _quite_ technical: that's because we're given
+some _mere_ (truncated) data, from the assumption that $H$ is a weak
+equivalence, so to use it as proper data, we need to characterise the
+use up to a contractible space of choices (after which we are free to
+project what we are interested in).
+
+## Full-faithfulness
+
+Let $A$, $B$, $C$ and $H$ be as before, except now assume that $H$ is
+full (in addition to eso).
+
+```agda
+eso-full→pre-ff
+  : (H : Functor A B)
+  → is-eso H → is-full H
+  → is-fully-faithful {C = Cat[ B , C ]} (H !)
+eso-full→pre-ff {A = A} {B = B} {C = C} H H-eso H-full = res where
+```
+
+We will show that, for every natural transformation $\gamma : FH \to
+GH$, and each $b : B$, there is a contractible type of "component data"
+over $b$.  This data consists of a morphism $g : Fb \to Gb$, together
+with a witness that $g$ is compatible with any way to exhibit $b$ as
+being in the image of $H$.
+
+<!--
+```agda
+  module A = Cat.Reasoning A
+  module B = Cat.Reasoning B
+  module C = Cat.Reasoning C
+  module H = FR H
+
+  module _ (F G : Functor B C) (γ : F F∘ H => G F∘ H) where
+    module F = FR F
+    module FH = FR (F F∘ H)
+    module G = FR G
+    module GH = FR (G F∘ H)
+    module γ = _=>_ γ
+```
+-->
+
+The compatibility condition is: if we're given an essential fibre
+$(a,f)$ of $H$ over $b$, then it must have been the case that our
+_component_ $g$ came from $\gamma$ through an adjustment using $f$.
+
+```agda
+    T : B.Ob → Type _
+    T b = Σ (C.Hom (F.₀ b) (G.₀ b)) λ g →
+      (a : A.Ob) (f : H.₀ a B.≅ b) →
+      γ.η a ≡ G.₁ (f .from) C.∘ g C.∘ F.₁ (f .to)
+```
+
+For starters, assume that we have some $b : B$ and an essential fibre
+$(a_0, h_0)$ over it. Don't concern yourself with actually producing an
+$(a_0, h_0)$ just yet. Given that data, we can directly define $g$ to
+come from $\gamma$ through the inverse of the adjustment described in
+the compatibility condition, and a short calculation establishes that
+defining
+
+<!--
+```agda
+    module Mk (b : B.Ob) (a₀ : A.Ob) (h : H.₀ a₀ B.≅ b) where
+      private module h = B._≅_ h
+```
+-->
+
+```agda
+      g = G.₁ h.to C.∘ γ.η a₀ C.∘ F.₁ h.from
+```
+
+is indeed a correct option. We present the formalisation below, but do
+not comment on the calculation, leaving it to the curious reader to load
+this file in Agda and poke around the proof.
+
+```agda
+      lemma : (a : A.Ob) (f : H.₀ a B.≅ b)
+            → γ.η a ≡ G.₁ (f .from) C.∘ g C.∘ F.₁ (f .to)
+      lemma a f = ∥-∥-proj {ap = C.Hom-set _ _ _ _} do
+        (k , p)   ← H-full (h.from B.∘ B.to f)
+        (k⁻¹ , q) ← H-full (B.from f B.∘ h.to)
+        ∥_∥.inc $
+             C.intror (F.annihilate
+               (ap₂ B._∘_ q p ·· B.cancel-inner h.invl ·· f .invr))
+          ·· C.extendl (γ.is-natural _ _ _)
+          ·· ap₂ (λ e e′ → G.₁ e C.∘ γ.η a₀ C.∘ F.₁ e′) q p
+          ·· ap₂ (λ e e′ → e C.∘ γ.η a₀ C.∘ e′) (G.F-∘ _ _) (F.F-∘ _ _)
+          ·· C.pullr (ap (G.₁ h.to C.∘_) (C.pulll refl) ∙ C.pulll refl)
+```
+
+The result of having $g$ satisfy this coherence condition is that if we
+have any $g$, $g'$ both satisfying it, then we have $\gamma$ equal to
+both $G(h)gF(h^{-1})$ and $G(h)g'F(h^{-1})$. Since isomorphisms are both
+monic and epic, we can cancel $G(h)$ and $F(h^{-1})$ from these
+equations to conclude $g = g'$. Since the coherence condition is a
+proposition, the type of component data over $b$ is a proposition.
+
+```agda
+    T-prop : ∀ b → is-prop (T b)
+    T-prop b (g , coh) (g′ , coh′) =
+      Σ-prop-path (λ x → Π-is-hlevel² 1 λ _ _ → C.Hom-set _ _ _ _) $
+        ∥-∥-proj {ap = C.Hom-set _ _ _ _} do
+        (a₀ , h) ← H-eso b
+        pure $ C.iso→epic (F-map-iso F h) _ _
+          (C.iso→monic (F-map-iso G (h B.Iso⁻¹)) _ _
+            (sym (coh a₀ h) ∙ coh′ a₀ h))
+```
+
+Given any $b$, $H$ being eso means that we _merely_ have an essential
+fibre $(a,h)$ of $H$ over $b$. But since the type of components over $b$
+is a proposition, we can use unique choice to get our hands on an
+$(a,h)$, and thus on a concrete component $g : Fb \to Gb$.
+
+```agda
+    mkT′ : ∀ b → ∥ Essential-fibre H b ∥ → ∥ T b ∥
+    mkT′ b he = do
+      (a₀ , h) ← he
+      ∥_∥.inc (Mk.g b a₀ h , Mk.lemma b a₀ h)
+
+    mkT : ∀ b → T b
+    mkT b = ∥-∥-proj {ap = T-prop b} (mkT′ b (H-eso b))
+```
+
+Another calculation shows that, since $H$ is full, given any pair of
+essential fibres $(a, h)$ over $b$ and $(a', h')$ over $b'$, with a
+mediating map $f : b \to b'$, we can choose a map $k : Ha \to Ha'$
+satisfying $Hk = h'fh$, and since both the components at $b$ and $b$
+"come from $\gamma$" (which is natural), we get a naturality result for
+the transformation we're defining, too.
+
+<details>
+<summary>That computation is a bit weirder, so it's hidden in this
+`<details>`{.html} tag.</summary>
+
+```agda
+    module
+      _ {b b′} (f : B.Hom b b′) (a a′ : A.Ob)
+        (h : H.₀ a B.≅ b) (h′ : H.₀ a′ B.≅ b′)
+      where
+      private
+        module h′ = B._≅_ h′
+        module h = B._≅_ h
+
+      naturality : _
+      naturality = ∥-∥-proj {ap = C.Hom-set _ _ _ _} do
+        (k , p) ← H-full (h′.from B.∘ f B.∘ h.to)
+        pure $ C.pullr (C.pullr (F.weave (sym
+                  (B.pushl p ∙ ap₂ B._∘_ refl (B.cancelr h.invl)))))
+            ·· ap₂ C._∘_ refl (C.extendl (γ.is-natural _ _ _))
+            ·· C.extendl (G.weave (B.lswizzle p h′.invl))
+```
+
+</details>
+
+Because of this naturality result, all the components we've chosen piece
+together into a natural transformation. And since we defined $\delta$
+parametrically over the choice of essential fibre, if we're looking at
+some $Hb$, then we can choose the _identity_ isomorphism, from which it
+falls out that $\deltaH = \gamma$. Since we had already established that
+$H_!$ is faithful, and now we've shown it is full, it is fully faithful.
+
+```agda
+    δ : F => G
+    δ .η b = mkT b .fst
+    δ .is-natural b b′ f = ∥-∥-elim₂
+      {P = λ α β → ∥-∥-proj {ap = T-prop b′} (mkT′ b′ α) .fst C.∘ F.₁ f
+                 ≡ G.₁ f C.∘ ∥-∥-proj {ap = T-prop b} (mkT′ b β) .fst}
+      (λ _ _ → C.Hom-set _ _ _ _)
+      (λ (a′ , h′) (a , h) → naturality f a a′ h h′) (H-eso b′) (H-eso b)
+
+  full : is-full (H !)
+  full {x = x} {y = y} γ = pure (δ _ _ γ , Nat-path p) where
+    p : ∀ b → δ _ _ γ .η (H.₀ b) ≡ γ .η b
+    p b = subst
+      (λ e → ∥-∥-proj {ap = T-prop _ _ γ (H.₀ b)} (mkT′ _ _ γ (H.₀ b) e) .fst
+           ≡ γ .η b)
+      (squash (inc (b , B.id-iso)) (H-eso (H.₀ b)))
+      (C.eliml (y .F-id) ∙ C.elimr (x .F-id))
+
+  res : is-fully-faithful (H !)
+  res = full+faithful→ff (H !) full λ {F} {G} {γ} {δ} p →
+    eso→pre-faithful H H-eso γ δ λ b → p ηₚ b
+```
+
+## Essential surjectivity
+
+The rest of the proof proceeds in this same way: Define a type which
+characterises, up to a compatible space of choices, first the action on
+morphisms of a functor which inverts $H_!$, and in terms of this type,
+the action on morphisms. It's mostly the same trick as above, but a
+_lot_ wilder. We do not comment on it too extensively: the curious
+reader, again, can load this file in Agda and play around.
+
+<!--
+```agda
+module
+  _ {ao aℓ bo bℓ co cℓ}
+    {A : Precategory ao aℓ} {B : Precategory bo bℓ} {C : Precategory co cℓ}
+    (H : Functor A B) (H-eso : is-eso H) (H-ff : is-fully-faithful H)
+    (c-cat : is-category C)
+  where
+
+  private
+    module A = Cat.Reasoning A
+    module B = Cat.Reasoning B
+    module C = Cat.Reasoning C
+    module H = FfR H H-ff
+```
+-->
+
+The type of object-candidates `Obs`{.Agda} is indexed by a $b : \ca{B}$,
+and any object candidate $c$ must come with a family of isomorphisms
+$k_h$ giving, for every way of expressing $b$ as coming from $Ha$, a way
+of $c$ coming from $Fa$. To show this type is a proposition, we
+additionally require a naturality condition for these isomorphisms.
+
+```agda
+  private module _ (F : Functor A C) where
+    private module F = FR F
+
+    Obs : B.Ob → Type _
+    Obs b =
+      Σ C.Ob λ c →
+      Σ ((a : A.Ob) (h : H.₀ a B.≅ b) → F.₀ a C.≅ c) λ k →
+      ((a , h) (a′ , h′) : Essential-fibre H b) (f : A.Hom a a′) →
+      h′ .to B.∘ H.₁ f ≡ h .to →
+      k a′ h′ .to C.∘ F.₁ f ≡ k a h .to
+```
+
+Note that we can _derive_ an object candidate over $b$ from a fibre
+$(a,h)$ of $H$ over $b$. Moreover, this choice is a center of
+contraction, so we can once more apply unique choice and the assumption
+that $H$ is eso to conclude that every $b : \ca{B}$ has an object
+candidate over it.
+
+```agda
+    obj′ : ∀ {b} → Essential-fibre H b → Obs b
+    obj′ (a₀ , h₀) .fst = F.₀ a₀
+    obj′ (a₀ , h₀) .snd .fst a h = F-map-iso F (H.iso.from (h B.∘Iso (h₀ B.Iso⁻¹)))
+    obj′ (a₀ , h₀) .snd .snd (a , h) (a′ , h′) f p = F.collapse (H.ipushr p)
+
+    Obs-is-prop : ∀ {b} (f : Essential-fibre H b) (c : Obs b) → obj′ f ≡ c
+    Obs-is-prop (a₀ , h₀) (c′ , k′ , β) =
+      Σ-pathp (Univalent.iso→path c-cat c≅c′) $
+      Σ-prop-pathp
+        (λ i x → Π-is-hlevel³ 1 λ _ _ _ → Π-is-hlevel 1 λ _ → C.Hom-set _ _ _ _) $
+        funextP λ a → funextP λ h → C.≅-pathp _ _ $
+          Univalent.Hom-pathp-reflr-iso c-cat {q = c≅c′}
+            ( C.pullr (F.eliml (H.from-id (transport-refl _ ∙ h₀ .invr)))
+            ∙ β _ _ _ (H.ε-lswizzle (h₀ .invl)))
+      where
+        ckα = obj′ (a₀ , h₀)
+        c = ckα .fst
+        k = ckα .snd .fst
+        α = ckα .snd .snd
+        c≅c′ = (k a₀ h₀ C.Iso⁻¹) C.∘Iso k′ a₀ h₀
+```
+
+<!--
+```agda
+    summon : ∀ {b} → ∥ Essential-fibre H b ∥ → is-contr (Obs b)
+    summon f = ∥-∥-proj {ap = is-contr-is-prop} do
+      f ← f
+      pure $ contr (obj′ f) (Obs-is-prop f)
+
+    G₀ : B.Ob → C.Ob
+    G₀ b = summon {b = b} (H-eso b) .centre .fst
+
+    k : ∀ {b} a (h : H.₀ a B.≅ b) → F.₀ a C.≅ G₀ b
+    k {b = b} a h = summon {b = b} (H-eso b) .centre .snd .fst a h
+
+    kcomm
+      : ∀ {b} ((a , h) (a′ , h′) : Essential-fibre H b) (f : A.Hom a a′)
+      → h′ .to B.∘ H.₁ f ≡ h .to → k a′ h′ .to C.∘ F.₁ f ≡ k a h .to
+    kcomm {b} f1 f2 f w = summon {b = b} (H-eso b) .centre .snd .snd f1 f2 f w
+```
+-->
+
+We will write `G₀`{.Agda} for the canonical choice of object candidate,
+and `k`{.Agda} for the associated family of isomorphisms. The type of
+morphism candidates over $f : b \to b'$ consists of maps $G_0(b) \to
+G_0(b')$ which are compatible with the reindexing isomorphisms $k$ for
+any essential fibre $(a,h)$ over $b$, $(a',h')$ over $b'$, and map $l : a
+\to a'$ satisfying $h'H(l) = fh$.
+
+```agda
+    compat : ∀ {b b′} (f : B.Hom b b′) → C.Hom (G₀ b) (G₀ b′) → Type _
+    compat {b} {b′} f g =
+      ∀ a (h : H.₀ a B.≅ b) a′ (h′ : H.₀ a′ B.≅ b′) (l : A.Hom a a′)
+      → h′ .to B.∘ H.₁ l ≡ f B.∘ h .to
+      → k a′ h′ .to C.∘ F.₁ l ≡ g C.∘ k a h .to
+
+    Homs : ∀ {b b′} (f : B.Hom b b′) → Type _
+    Homs {b = b} {b′} f = Σ (C.Hom (G₀ b) (G₀ b′)) (compat f)
+```
+
+<!--
+```agda
+    compat-prop : ∀ {b b′} (f : B.Hom b b′) {g : C.Hom (G₀ b) (G₀ b′)}
+                → is-prop (compat f g)
+    compat-prop f = Π-is-hlevel³ 1 λ _ _ _ →
+                    Π-is-hlevel³ 1 λ _ _ _ → C.Hom-set _ _ _ _
+```
+-->
+
+<details>
+<summary>It will again turn out that any initial choice of fibre over
+$b$ and $b'$ gives a morphism candidate over $f : b \to b'$, and the
+compatibility data is exactly what we need to show the type of morphism
+candidates is a proposition.</summary>
+
+This proof _really_ isn't commented. I'm sorry.
+
+```agda
+    module _ {b b′} (f : B.Hom b b′)
+             a₀ (h₀ : H.₀ a₀ B.≅ b)
+             a₀′ (h₀′ : H.₀ a₀′ B.≅ b′) where
+      l₀ : A.Hom a₀ a₀′
+      l₀ = H.from (h₀′ .from B.∘ f B.∘ h₀ .to)
+
+      p : h₀′ .to B.∘ H.₁ l₀ ≡ (f B.∘ h₀ .to)
+      p = H.ε-lswizzle (h₀′ .invl)
+
+      g₀ : C.Hom (G₀ b) (G₀ b′)
+      g₀ = k a₀′ h₀′ .to C.∘ F.₁ l₀ C.∘ k a₀ h₀ .from
+
+      module _ a (h : H.₀ a B.≅ b) a′ (h′ : H.₀ a′ B.≅ b′)
+                (l : A.Hom a a′) (w : h′ .to B.∘ H.₁ l ≡ f B.∘ h .to) where
+        m : a₀ A.≅ a
+        m = H.iso.from (h₀ B.∘Iso (h B.Iso⁻¹))
+
+        m′ : a₀′ A.≅ a′
+        m′ = H.iso.from (h₀′ B.∘Iso (h′ B.Iso⁻¹))
+
+        α : k a₀ h₀ .from ≡ F.₁ (m .from) C.∘ k a h .from
+        α = C.inverse-unique _ _ {f = k a₀ h₀} {g = F-map-iso F m C.∘Iso k a h} $
+          sym (kcomm _ _ _ (H.ε-lswizzle (h .invl)))
+
+        γ : H.₁ (m′ .to) B.∘ H.₁ l₀ ≡ H.₁ l B.∘ H.₁ (m .to)
+        γ =  B.pushl (H.ε _)
+          ·· ap₂ B._∘_ refl (p ∙
+              B.pushl (B.insertr (h .invl) ∙ ap₂ B._∘_ (sym w) refl))
+          ·· B.deletel (h′ .invr)
+          ∙ ap₂ B._∘_ refl (sym (H.ε _))
+
+        γ′ : l₀ A.∘ m .from ≡ m′ .from A.∘ l
+        γ′ = A.iso→monic m′ _ _ $ A.extendl (H.injective (H.swap γ))
+                               ·· A.elimr (m .invl)
+                               ·· A.insertl (m′ .invl)
+
+        δ : g₀ C.∘ k a h .to ≡ k a′ h′ .to C.∘ F.₁ l
+        δ = C.pullr ( C.pullr refl ·· ap₂ C._∘_ refl (C.pushl α)
+                   ·· C.pulll refl ∙ C.elimr (k a h .invr))
+          ·· ap₂ C._∘_ refl (F.weave γ′)
+          ·· C.pulll (C.pushl (sym (kcomm _ _ _ (H.ε-lswizzle (h′ .invl))))
+              ∙ C.elimr (F.annihilate (m′ .invl)))
+
+      Homs-pt : Homs f
+      Homs-pt = g₀ , λ a h a′ h′ l w → sym (δ a h a′ h′ l w)
+
+      Homs-prop′ : (h′ : Homs f) → h′ .fst ≡ g₀
+      Homs-prop′ (g₁ , w) = C.iso→epic (k a₀ h₀) _ _
+        (sym (δ a₀ h₀ a₀′ h₀′ l₀ p ∙ w a₀ h₀ a₀′ h₀′ l₀ p))
+
+    Homs-contr′ : ∀ {b b′} (f : B.Hom b b′) → ∥ is-contr (Homs f) ∥
+    Homs-contr′ {b = b} {b′} f = do
+      (a₀ , h)   ← H-eso b
+      (a₀′ , h′) ← H-eso b′
+      inc (contr (Homs-pt f a₀ h a₀′ h′) λ h′ → Σ-prop-path
+        (λ _ → compat-prop f) (sym (Homs-prop′ f _ _ _ _ h′)))
+
+    Homs-contr : ∀ {b b′} (f : B.Hom b b′) → is-contr (Homs f)
+    Homs-contr f = ∥-∥-proj (Homs-contr′ f)
+
+    G₁ : ∀ {b b′} → B.Hom b b′ → C.Hom (G₀ b) (G₀ b′)
+    G₁ f = Homs-contr f .centre .fst
+```
+
+</details>
+
+
+<details>
+<summary>Using the compatibility condition, and choices of $(a, h)$, we can show
+that the assignment of morphism candidates _does_ assemble into a
+functor.</summary>
+
+```agda
+    module G∘ {x y z} (f : B.Hom y z) (g : B.Hom x y)
+              {ax ay az} (hx : H.₀ ax B.≅ x) (hy : H.₀ ay B.≅ y)
+              (hz : H.₀ az B.≅ z) where
+
+      af : A.Hom ay az
+      af = H.from (hz .from B.∘ f B.∘ hy .to)
+
+      ag : A.Hom ax ay
+      ag = H.from (hy .from B.∘ g B.∘ hx .to)
+
+      h′ : H.₁ (af A.∘ ag) ≡ hz .from B.∘ f B.∘ g B.∘ hx .to
+      h′ = H.ε-expand refl ∙ B.pullr (B.cancel-inner (hy .invl))
+
+      commutes : G₁ (f B.∘ g) ≡ G₁ f C.∘ G₁ g
+      commutes = C.iso→epic (k ax hx) _ _ $
+          sym (Homs-contr (f B.∘ g) .centre .snd ax hx az hz (af A.∘ ag)
+                (ap₂ B._∘_ refl h′ ·· B.cancell (hz .invl) ·· B.pulll refl))
+        ∙ sym ( C.pullr (sym (Homs-contr g .centre .snd ax hx ay hy ag
+                  (H.ε-lswizzle (hy .invl))))
+              ∙ C.pulll (sym (Homs-contr f .centre .snd ay hy az hz af
+                  (H.ε-lswizzle (hz .invl))))
+              ∙ F.pullr refl)
+```
+
+</details>
+
+In this manner, the assignment of object candidates and morphism
+candidates fits together into a functor $G : \ca{B} \to \ca{C}$. After
+finishing this, we have to show that $GH = F$. But the compatibility
+data which we have used to uniquely characterise $G$... uniquely
+characterises $G$, after all, and it does so as _composing with $H$ to
+give $F$_.
+
+```agda
+    G : Functor B C
+    G .F₀ b = G₀ b
+    G .F₁ f = G₁ f
+
+    G .F-id = ap fst $ Homs-contr B.id .paths $ C.id , λ a h a′ h′ l w →
+      sym (C.idl _ ∙ sym (kcomm (a , h) (a′ , h′) l (w ∙ B.idl _)))
+
+    G .F-∘ {x} {y} {z} f g = ∥-∥-proj do
+      (ax , hx) ← H-eso x
+      (ay , hy) ← H-eso y
+      (az , hz) ← H-eso z
+      inc (G∘.commutes f g hx hy hz)
+```
+
+That is: For any $x : \ca{A}$, the object $F(x)$ can be made into an
+object candidate over $H(x)$, which, since the type of object candidates
+is a proposition, is equal to the centre of contraction --- the value
+$GH(x)$. So that's half done.
+
+```agda
+    module _ (x : A.Ob) where
+      hf-obs : Obs (H.₀ x)
+      hf-obs .fst = F.F₀ x
+      hf-obs .snd .fst a h = F-map-iso F (H.iso.from h)
+      hf-obs .snd .snd (a , h) (a′ , h′) f α = F.collapse (H.inv∘l α)
+
+      abstract
+        objp : G₀ (H.₀ x) ≡ F.₀ x
+        objp = ap fst $ summon {H.₀ x} (H-eso _) .paths hf-obs
+```
+
+<!--
+```agda
+        kp : (a : A.Ob) (h : H.₀ a B.≅ H.₀ x)
+           → PathP (λ i → F.₀ a C.≅ objp i) (k a h) (hf-obs .snd .fst a h)
+        kp a h = ap (λ e → e .snd .fst a h)
+          (summon {H.₀ x} (H-eso (H.₀ x)) .paths hf-obs)
+```
+-->
+
+_Over that identification_, we can, by the characterisation of paths in
+(pre)categories, show that any map $f : x \to y$ in $\ca{A}$ can be
+extended to a morphism candidate for $H(f)$, which is thus equal ---
+over the identification $GH(x) = F(x)$ we just constructed --- to the
+value of $GF(x)$. So we're done!
+
+```agda
+    module _ {x y} (f : A.Hom x y) where
+      hom′ : Homs (H.₁ f)
+      hom′ .fst = transport (λ i → C.Hom (objp x (~ i)) (objp y (~ i))) (F.₁ f)
+      hom′ .snd a h a′ h′ l w = sym $
+        C.pushl (Hom-transport C (sym (objp x)) (sym (objp y)) (F.₁ f))
+        ·· ap₂ C._∘_ refl
+          ( C.pullr (from-pathp-from C (objp x) (λ i → kp x a h i .to))
+          ∙ F.weave (H.ε-twist (sym w)))
+        ·· C.pulll (from-pathp-to C (sym (objp y)) λ i → kp y a′ h′ (~ i) .to)
+
+      homp : transport (λ i → C.Hom (objp x (~ i)) (objp y (~ i))) (F.₁ f)
+           ≡ Homs-contr (H.₁ f) .centre .fst
+      homp = ap fst $ sym $ Homs-contr (H.₁ f) .paths hom′
+
+    correct : G F∘ H ≡ F
+    correct = Functor-path objp λ {x} {y} f → symP
+      {A = λ i → C.Hom (objp x (~ i)) (objp y (~ i))} $
+      to-pathp (homp f)
+```
+
+All that remains after showing that $GH(x) = F(x)$ for every $x$, and
+similarly for morphisms, is appealing to our pre-existing proof that
+$H_!$ is fully faithful, and the proof that fully faithful essentially
+surjective functors between categories are equivalences.
+
+```agda
+  weak-equiv→pre-equiv : is-equivalence {C = Cat[ B , C ]} (H !)
+  weak-equiv→pre-equiv = ff+eso→is-equivalence (H !)
+    (Functor-is-category c-cat)
+    (Functor-is-category c-cat)
+    (eso-full→pre-ff H H-eso λ g → inc (H.from g , H.ε g))
+    λ F → inc (G F , path→iso (correct F))
+```

--- a/src/Data/Maybe/Base.lagda.md
+++ b/src/Data/Maybe/Base.lagda.md
@@ -1,0 +1,62 @@
+```agda
+open import 1Lab.Type
+
+open import Meta.Idiom
+open import Meta.Bind
+open import Meta.Alt
+
+module Data.Maybe.Base where
+
+open import Prim.Data.Maybe public
+```
+
+# The Maybe type
+
+<!--
+```agda
+private variable
+  ℓ ℓ′ : Level
+  A B C : Type ℓ
+```
+-->
+
+<!-- TODO [Amy 2022-12-14]
+Write something informative here
+-->
+
+
+```agda
+map : (A → B) → Maybe A → Maybe B
+map f (just x) = just (f x)
+map f nothing  = nothing
+
+extend : Maybe A → (A → Maybe B) → Maybe B
+extend (just x) k = k x
+extend nothing k  = nothing
+```
+
+<!--
+```agda
+instance
+  Map-Maybe : Map (eff Maybe)
+  Map-Maybe .Map._<$>_ = map
+
+  Idiom-Maybe : Idiom (eff Maybe)
+  Idiom-Maybe .Idiom.pure = just
+  Idiom-Maybe .Idiom._<*>_ = λ where
+    (just f) (just x) → just (f x)
+    _ _ → nothing
+
+  Bind-Maybe : Bind (eff Maybe)
+  Bind-Maybe .Bind._>>=_ = extend
+```
+-->
+
+## Pointed types as Maybe-algebras
+
+```agda
+maybe→alt : ∀ {M : Effect} {ℓ} {A : Type ℓ}
+          → ⦃ _ : Alt M ⦄ ⦃ _ : Idiom M ⦄ → Maybe A → M .Effect.₀ A
+maybe→alt (just x) = pure x
+maybe→alt nothing  = fail
+```

--- a/src/Data/Set/Surjection.lagda.md
+++ b/src/Data/Set/Surjection.lagda.md
@@ -54,7 +54,7 @@ surjective→regular-epi c d f surj .has-is-coeq = coeqs where
   go : ∀ {F} (e′ : ∣ c ∣ → ∣ F ∣) p (x : ∣ d ∣) → ∥ fibre f x ∥ → ∣ F ∣
   go e′ p x =
     ∥-∥-rec-set (λ x → e′ (x .fst))
-      (λ x y → p $ₚ x .fst , y .fst , x .snd ∙ sym (y .snd))
+      (λ x y → p $ₚ (x .fst , y .fst , x .snd ∙ sym (y .snd)))
       hlevel!
 ```
 
@@ -67,10 +67,10 @@ surjectivity out of the way, we get what we wanted.
   coeqs .coequalise {F} {e′} p x = go {F = F} e′ p x (surj x)
   coeqs .universal {F} {e′} {p = p} = funext λ x →
     ∥-∥-elim {P = λ e → go {F} e′ p (f x) e ≡ e′ x}
-      (λ x → hlevel!) (λ e → p $ₚ e .fst , x , e .snd) (surj (f x))
+      (λ x → hlevel!) (λ e → p $ₚ (e .fst , x , e .snd)) (surj (f x))
   coeqs .unique {F} {e′} {p} {colim} comm = funext λ a →
     ∥-∥-elim {P = λ e → colim a ≡ go {F} e′ p a e} (λ x → hlevel!)
-      (λ x → sym ((comm $ₚ x .fst) ∙ ap colim (x .snd)))
+      (λ x → sym (comm $ₚ x .fst ∙ ap colim (x .snd)))
       (surj a)
 ```
 

--- a/src/Meta/Alt.lagda.md
+++ b/src/Meta/Alt.lagda.md
@@ -11,9 +11,15 @@ module Meta.Alt where
 record Alt (M : Effect) : Typeω where
   private module M = Effect M
   field
-    fail : ∀ {ℓ} {A : Type ℓ} → M.₀ A
+    fail′ : ∀ {ℓ} {A : Type ℓ} → String → M.₀ A
     _<|>_ : ∀ {ℓ} {A : Type ℓ} → M.₀ A → M.₀ A → M.₀ A
   infixl 3 _<|>_
+
+  fail : ∀ {ℓ} {A : Type ℓ} → M.₀ A
+  fail = fail′ "Alt: empty error message"
+
+  _<?>_ : ∀ {ℓ} {A : Type ℓ} → M.₀ A → String → M.₀ A
+  what <?> why = what <|> fail′ why
 
 open Alt ⦃ ... ⦄ public
 

--- a/src/Topoi/Base.lagda.md
+++ b/src/Topoi/Base.lagda.md
@@ -313,7 +313,7 @@ limits directly for efficiency concerns. </summary>
     func = incl .F₀ set
     cent = psh-terminal func .centre
     uniq : ∀ f → cent .η _ ≡ f
-    uniq f = ap (λ e → e .η _) (psh-terminal func .paths f′) where
+    uniq f = psh-terminal func .paths f′ ηₚ _ where
       f′ : _ => _
       f′ .η _ = f
       f′ .is-natural _ _ _ = funext λ x → happly (sym (F-id T)) _
@@ -321,7 +321,7 @@ limits directly for efficiency concerns. </summary>
   sets .L-lex .pres-pullback {P} {X} {Y} {Z} pb = pb′ where
     open is-pullback
     pb′ : is-pullback (Sets κ) _ _ _ _
-    pb′ .square = ap (λ e → η e _) (pb .square)
+    pb′ .square = pb .square ηₚ _
     pb′ .limiting {P'} {p₁' = p₁'} {p₂' = p₂'} p =
       η (pb .limiting {P′ = incl .F₀ P'} {p₁' = p1'} {p₂' = p2'}
           (Nat-path λ _ → p)) _
@@ -332,11 +332,10 @@ limits directly for efficiency concerns. </summary>
         p2' : _ => _
         p2' .η _ = p₂'
         p2' .is-natural x y f i o = F-id Y (~ i) (p₂' o)
-    pb′ .p₁∘limiting = ap (λ e → η e _) (pb .p₁∘limiting)
-    pb′ .p₂∘limiting = ap (λ e → η e _) (pb .p₂∘limiting)
+    pb′ .p₁∘limiting = pb .p₁∘limiting ηₚ _
+    pb′ .p₂∘limiting = pb .p₂∘limiting ηₚ _
     pb′ .unique {P′} {lim' = lim'} p1 p2 =
-      ap (λ e → η e _) (pb .unique {lim' = l′}
-        (Nat-path λ _ → p1) (Nat-path λ _ → p2))
+      pb .unique {lim' = l′} (Nat-path λ _ → p1) (Nat-path λ _ → p2) ηₚ _
       where
         l′ : incl .F₀ P′ => P
         l′ .η _ = lim'


### PR DESCRIPTION
I'm not sure if CI will pass or not, but it's late and I'm tired and I want to ~~go to sleep~~ game. I think the proof ended up being not-too-awful. This PR also introduces the `_ηₚ_` operator which inverts `Nat-path` (it could potentially be made to invert `Nat-pathp` but none of the use-sites I cleaned up needed that).