### PR TITLE
chore: Fix a couple typos

### DIFF
--- a/src/1Lab/intro.lagda.md
+++ b/src/1Lab/intro.lagda.md
@@ -487,8 +487,8 @@ can make a map into $B$ with subsingleton fibres by carefully choosing
 the domain. We take the domain to be the disjoint union of the family
 $\chi$, that is, the set $\sum_{(x : B)} \chi(x)$. The elements of this
 set can be described, moving closer to type-theoretic language, as pairs
-$(i, p)$ where $i \in B$ and $p \in \chi(i)$ is a witness that $i$
-holds.
+$(i, p)$ where $i \in B$ and $p \in \chi(i)$ is a witness that the
+subset predicate holds of $i$.
 
 I claim: the map $\pi_1 : (\sum_{(x : B)} \chi(x)) \to B$ which takes
 $(i, p) \mapsto i$ has subsingleton fibres. This is because an element


### PR DESCRIPTION
# Description

Just fixes a typo and some slightly awkward phrasing ("_subject_ holds" rather than "_predicate_ holds of _subject_").

## Checklist

Before submitting a merge request, please check the items below:

- [x] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [x] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [x] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".

If a commit affects many files without adding any content and you don't
want your name to appear on those pages (for example, treewide refactorings
or reformattings), include the word `NOAUTHOR` in the commit message.
