### PR TITLE
Fix typos

### DIFF
--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -139,7 +139,7 @@ equiv-path→identity-system {R = R} {r = r} eqv pres′ = ids where
     i .fst
 ```
 
-Note that for any $(R, r)$, the type of identity sytem data on $(R, r)$
+Note that for any $(R, r)$, the type of identity system data on $(R, r)$
 is a proposition. This is because it is exactly equivalent to the type
 $\sum_a (R a)$ being contractible for every $a$, which is a proposition
 by standard results.

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -218,7 +218,7 @@ essentially, a loop: If w doesn't work, then try
   is-hlevel-suc n w : is-hlevel T (suc n)
 
 until you reach a sucᵏ n = k + n. Actually, slightly more efficient, we
-keep around a counter k′ for the number of tries, and transfer sucessors
+keep around a counter k′ for the number of tries, and transfer successors
 from the wanted level (k + n) until is-hlevel-+ n (sucᵏ′ n) w works.
 -}
   lift-sol : Term → Term → Nat → Term

--- a/src/1Lab/Resizing.lagda.md
+++ b/src/1Lab/Resizing.lagda.md
@@ -25,7 +25,7 @@ type families, that just so happen to be valued in \r{propositions}. For
 most purposes we can work with this limitation: this is called
 **predicative mathematics**. But, for a few classes of theorems,
 predicativity is too restrictive: Even if we don't have a single
-universe of propositions that can accomodate all predicates, we would
+universe of propositions that can accommodate all predicates, we would
 still like for universes to be closed under power-sets.
 
 Using some of Agda's more suspicious features, we can achieve this in a

--- a/src/1Lab/Univalence.lagda.md
+++ b/src/1Lab/Univalence.lagda.md
@@ -418,7 +418,7 @@ module _ where private
 
 However, because of efficiency concerns (Agda _is_ a programming
 language, after all), instead of using `id→equiv`{.Agda} defined using
-J, we use `path→equiv`{.Agda}, which is [defined in an auxilliary
+J, we use `path→equiv`{.Agda}, which is [defined in an auxiliary
 module](1Lab.Equiv.FromPath.html).
 
 ```agda

--- a/src/1Lab/intro.lagda.md
+++ b/src/1Lab/intro.lagda.md
@@ -399,7 +399,7 @@ even is a subset?
 a membership relation $\in$, then $S$ is a subset of $T$ if every
 element of $S$ is also an element of $T$. However, this notion does not
 carry over directly to structural set theory (where sets are essentially
-opaque objects of a category satifsying some properties), or indeed to
+opaque objects of a category satisfying some properties), or indeed to
 type theory (where there is no membership relation) --- but we can
 salvage it.
 
@@ -481,7 +481,7 @@ proposition.[^hprops]
 
 [^hprops]: In some foundational systems --- including HoTT, the one we
 are discussing --- "subsingleton" is literally taken as the _definition_
-of "proposition", so this translation isn't merely ommitted, it's not
+of "proposition", so this translation isn't merely omitted, it's not
 necessary at all.
 
 Conversely, if we have such an assignment $\chi : B \to \Omega$, we
@@ -1063,7 +1063,7 @@ left- and right- hand side of the unit interval. A classic result in the
 interpretation of constructive mathematics says that any function
 defined inside type theory is automatically continuous, and so, we
 define the type $x \equiv_A y$ to be the type of functions $f :
-\bb{I} \to A$, restricted to thse where $f(\id{i0}) = x$ and
+\bb{I} \to A$, restricted to those where $f(\id{i0}) = x$ and
 $f(\id{i1}) = y$ _definitionally_.
 
 The introduction rule for paths says that if $e : \bb{I} \to A$,
