### PR TITLE
Lower minimum screen width for desktop

### DIFF
--- a/support/web/css/default.scss
+++ b/support/web/css/default.scss
@@ -258,7 +258,7 @@ table {
   }
 }
 
-@media only screen and (min-width: 1500px) {
+@media only screen and (min-width: 1280px) {
   .narrow-only {
     display: none !important;
   }


### PR DESCRIPTION
On my laptop, I learned that sidebar even exists only when I suddenly zoomed out the page. Before that, I just wondered why the website is so minimalistic.

AFAIK 1280px is quite a popular choice for determining desktop screen. 13.3-inch macbook has 1280px for instance.