### PR TITLE
Add an option to skip building Agda code

### DIFF
--- a/support/shake/app/Shake/Options.hs
+++ b/support/shake/app/Shake/Options.hs
@@ -6,6 +6,7 @@ module Shake.Options
   ( Option(..)
   , setOptions
   , getSkipTypes
+  , getSkipAgda
   , getWatching
   ) where
 
@@ -16,6 +17,7 @@ import GHC.Generics (Generic)
 
 data Option
   = SkipTypes -- ^ Skip generating types when emitting HTML.
+  | SkipAgda -- ^ Skip typechecking Agda, emitting the markdown directly.
   | Watching -- ^ Launch in watch mode. Prevents some build tasks running.
   deriving (Eq, Show, Typeable, Generic)
 
@@ -31,9 +33,13 @@ setOptions options = do
   _ <- addOracle (pure . getOption)
   pure ()
   where
-    getOption SkipTypes = SkipTypes `elem` options || Watching `elem` options
+    getOption SkipTypes = SkipTypes `elem` options
+                       || SkipAgda `elem` options
+                       || Watching `elem` options
+    getOption SkipAgda = SkipAgda `elem` options
     getOption Watching = Watching `elem` options
 
-getSkipTypes, getWatching :: Action Bool
+getSkipTypes, getSkipAgda, getWatching :: Action Bool
 getSkipTypes = askOracle SkipTypes
+getSkipAgda = askOracle SkipAgda
 getWatching = askOracle Watching


### PR DESCRIPTION
Closes #187. 

Currently [Agda code being embedded in code blocks](https://user-images.githubusercontent.com/4346137/217057817-b10648a1-9419-4f2a-969c-9a2ad9efc323.png) - I don't know if we want to add a special class to these, so they don't have a border?

This is implemented by avoiding any build steps which would cause an Agda compile (specifically `_build/all-pages.json`). The alternative would be to rely on staler versions of those files, and simply not rebuild them.

I think what I'm doing here is the correct thing to do. It keeps us honest with our task dependencies, and means `--skip-agda` works from a clean build directory. It does mean some site features (namely `agda://` links) won't work. 