@@ -1361,7 +1361,7 @@ path at the left and right endpoints of the interval.
 As a very quick aside, there is a map $r : \lambda x.\ (x, x, \id{refl}$
 making the diagram below commute. This diagram expresses that the
 diagonal $A \to A \times A$ can be factored as a weak equivalence
-follwed by a fibration through $A^\bb{I}$, which is the defining
+followed by a fibration through $A^\bb{I}$, which is the defining
 property of a _path space object_.
 $A$.
 

--- a/src/Algebra/Group/Homotopy.lagda.md
+++ b/src/Algebra/Group/Homotopy.lagda.md
@@ -37,7 +37,7 @@ which we denote $\Omega^n A$.
 
 For positive $n$, we can give $\Omega^n A$ a `Group`{.Agda} structure,
 obtained by [truncating](Data.Set.Truncation.html) the higher
-groupoid structure that $A$ is equiped with. We call the sequence
+groupoid structure that $A$ is equipped with. We call the sequence
 $\pi_n(A)$ the **homotopy groups** of $A$, but remark that the indexing
 used by `πₙ`{.Agda} is off by 1: `πₙ 0 A` is the **fundamental group**
 $\pi_1(A)$.

--- a/src/Algebra/Monoid.lagda.md
+++ b/src/Algebra/Monoid.lagda.md
@@ -140,7 +140,7 @@ direction, namely, that every unital semigroup is a monoid.
 # Inverses
 
 A useful application of the monoid laws is in showing that _having an
-**inverse**_ is a _proprety_ of a specific element, not structure on
+**inverse**_ is a _property_ of a specific element, not structure on
 that element. To make this precise: Let $e$ be an element of a monoid,
 say $(M, 1, \star)$; If there are $x$ and $y$ such that $x \star e = 1$
 and $e \star y = 1$, then $x = y$.

--- a/src/Algebra/Semigroup.lagda.md
+++ b/src/Algebra/Semigroup.lagda.md
@@ -134,7 +134,7 @@ module _
 
 ## The "min" semigroup
 
-An example of a naturally-occuring semigroup are the natural numbers
+An example of a naturally-occurring semigroup are the natural numbers
 under taking `minimums`{.Agda ident=min}.
 
 ```agda
@@ -147,7 +147,7 @@ Nat-min .has-is-magma .has-is-set = Nat-is-set
 Nat-min .associative = min-assoc _ _ _
 ```
 
-What is meant by "naturally occuring" is that this semigroup can not be
+What is meant by "naturally occurring" is that this semigroup can not be
 made into a monoid: There is no natural number `unit` such that, for all
 `y`, `min unit y ≡ y` and `min y unit ≡ y`.
 

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -37,7 +37,7 @@ relating all of those objects and morphisms.
 [coequalisers]: Cat.Diagram.Coequaliser.html
 [initial objects]: Cat.Diagram.Initial.html
 
-It would be convienent to be able to talk about _all_ of these
+It would be convenient to be able to talk about _all_ of these
 situations at once, as opposed to on a case-by-case basis. To do this,
 we need to introduce a bit of categorical machinery: the Cocone.
 
@@ -86,7 +86,7 @@ designated object the "coapex" of the cocone.
 ```
 
 If our diagram consisted of only objects, we would be done! However,
-some diagrams contan non-identity morphisms, so we need to take those
+some diagrams contain non-identity morphisms, so we need to take those
 into account as well. This bit is best understood through the lens of
 the coequaliser: in order to describe the commuting condition there,
 we want every injection map from the codomain of a morphism to

--- a/src/Cat/Diagram/Equaliser/Kernel.lagda.md
+++ b/src/Cat/Diagram/Equaliser/Kernel.lagda.md
@@ -71,7 +71,7 @@ module Canonical-kernels
 
 We now show that the maps $! : \ker\ker f \to \emptyset$ and $¡ :
 \emptyset \to \ker\ker f$ are inverses. In one direction the composite
-is in $\emptyset \to \emptyset$, so it is trivally unique. In the other
+is in $\emptyset \to \emptyset$, so it is trivially unique. In the other
 direction, we have maps $\ker\ker f \to \ker\ker f$, which, since $\ker$
 is a limit, are uniquely determined _if_ they are cone homomorphisms.
 

--- a/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
+++ b/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
@@ -130,7 +130,7 @@ $\phi \circ i_2 = \id{arr_2}$.
 
 To show that $f$ also has the universal property of the equaliser of
 $i_1, i_2$, suppose that $e\prime : E \to b$ also equalises the
-injections. Then we can calulate:
+injections. Then we can calculate:
 
 $$
 \id{arr_1}e\prime = (\phi i_1)e\prime = (\phi i_2)e\prime = \id{arr_2}e\prime

--- a/src/Cat/Diagram/Monad/Codensity.lagda.md
+++ b/src/Cat/Diagram/Monad/Codensity.lagda.md
@@ -123,7 +123,7 @@ $(\Lan_F(F))^2 \To \Lan_F(F)$.
 <summary>Proving that these two extended natural transformations really
 do comprise a monad structure is a routine application of the uniqueness
 properties of Kan extensions. The real noise comes from having to
-construct auxilliary natural transformations representing each pair of
+construct auxiliary natural transformations representing each pair of
 maps we want to compute with.</summary>
 
 ```agda

--- a/src/Cat/Diagram/Monad/Limits.lagda.md
+++ b/src/Cat/Diagram/Monad/Limits.lagda.md
@@ -139,7 +139,7 @@ then so does $F$.
 
 What we must do, essentially, is prove that $\lim (U \circ F)$ admits an
 algebra structure, much like we did for products of groups. In this,
-we'll use two auxilliary cones over $U \circ F$, one with underlying
+we'll use two auxiliary cones over $U \circ F$, one with underlying
 object given by $M(\lim (U \circ F))$ and one by $M^2(\lim (U \circ
 F))$. We construct the one with a single $M$ first, and re-use its maps
 in the construction of the one with $M^2$.

--- a/src/Cat/Diagram/Monad/Solver.agda
+++ b/src/Cat/Diagram/Monad/Solver.agda
@@ -18,7 +18,7 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
 
   --------------------------------------------------------------------------------
   -- NOTE: Object Expressions
-  -- We can′t index everyting by 'Ob', as Agda will (rightfully) assume that M₀ is not injective,
+  -- We can′t index everything by 'Ob', as Agda will (rightfully) assume that M₀ is not injective,
   -- which then inhibits on our ability to pattern match on things.
   -- Therefore, we introduce a reflected type of object expressions,
   -- which solves the injectivity issue.

--- a/src/Cat/Diagram/Product/Solver.lagda.md
+++ b/src/Cat/Diagram/Product/Solver.lagda.md
@@ -14,7 +14,7 @@ open import Data.List
 
 Much like the [category solver], this module is split into two halves.
 The first implements an algorithm for normalizing expressions in the
-langauge of a category with binary products. The latter half consists
+language of a category with binary products. The latter half consists
 of the usual reflection hacks required to transform Agda expressions
 into our internal expression type.
 
@@ -134,7 +134,7 @@ We now define our eliminators for values.
 ## Quotation
 
 As noted above, our quotation is type-directed to make applying η-laws
-easier. When we encouter a `v : Value X (Y ‶⊗‶ Z)`, we will always
+easier. When we encounter a `v : Value X (Y ‶⊗‶ Z)`, we will always
 η-expand it using the eliminators defined above. If `v` is a
 `vpair`{.Agda}, then the eliminators will compute away, and we will be
 left with the same value we started with. If `v` is a `vhom`{.Agda},
@@ -281,7 +281,7 @@ morphism as naively interpreting the expression.
 
 In order to make the reflection easier later, we bundle up the soundness
 proof. Marking this as abstract is *very important*. This prevents
-agda from unfolding into an absolutely enourmous proof when used as
+agda from unfolding into an absolutely enormous proof when used as
 a macro, which is critical for performance.
 
 ```agda

--- a/src/Cat/Displayed/Instances/Pullback.lagda.md
+++ b/src/Cat/Displayed/Instances/Pullback.lagda.md
@@ -19,7 +19,7 @@ module
 # Pullback of a displayed category
 
 If we have a category $E$ displayed over $B$, then a functor $F : X \to
-B$ defines a (contravariant) "change-of-base" action, reasulting in a
+B$ defines a (contravariant) "change-of-base" action, resulting in a
 category $F^*(E)$ displayed over $X$.
 
 <!--

--- a/src/Cat/Displayed/Instances/Scone.lagda.md
+++ b/src/Cat/Displayed/Instances/Scone.lagda.md
@@ -31,7 +31,7 @@ of categories that we want to think of as somehow "syntactic".
 A scone over some object $X : \ca{B}$ consists of a set $U$, along with
 a function $U \to B(\top, X)$. If we think about $\ca{B}$ as some sort
 of category of contexts, then a scone over some context $X$
-is some means of attatching semantic information (the set $U$) to
+is some means of attaching semantic information (the set $U$) to
 $X$, such that we can recover closed terms of $X$ from elements of $U$.
 
 Morphisms behave like they do in an arrow category of $\ca{Sets}$:

--- a/src/Cat/Displayed/Instances/Simple.lagda.md
+++ b/src/Cat/Displayed/Instances/Simple.lagda.md
@@ -24,7 +24,7 @@ When constructing models of type theories, the general pattern
 is to construct a category of contexts and substitutions, and then
 to study types and terms as structures over this category.
 The language of displayed categories allows us to capture this situation
-quite succinctly by considering these extra pieces of equippment as
+quite succinctly by considering these extra pieces of equipment as
 being fibred over our category of contexts.
 
 Focusing in, the language of *simple fibrations* provides us with enough

--- a/src/Cat/Displayed/Reasoning.lagda.md
+++ b/src/Cat/Displayed/Reasoning.lagda.md
@@ -166,7 +166,7 @@ revive₁ {f′ = f′} {g′ = g′} {p = p} {q = q} p′ =
   hom[ p ∙ sym p ∙ q ] f′ ≡⟨ kill₁ p (sym p ∙ q) p′ ⟩
   hom[ sym p ∙ q ] g′     ∎
 
--- Idea: p is equal to some composite p′ ∙ q, but it's mis-associated or
+-- Idea: p is equal to some composite p′ ∙ q, but it's misassociated or
 -- something. We combine the reindexing to fix the association and
 -- killing the first parameter to "weave" here.
 weave

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -428,7 +428,7 @@ module _
 So, given an object $x \in \ca{C}$, we must find an object $y$ and a
 universal map $x \to R(y)$. Recall that, in the previous section, we
 constructed the left adjoint $L$'s action on objects by using our system
-of universal arrows; Symetrically, in this section, we take the codomain
+of universal arrows; Symmetrically, in this section, we take the codomain
 to be $y = L(x)$. We must then find an arrow $x \to RLx$, but this is
 exactly the adjunction unit $\eta$!
 

--- a/src/Cat/Functor/Hom.lagda.md
+++ b/src/Cat/Functor/Hom.lagda.md
@@ -100,7 +100,7 @@ postcomposition; This is natural because we must show $f \circ x \circ g
 よ₁ f .is-natural x y g = funext λ x → assoc f x g
 ```
 
-The other category laws from $\ca{C}$ ensure that this assigment of
+The other category laws from $\ca{C}$ ensure that this assignment of
 natural transformations is indeed functorial:
 
 ```agda

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -472,7 +472,7 @@ For essential surjectivity, given a map $f : X \to I$, we recover a
 family of sets $(f^*i)_{i \in I}$ by taking the `fibre`{.Agda} of $f$
 over each point, which cleanly extends to a functor. To show that the
 `Total-space`{.Agda} of this functor is isomorphic to the map we started
-with, we use one of the auxilliary lemmas used in the construction of an
+with, we use one of the auxiliary lemmas used in the construction of an
 object classifier: `Total-equiv`{.Agda}. This is cleaner than exhibiting
 an isomorphism directly, though it does involve an appeal to univalence.
 

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -14,7 +14,7 @@ module Cat.Morphism.Orthogonal where
 # Orthogonal maps
 
 A pair of maps $f : a \to b$ and $g : c \ to d$ are called
-**orthogonal**, writen $f \ortho g$^[Though hang tight for a note on
+**orthogonal**, written $f \ortho g$^[Though hang tight for a note on
 formalised notation], if for every $u, v$ fitting into a commutative
 diagram like
 

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -233,7 +233,7 @@ is-regular-epi→is-strong-epi {a} {b} f regular =
 
 # Images
 
-Now we come to the _raison d'etre_ for strong epimorphisms: [Images].
+Now we come to the _raison d'être_ for strong epimorphisms: [Images].
 The definition of image we use is very complicated, and the
 justification is already present there, but the short of it is that the
 image of a morphism $f : a \to b$ is a monomorphism $\im(f) \mono b$ which is

--- a/src/Cat/Univalent/Rezk/Universal.lagda.md
+++ b/src/Cat/Univalent/Rezk/Universal.lagda.md
@@ -164,7 +164,7 @@ $$
 We'll first show that components exist at all. Assume that we have some
 $b : \ca{B}$ and an essential fibre $(a_0, h_0)$ of $H$ over it^[Don't
 worry about actually getting your hands on an $(a_0, h_0)$.]. In this
-situation, guided by the compatibility condiiton (and isomorphisms being
+situation, guided by the compatibility condition (and isomorphisms being
 just the best), we can actually _define_ the component to be "whatever
 satisfies compatibility at $(a_0,h_0)$," and a short calculation
 establishes that defining

--- a/src/Homotopy/Space/Sinfty.lagda.md
+++ b/src/Homotopy/Space/Sinfty.lagda.md
@@ -68,11 +68,11 @@ is-contrS∞′ .paths = pathsS∞′
 
 The cubical approach essentially acomplishes the same thing as the previous
 proof, without using any helper lemmas, by way of drawing a slightly clever
-cube. The case of the defenition for the higher constructor requires a
+cube. The case of the definition for the higher constructor requires a
 square in which two of the sides are `merid N` and `merid x`. We start with
 a square in which both of these sides are `merid N` (specifically
 `merid N (i ∧ j)`), and then construct a cube in which one of the faces morphs
-`merid N ` into `merid x`. This is something that we can easilly do since we
+`merid N ` into `merid x`. This is something that we can easily do since we
 have a path `N ≡ x` via the recursive call `pathsS∞ x`.
 
 ```agda

--- a/src/Homotopy/Space/Torus.lagda.md
+++ b/src/Homotopy/Space/Torus.lagda.md
@@ -23,7 +23,7 @@ Such a CW complex can be regarded as a higher inductive type,
 regarding the 0-cell as a constructor `base`{.Agda}, the two 1-cells
 as distinct paths `base ≡ base`{.Agda}, and the 2-cell as a square
 with its top and bottom edges attached to one of the 1-cells, and its
-left and right edge attachd to the other.
+left and right edge attached to the other.
 
 ```agda
 data T² : Type where

--- a/src/Order/Frame/Free.lagda.md
+++ b/src/Order/Frame/Free.lagda.md
@@ -227,7 +227,7 @@ map $\widehat{f}$ satisfies $\widehat{f}(\darr x) = f(x)$.
     mkcomm x = sym (Lan↓-commutes A.po B.po B.cocomplete f-monotone x)
 ```
 
-Now we must define the unit map. We've already commited to defining
+Now we must define the unit map. We've already committed to defining
 $\eta_a = \darr a$, so we have to show that $\darr$ preserves finite
 meets. This is true because $\darr$ lands in _lower sets_, so it
 suffices to show an equivalence between (e.g.) being _under $a$ and

--- a/src/Topoi/Base.lagda.md
+++ b/src/Topoi/Base.lagda.md
@@ -130,8 +130,8 @@ satisfying these properties (finite meets, arbitrary joins, the
 distributive law) is called a **frame**. A map of frames $f : A \to B$
 is defined to be a map of their underlying sets preserving finite meets
 and arbitrary joins --- by abstract nonsense, this is the same as a
-function $f^* : B \to A$ which preserves finite meets and has a right
-adjoint $f_* : A \to B$[^aft].
+function $f^* : A \to B$ which preserves finite meets and has a right
+adjoint $f_* : B \to A$[^aft].
 
 [^aft]: By the adjoint functor theorem, any map between posets which
 preserves arbitrary joins has a right adjoint; Conversely, every map

--- a/support/shake/app/Shake/AgdaCompile.hs
+++ b/support/shake/app/Shake/AgdaCompile.hs
@@ -211,7 +211,7 @@ getInterface tcState name =
   let modules = tcState ^. stVisitedModules in
   case Map.lookup name modules of
     Just iface -> miInterface iface
-    Nothing -> error $ "Cannot find inferface for module " ++ prettyShow name
+    Nothing -> error $ "Cannot find interface for module " ++ prettyShow name
 
 runTCMPrettyErrors :: TCEnv -> TCState -> TCM a -> IO (a, TCState)
 runTCMPrettyErrors env state tcm = do


### PR DESCRIPTION
Found using the [typos](https://github.com/crate-ci/typos) crate with the following configuration:

```toml
[files]
extend-exclude = ["support/shake/app/HTML", "*.scss"]

[default.extend-words]
substituters = "substituters" # should probably be added upstream
intensional = "intensional" # this spelling is very much intentional
raison = "raison" # d'être

# parts of identifiers
fo = "fo"
mor = "mor"
som = "som"
ue = "ue"
unitl = "unitl"
```

(except the frame morphism thing, I had that in my local checkout for a while)