### PR TITLE
Composition of Displayed Categories and Fibrations

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -1534,6 +1534,16 @@ from-pathp : ∀ {ℓ} {A : I → Type ℓ} {x : A i0} {y : A i1}
            → PathP A x y
            → coe0→1 A x ≡ y
 from-pathp {A = A} {x} {y} p = transport (PathP≡Path A x y) p
+
+to-pathp⁻ : ∀ {ℓ} {A : I → Type ℓ} {x : A i0} {y : A i1}
+         → x ≡ coe1→0 A y
+         → PathP A x y
+to-pathp⁻ {A = A} {x} {y} p = transport (sym (PathP≡Path⁻ A x y)) p
+
+from-pathp⁻ : ∀ {ℓ} {A : I → Type ℓ} {x : A i0} {y : A i1}
+           → PathP A x y
+           → x ≡ coe1→0 A y
+from-pathp⁻ {A = A} {x} {y} p = transport (PathP≡Path⁻ A x y) p
 ```
 
 These definitions illustrate how using the named squeezes and spreads

--- a/src/Cat/Displayed/Cartesian.lagda.md
+++ b/src/Cat/Displayed/Cartesian.lagda.md
@@ -83,7 +83,6 @@ through a map $u' \to a'$ (in green, marked $\exists!$).
     unique    : ∀ {u u′} {m : Hom u a} {h′ : Hom[ f ∘ m ] u′ b′}
               → (m′ : Hom[ m ] u′ a′) → f′ ∘′ m′ ≡ h′ → m′ ≡ universal m h′
 ```
-
 Given a "right corner" like that of the diagram below, and note that the
 input data consists of $a$, $b$, $f : a \to b$ and $b'$ over $a$,
 
@@ -97,7 +96,41 @@ input data consists of $a$, $b$, $f : a \to b$ and $b'$ over $a$,
 \end{tikzcd}\]
 ~~~
 
-we call an object $a'$ over $a$ together with a Cartesian arrow $f' : a'
+We also provide some helper functions for working with morphisms that
+are displayed over something that is *propositionally* equal to a
+composite, rather than displayed directly over a composite.
+
+```agda
+  universal′ : ∀ {u u′} {m : Hom u a} {k : Hom u b}
+             → (p : f ∘ m ≡ k) (h′ : Hom[ k ] u′ b′)
+             → Hom[ m ] u′ a′
+  universal′ {u′ = u′} p h′ =
+    universal _ (coe1→0 (λ i → Hom[ p i ] u′ b′) h′)
+
+  commutesp : ∀ {u u′} {m : Hom u a} {k : Hom u b}
+            → (p : f ∘ m ≡ k) (h′ : Hom[ k ] u′ b′)
+            → f′ ∘′ universal′ p h′ ≡[ p ] h′
+  commutesp {u′ = u′} p h′ =
+    to-pathp⁻ $ commutes _ (coe1→0 (λ i → Hom[ p i ] u′ b′) h′)
+
+  universalp : ∀ {u u′} {m₁ m₂ : Hom u a} {k : Hom u b}
+          → (p : f ∘ m₁ ≡ k) (q : m₁ ≡ m₂) (r : f ∘ m₂ ≡ k)
+          → (h′ : Hom[ k ] u′ b′)
+          → universal′ p h′ ≡[ q ] universal′ r h′
+  universalp {u = u} p q r h′ i =
+    universal′ (is-set→squarep (λ _ _ → Hom-set u b) (ap (f ∘_) q) p r refl i) h′
+
+  uniquep : ∀ {u u′} {m₁ m₂ : Hom u a} {k : Hom u b}
+          → (p : f ∘ m₁ ≡ k) (q : m₁ ≡ m₂) (r : f ∘ m₂ ≡ k)
+          → {h′ : Hom[ k ] u′ b′}
+          → (m′ : Hom[ m₁ ] u′ a′)
+          → f′ ∘′ m′ ≡[ p ] h′ → m′ ≡[ q ] universal′ r h′
+  uniquep p q r {h′ = h′} m′ s =
+    to-pathp⁻ (unique m′ (from-pathp⁻ s) ∙ from-pathp⁻ (universalp p q r h′))
+```
+
+
+We call an object $a'$ over $a$ together with a Cartesian arrow $f' : a'
 \to b'$ a _Cartesian lift_ of $f$. Cartesian lifts, defined by universal
 property as they are, are unique when they exist, so that "having
 Cartesian lifts" is a _property_, not a structure.

--- a/src/Cat/Displayed/Composition.lagda.md
+++ b/src/Cat/Displayed/Composition.lagda.md
@@ -1,0 +1,143 @@
+```agda
+open import Cat.Prelude
+
+open import Cat.Displayed.Base
+open import Cat.Displayed.Functor
+open import Cat.Displayed.Total
+
+open import Cat.Displayed.Cartesian
+
+import Cat.Displayed.Reasoning as DR
+
+module Cat.Displayed.Composition where
+```
+
+# Composition of Displayed Categories
+
+A displayed category $\ca{E}$ over $\ca{B}$ is equivalent to the data
+of a functor into $\ca{B}$; the forward direction of this equivalence is
+witnessed by the [total category] of $\ca{E}$, along with the canonical
+projection functor from the total category into $\ca{B}$. This suggests
+that we ought to be able to compose displayed categories. That is,
+if $\ca{E}$ is displayed over $\ca{B}$, and $\ca{F}$ is displayed over
+$\int \ca{E}$, then we can construct a new category $\ca{E} \cdot \ca{F}$
+displayed over $\ca{B}$ that contains the data of both $\ca{E}$ and
+$\ca{F}$.
+
+[total category] Cat.Displayed.Total.html
+
+To actually construct the composite, we bundle up the data of
+$\ca{E}$ and $\ca{F}$ into pairs, so an object in $\ca{E} \cdot \ca{F}$
+over $X : \ca{B}$ consists of a pair objects of $X' : \ca{E}$ over $X$,
+and $X'' : \ca{F}$ over $X$ and $X'$. Morphisms are defined similarly,
+as do equations.
+
+```agda
+_D∘_ : ∀ {o ℓ o′ ℓ′ o″ ℓ″}
+       → {ℬ : Precategory o ℓ}
+       → (ℰ : Displayed ℬ o′ ℓ′) → (ℱ : Displayed (∫ ℰ) o″ ℓ″)
+       → Displayed ℬ (o′ ⊔ o″) (ℓ′ ⊔ ℓ″)
+_D∘_ {ℬ = ℬ} ℰ ℱ = disp where
+  module ℰ = Displayed ℰ
+  module ℱ = Displayed ℱ
+
+  disp : Displayed ℬ _ _
+  Displayed.Ob[ disp ] X =
+    Σ[ X′ ∈ ℰ.Ob[ X ] ] ℱ.Ob[ X , X′ ]
+  Displayed.Hom[ disp ] f X Y =
+    Σ[ f′ ∈ ℰ.Hom[ f ] (X .fst) (Y .fst) ] ℱ.Hom[ total-hom f f′ ] (X .snd) (Y .snd)
+  Displayed.Hom[ disp ]-set f x y =
+    Σ-is-hlevel 2 (ℰ.Hom[ f ]-set (x .fst) (y .fst)) λ f′ →
+    ℱ.Hom[ total-hom f f′ ]-set (x .snd) (y .snd)
+  disp .Displayed.id′ =
+    ℰ.id′ , ℱ.id′
+  disp .Displayed._∘′_ f′ g′ =
+    (f′ .fst ℰ.∘′ g′ .fst) , (f′ .snd ℱ.∘′ g′ .snd)
+  disp .Displayed.idr′ f′ =
+    ℰ.idr′ (f′ .fst) ,ₚ ℱ.idr′ (f′ .snd)
+  disp .Displayed.idl′ f′ =
+    ℰ.idl′ (f′ .fst) ,ₚ ℱ.idl′ (f′ .snd)
+  disp .Displayed.assoc′ f′ g′ h′ =
+    (ℰ.assoc′ (f′ .fst) (g′ .fst) (h′ .fst)) ,ₚ (ℱ.assoc′ (f′ .snd) (g′ .snd) (h′ .snd))
+```
+
+We also obtain a displayed functor from $\ca{E} \cdot \ca{F}$ to $\ca{E}$
+that projects out the data of $\ca{E}$ from the composite.
+
+```agda
+πᵈ : ∀ {o ℓ o′ ℓ′ o″ ℓ″}
+    → {ℬ : Precategory o ℓ}
+    → {ℰ : Displayed ℬ o′ ℓ′} {ℱ : Displayed (∫ ℰ) o″ ℓ″}
+    → Displayed-functor (ℰ D∘ ℱ) ℰ Id
+πᵈ .Displayed-functor.F₀′ = fst
+πᵈ .Displayed-functor.F₁′ = fst
+πᵈ .Displayed-functor.F-id′ = refl
+πᵈ .Displayed-functor.F-∘′ = refl
+```
+
+## Composition of fibrations
+
+As one may expect, the composition of fibrations is itself a fibration.
+
+
+<!--
+```agda
+module _
+  {o ℓ o′ ℓ′ o″ ℓ″}
+  {ℬ : Precategory o ℓ}
+  {ℰ : Displayed ℬ o′ ℓ′} {ℱ : Displayed (∫ ℰ) o″ ℓ″}
+  where
+
+  private
+    open Precategory ℬ
+    module ℰ = Displayed ℰ
+    module ℱ = Displayed ℱ
+    module ℱR = DR ℱ
+```
+-->
+
+The idea of the proof is that we can take lifts of lifts, and in fact,
+this is exactly how we construct the liftings.
+
+```agda
+  fibration-∘ : Cartesian-fibration ℰ → Cartesian-fibration ℱ
+              → Cartesian-fibration (ℰ D∘ ℱ)
+  fibration-∘ ℰ-fib ℱ-fib = ℰ∘ℱ-fib where
+    open Cartesian-fibration
+    open Cartesian-lift
+
+    ℰ∘ℱ-fib : Cartesian-fibration (ℰ D∘ ℱ)
+    ℰ∘ℱ-fib .has-lift f (y′ , y″) = cart-lift where
+
+      ℰ-lift = ℰ-fib .has-lift f y′
+      ℱ-lift = ℱ-fib .has-lift (total-hom f (ℰ-lift .lifting)) y″
+
+      cart-lift : Cartesian-lift (ℰ D∘ ℱ) f (y′ , y″)
+      cart-lift .x′ = ℰ-lift .x′ , ℱ-lift .x′
+      cart-lift .lifting = ℰ-lift .lifting , ℱ-lift .lifting
+```
+
+However, showing that the constructed lift is cartesian is somewhat more
+subtle. The issue is that when we go to construct the universal map,
+we are handed an $h'$ displayed over $f \cdot m$, and also an $h''$
+displayed over $f \cdot m, h'$, which is not a composite definitionally.
+However, it is *propositionally* a composite, as is witnessed by
+`ℰ-lift .commutes`, so we can use the generalized propositional functions
+of `ℱ-lift` to construct the universal map, and show that it is indeed
+universal.
+
+```agda
+      cart-lift .cartesian .Cartesian.universal m (h′ , h″) =
+        ℰ-lift .universal m h′ ,
+        universal′ ℱ-lift (total-hom-path ℰ refl (ℰ-lift .commutes m h′)) h″
+      cart-lift .cartesian .Cartesian.commutes m h′ =
+        ℰ-lift .commutes m (h′ .fst) ,ₚ
+        commutesp ℱ-lift _ (h′ .snd)
+      cart-lift .cartesian .Cartesian.unique m′ p =
+        ℰ-lift .unique (m′ .fst) (ap fst p) ,ₚ
+        uniquep ℱ-lift _ _
+          (total-hom-path ℰ refl (ℰ-lift .commutes _ _))
+          (m′ .snd)
+          (ap snd p)
+```
+

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -600,6 +600,9 @@ open import Cat.Displayed.Reasoning
 open import Cat.Displayed.Instances.Elements
 -- The category of elements of a presheaf, instantiated as being
 -- displayed over the domain.
+
+open import Cat.Displayed.Composition
+  -- Composition of displayed categories
 ```
 
 We can also investigate how displayed categories relate to other


### PR DESCRIPTION
# Description

This patch defines the composition of displayed categories, and proves that the composite of fibrations is a fibration.
Doing so required some minor additions to `Path`, along with functions in `Cartesian` that allow for construction of
universal maps for morphisms that are *propositionally* displayed over a composite.