### PR TITLE
Adjoints have Kan extensions, revisited

### DIFF
--- a/src/Cat/Diagram/Coend/Sets.lagda.md
+++ b/src/Cat/Diagram/Coend/Sets.lagda.md
@@ -29,7 +29,7 @@ However, if we take a [coequaliser] of `Σ[ X ∈ Ob ] ∣ F₀ (X , X) ∣` bot
 of these problems immediately disappear. In particular, we want to take
 the coequaliser of the following pair of functions:
 
-[coequaliser] Data.Set.Coequaliser.html
+[coequaliser]: Data.Set.Coequaliser.html
 
 ~~~{.quiver}
 \begin{tikzcd}

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -667,7 +667,7 @@ between [postcomposition and precomposition functors], respectively:
 ```agda
   open import Cat.Instances.Functor.Compose
 
-  postcomposite-adjunction : (L ^*) {D = E} ⊣ R ^*
+  postcomposite-adjunction : postcompose L {D = E} ⊣ postcompose R
   postcomposite-adjunction .unit .η F .η = (adj.unit ◂ F) .η
   postcomposite-adjunction .unit .η F .is-natural = (adj.unit ◂ F) .is-natural
   postcomposite-adjunction .unit .is-natural F G α = Nat-path λ _ → adj.unit.is-natural _ _ _
@@ -677,7 +677,7 @@ between [postcomposition and precomposition functors], respectively:
   postcomposite-adjunction .zig = Nat-path λ _ → adj.zig
   postcomposite-adjunction .zag = Nat-path λ _ → adj.zag
 
-  precomposite-adjunction : (R !) {D = E} ⊣ L !
+  precomposite-adjunction : precompose R {D = E} ⊣ precompose L
   precomposite-adjunction .unit .η F .η = (F ▸ adj.unit) .η
   precomposite-adjunction .unit .η F .is-natural = (F ▸ adj.unit) .is-natural
   precomposite-adjunction .unit .is-natural F G α = Nat-path λ _ → sym (α .is-natural _ _ _)

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -666,23 +666,20 @@ between [postcomposition and precomposition functors], respectively:
 
 ```agda
   open import Cat.Instances.Functor.Compose
+  open import Cat.Functor.Coherence
 
   postcomposite-adjunction : postcompose L {D = E} ⊣ postcompose R
-  postcomposite-adjunction .unit .η F .η = (adj.unit ◂ F) .η
-  postcomposite-adjunction .unit .η F .is-natural = (adj.unit ◂ F) .is-natural
+  postcomposite-adjunction .unit .η F = cohere! (adj.unit ◂ F)
   postcomposite-adjunction .unit .is-natural F G α = Nat-path λ _ → adj.unit.is-natural _ _ _
-  postcomposite-adjunction .counit .η F .η = (adj.counit ◂ F) .η
-  postcomposite-adjunction .counit .η F .is-natural = (adj.counit ◂ F) .is-natural
+  postcomposite-adjunction .counit .η F = cohere! (adj.counit ◂ F)
   postcomposite-adjunction .counit .is-natural F G α = Nat-path λ _ → adj.counit.is-natural _ _ _
   postcomposite-adjunction .zig = Nat-path λ _ → adj.zig
   postcomposite-adjunction .zag = Nat-path λ _ → adj.zag
 
   precomposite-adjunction : precompose R {D = E} ⊣ precompose L
-  precomposite-adjunction .unit .η F .η = (F ▸ adj.unit) .η
-  precomposite-adjunction .unit .η F .is-natural = (F ▸ adj.unit) .is-natural
+  precomposite-adjunction .unit .η F = cohere! (F ▸ adj.unit)
   precomposite-adjunction .unit .is-natural F G α = Nat-path λ _ → sym (α .is-natural _ _ _)
-  precomposite-adjunction .counit .η F .η = (F ▸ adj.counit) .η
-  precomposite-adjunction .counit .η F .is-natural = (F ▸ adj.counit) .is-natural
+  precomposite-adjunction .counit .η F = cohere! (F ▸ adj.counit)
   precomposite-adjunction .counit .is-natural F G α = Nat-path λ _ → sym (α .is-natural _ _ _)
   precomposite-adjunction .zig {F} = Nat-path λ _ → Func.annihilate F adj.zag
   precomposite-adjunction .zag {F} = Nat-path λ _ → Func.annihilate F adj.zig

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -20,7 +20,7 @@ module Cat.Functor.Adjoint where
 ```agda
 private variable
   o h : Level
-  C D : Precategory o h
+  C D E : Precategory o h
 
 open Functor hiding (op)
 
@@ -635,14 +635,16 @@ Furthermore, these equivalences are natural.
 ```
 -->
 
-<!--
+# Induced adjunctions
+
+Any adjunction $L \dashv R$ induces, in a very boring way, an *opposite* adjunction
+$R\op \dashv L\op$ between `opposite functors`{.Agda ident=op}:
+
 ```agda
 module _ {L : Functor C D} {R : Functor D C} (adj : L ⊣ R) where
   private
     module L = Functor L
     module R = Functor R
-    module C = Cat.Reasoning C
-    module D = Cat.Reasoning D
     module adj = _⊣_ adj
 
   open _⊣_
@@ -655,7 +657,39 @@ module _ {L : Functor C D} {R : Functor D C} (adj : L ⊣ R) where
   opposite-adjunction .counit .is-natural x y f = sym (adj.unit.is-natural _ _ _)
   opposite-adjunction .zig = adj.zag
   opposite-adjunction .zag = adj.zig
+```
 
+As well as adjunctions $L \circ - \dashv R \circ -$ and $- \circ R \dashv - \circ L$
+between [postcomposition and precomposition functors], respectively:
+
+[postcomposition and precomposition functors]: Cat.Instances.Functor.Compose.html
+
+```agda
+  open import Cat.Instances.Functor.Compose
+
+  postcomposite-adjunction : (L ^*) {D = E} ⊣ R ^*
+  postcomposite-adjunction .unit .η F .η = (adj.unit ◂ F) .η
+  postcomposite-adjunction .unit .η F .is-natural = (adj.unit ◂ F) .is-natural
+  postcomposite-adjunction .unit .is-natural F G α = Nat-path λ _ → adj.unit.is-natural _ _ _
+  postcomposite-adjunction .counit .η F .η = (adj.counit ◂ F) .η
+  postcomposite-adjunction .counit .η F .is-natural = (adj.counit ◂ F) .is-natural
+  postcomposite-adjunction .counit .is-natural F G α = Nat-path λ _ → adj.counit.is-natural _ _ _
+  postcomposite-adjunction .zig = Nat-path λ _ → adj.zig
+  postcomposite-adjunction .zag = Nat-path λ _ → adj.zag
+
+  precomposite-adjunction : (R !) {D = E} ⊣ L !
+  precomposite-adjunction .unit .η F .η = (F ▸ adj.unit) .η
+  precomposite-adjunction .unit .η F .is-natural = (F ▸ adj.unit) .is-natural
+  precomposite-adjunction .unit .is-natural F G α = Nat-path λ _ → sym (α .is-natural _ _ _)
+  precomposite-adjunction .counit .η F .η = (F ▸ adj.counit) .η
+  precomposite-adjunction .counit .η F .is-natural = (F ▸ adj.counit) .is-natural
+  precomposite-adjunction .counit .is-natural F G α = Nat-path λ _ → sym (α .is-natural _ _ _)
+  precomposite-adjunction .zig {F} = Nat-path λ _ → Func.annihilate F adj.zag
+  precomposite-adjunction .zag {F} = Nat-path λ _ → Func.annihilate F adj.zig
+```
+
+<!--
+```agda
 record make-left-adjoint (R : Functor D C) : Type (adj-level C D) where
   private
     module C = Cat.Reasoning C

--- a/src/Cat/Functor/Adjoint/Kan.lagda.md
+++ b/src/Cat/Functor/Adjoint/Kan.lagda.md
@@ -216,6 +216,5 @@ module
 
     fixed .is-ran.σ-comm = Nat-path λ x → p.σ-comm ηₚ _
     fixed .is-ran.σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → p.σ-uniq {σ′ = σ′′} (Nat-path λ x → p ηₚ x) ηₚ x where
-      unquoteDecl σ′′ = dualise-into σ′′ _ σ′
+      Nat-path λ x → p.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 ```

--- a/src/Cat/Functor/Amnestic.lagda.md
+++ b/src/Cat/Functor/Amnestic.lagda.md
@@ -40,7 +40,7 @@ _functor_ $F$. So, we define:
 
 An isomorphism $f : a \cong b$ **is an identity** if it is an identity
 in the total space of `Hom`{.Agda}, i.e. if there is an object $c : \cC$
-s.t. $(c, \id) = (a, b, f)$ in the type $\Sigma_a \Sigma_b (a \to b)$.
+s.t. $(c, c, \id) = (a, b, f)$ in the type $\Sigma_a \Sigma_b (a \to b)$.
 Every isomorphism in a univalent category is an identity, since we can
 take $c = a$, and the identification in `Mor`{.Agda} follows from
 univalence.

--- a/src/Cat/Functor/Kan/Adjoint.lagda.md
+++ b/src/Cat/Functor/Kan/Adjoint.lagda.md
@@ -1,113 +1,99 @@
 ```agda
+open import Cat.Instances.Functor.Compose
 open import Cat.Functor.Kan.Duality
+open import Cat.Functor.Kan.Global
+open import Cat.Instances.Functor
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Adjoint
 open import Cat.Prelude
-
-import Cat.Functor.Reasoning as Func
-import Cat.Reasoning as Cat
 
 module Cat.Functor.Kan.Adjoint where
 ```
 
 <!--
 ```agda
+open _=>_
+open _⊣_
+
 private
   variable
     o ℓ : Level
-    C C′ D E : Precategory o ℓ
+    C D E : Precategory o ℓ
 ```
 -->
 
 # Adjoints are Kan extensions
 
-The elevator pitch for Kan extensions is that "all concepts are Kan
-extensions". The example we will give here is that, if $F \dashv G$ is
-an adjunction, then $(G, \eta)$ gives $\Lan_F(\rm{Id})$. This isn't
-exactly enlightening: adjunctions and Kan extensions have very different
-vibes, but the latter concept _is_ a legitimate generalisation.
-
-<!--
-```agda
-module _ {F : Functor C D} {G : Functor D C} (adj : F ⊣ G) where
-  open Lan
-  open is-lan
-  open is-ran
-  private
-    module F = Functor F
-    module G = Functor G
-    module C = Cat C
-    module D = Cat D
-
-  open Functor
-  open _⊣_ adj
-  open _=>_
-```
--->
-
-```agda
-  adjoint→is-lan : is-lan F Id G unit
-```
-
-The proof is mostly pushing symbols around, and the calculation is
-available below unabridged. In components, $\sigma_x$ must give,
-assuming a map $\alpha : \rm{Id} \To MFx$, a map $Gx \to Mx$. The
-transformation we're looking for arises as the composite
+One way to think about [Kan extensions] is that, when they exist, they allow us to
+"compose" two functors when one of them is going the wrong way: given a span
 
 $$
-Gx \xto{\alpha} MFGx \xto{M\epsilon} Mx\text{,}
+D \xot{F} C \xto{H} E
 $$
 
-where uniqueness and commutativity follows from the triangle identities
-`zig`{.Agda} and `zag`{.Agda}.
+we get a "composite" $\Lan_F(H) : D \to E$. With this perspective in mind, it's
+reasonable to expect that, if $F$ has an [inverse] $G : D \to C$, the composite
+we get should be the actual composite $H \circ G$.
+
+In fact, we can do better: if $F$ only has a [right adjoint] $F \dashv G$ (which
+we can think of as a directed inverse), then the induced
+`precomposite adjunction`{.Agda ident=precomposite-adjunction} $- \circ G \dashv - \circ F$
+means that *left* ([global]) Kan extensions along $F$ are given by precomposition with $G$
+(and, dually, right Kan extensions along $G$ are given by precomposition with $F$).
+
+[Kan extensions]: Cat.Functor.Kan.Base.html
+[inverse]: Cat.Functor.Equivalence.html
+[right adjoint]: Cat.Functor.Adjoint.html
+[global]: Cat.Functor.Kan.Global.html
 
 ```agda
-  adjoint→is-lan .σ {M} α .η x = M .F₁ (counit.ε _) C.∘ α .η (G.₀ x)
-  adjoint→is-lan .σ {M} nt .is-natural x y f =
-    (M.₁ (counit.ε _) C.∘ nt .η _) C.∘ G.₁ f            ≡⟨ C.pullr (nt .is-natural _ _ _) ⟩
-    M.₁ (counit.ε _) C.∘ M.₁ (F.₁ (G.₁ f)) C.∘ nt .η _  ≡⟨ M.extendl (counit.is-natural _ _ _) ⟩
-    M.₁ f C.∘ M.₁ (counit.ε _) C.∘ nt .η _              ∎
-    where module M = Func M
-
-  adjoint→is-lan .σ-comm {M} {α} = Nat-path λ _ →
-    (M.₁ (counit.ε _) C.∘ α.η _) C.∘ unit.η _              ≡⟨ C.pullr (α.is-natural _ _ _) ⟩
-    M.₁ (counit.ε _) C.∘ M.₁ (F.F₁ (unit .η _)) C.∘ α.η _  ≡⟨ M.cancell zig ⟩
-    α.η _                                                  ∎
-    where module α = _=>_ α
-          module M = Func M
-
-  adjoint→is-lan .σ-uniq {M} {α} {σ'} p = Nat-path λ x →
-    M.₁ (counit.ε _) C.∘ α.η _                ≡⟨ ap (_ C.∘_) (p ηₚ _) ⟩
-    M.₁ (counit.ε _) C.∘ σ' .η _ C.∘ unit.η _ ≡⟨ C.extendl (sym (σ' .is-natural _ _ _)) ⟩
-    σ' .η _ C.∘ G.₁ (counit.ε _) C.∘ unit.η _ ≡⟨ C.elimr zag ⟩
-    σ' .η x                                   ∎
-    where module α = _=>_ α
-          module M = Func M
+module _ {F : Functor C D} {G : Functor D C} (F⊣G : F ⊣ G) where
+  adjoint→is-lan
+    : (H : Functor C E)
+    → is-lan F H (H F∘ G) (precomposite-adjunction F⊣G .unit .η H)
+  adjoint→is-lan = adjoint-precompose→Lan F (precompose G) (precomposite-adjunction F⊣G)
 ```
 
-As expected, adjoints also yield right Kan extensions.
+A more common way to say this is that $G$ is the `absolute`{.Agda ident=is-absolute-lan}
+left Kan extension of $F$ along the identity; this is essentially a reformulation of the above fact:
 
 ```agda
-  adjoint→is-ran : is-ran G Id F counit
+  adjoint→is-lan-id : is-lan F Id G (F⊣G .unit)
+  adjoint→is-lan-id =
+    transport (λ i → is-lan F Id (F∘-idl i) (fixNT i))
+      (adjoint→is-lan Id)
+    where
+      fixNT : PathP (λ i → Id => F∘-idl {F = G} i F∘ F) _ _
+      fixNT = Nat-pathp refl (λ i → F∘-idl i F∘ F) (λ _ → refl)
+
+  adjoint→is-absolute-lan : is-absolute-lan adjoint→is-lan-id
+  adjoint→is-absolute-lan H =
+    transport (λ i → is-lan F (F∘-idr (~ i)) (H F∘ G) (fixNT (~ i)))
+      (adjoint→is-lan H)
+    where
+      fixNT : PathP (λ i → F∘-idr {F = H} i => (H F∘ G) F∘ F) _ _
+      fixNT = Nat-pathp F∘-idr refl (λ _ → refl)
 ```
 
-<details>
-<summary>The proof is the same as left adjoints, just dualized.
-</summary>
+The dual statement is obtained by... [duality], this time using the `counit`{.Agda} of the precomposite adjunction:
+
+[duality]: Cat.Functor.Kan.Duality.html
 
 ```agda
-  adjoint→is-ran .σ {M} β .η x = β .η _ D.∘ M .F₁ (unit.η _)
-  adjoint→is-ran .σ {M} β .is-natural _ _ _ =
-    M.extendr (unit.is-natural _ _ _)
-    ∙ D.pushl (β .is-natural _ _ _)
-    where module M = Func M
-  adjoint→is-ran .σ-comm {M} {β} = Nat-path λ _ →
-    D.pulll (sym $ β .is-natural _ _ _)
-    ∙ M.cancelr zag
-    where module M = Func M
-  adjoint→is-ran .σ-uniq {M} {β} {σ′} p = Nat-path λ _ →
-    ap (D._∘ _) (p ηₚ _)
-    ·· D.extendr (σ′ .is-natural _ _ _)
-    ·· D.eliml zig
+module _ {F : Functor C D} {G : Functor D C} (F⊣G : F ⊣ G) where
+  adjoint→is-ran
+    : (H : Functor D E)
+    → is-ran G H (H F∘ F) (precomposite-adjunction F⊣G .counit .η H)
+  adjoint→is-ran H =
+    transport (λ i → is-ran G H (fixF i) (fixNT i))
+      (is-co-lan'→is-ran G H
+        (adjoint→is-lan (opposite-adjunction F⊣G) (Functor.op H)))
+    where
+      fixF : Functor.op (Functor.op H F∘ Functor.op F) ≡ H F∘ F
+      fixF = Functor-path (λ _ → refl) (λ _ → refl)
+      fixNT : PathP (λ i → fixF i F∘ G => H) _ _
+      fixNT = Nat-pathp (λ i → fixF i F∘ G) refl (λ _ → refl)
 ```
-</details>
+
+Even more dually, we can flip the span above to get a *cospan* of functors, giving rise to the theory of
+**Kan lifts**. We then get analogous statements: left (resp. right) adjoints are absolute left (resp. right) Kan lifts along the identity.

--- a/src/Cat/Functor/Kan/Base.lagda.md
+++ b/src/Cat/Functor/Kan/Base.lagda.md
@@ -300,6 +300,17 @@ In the diagram above, the 2-cell is simply the whiskering $H\eta$.
 Unfortunately, proof assistants; our definition of whiskering lands in
 $H(Gp)$, but we requires a natural transformation to $(HG)p$.
 
+We say that a Kan extension is **absolute** if it is preserved by *all* functors out of $D$.
+An important example of this is given by [adjoint functors].
+
+[adjoint functors]: Cat.Functor.Kan.Adjoint.html
+
+```agda
+  is-absolute-lan : is-lan p F G eta → Typeω
+  is-absolute-lan lan =
+    {o ℓ : Level} {E : Precategory o ℓ} (H : Functor D E) → preserves-lan H lan
+```
+
 It may also be the case that $(HG, H\eta)$ is already a left kan
 extension of $HF$ along $p$. We say that $H$ reflects this Kan extension
 if $G, \eta$ is a also a left extension of $F$ along $p$.
@@ -326,6 +337,10 @@ We can define dual notions for right Kan extensions as well.
   preserves-ran : (H : Functor D E) → is-ran p F G eps → Type _
   preserves-ran H _ =
     is-ran p (H F∘ F) (H F∘ G) (nat-assoc-from (H ▸ eps))
+
+  is-absolute-ran : is-ran p F G eps → Typeω
+  is-absolute-ran ran =
+    {o ℓ : Level} {E : Precategory o ℓ} (H : Functor D E) → preserves-ran H ran
 
   reflects-ran
     : (H : Functor D E)

--- a/src/Cat/Functor/Kan/Duality.lagda.md
+++ b/src/Cat/Functor/Kan/Duality.lagda.md
@@ -71,8 +71,7 @@ module _ (p : Functor C C′) (F : Functor C D) where
 
     ran .σ-comm = Nat-path λ x → lan.σ-comm ηₚ x
     ran .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → lan.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
-      where unquoteDecl σ′op = dualise-into σ′op _ σ′
+      Nat-path λ x → lan.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 ```
 
 <!--
@@ -93,8 +92,7 @@ module _ (p : Functor C C′) (F : Functor C D) where
         α
     ran .σ-comm = Nat-path λ x → lan.σ-comm ηₚ x
     ran .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → lan.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
-      where unquoteDecl σ′op = dualise-into σ′op _ σ′
+      Nat-path λ x → lan.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 
   is-ran→is-co-lan
     : ∀ {Ext : Functor C′ D} {eta : Ext F∘ p => F}
@@ -110,8 +108,7 @@ module _ (p : Functor C C′) (F : Functor C D) where
 
     lan .σ-comm = Nat-path λ x → ran.σ-comm ηₚ x
     lan .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → ran.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
-      where unquoteDecl σ′op = dualise-into σ′op _ σ′
+      Nat-path λ x → ran.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 
   Co-lan→Ran : Lan (Functor.op p) (Functor.op F) → Ran p F
   Co-lan→Ran lan .Ext     = Functor.op (lan .Ext)
@@ -137,8 +134,7 @@ module _ (p : Functor C C′) (F : Functor C D) where
         β
     lan .σ-comm = Nat-path λ x → ran.σ-comm ηₚ x
     lan .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → ran.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
-      where unquoteDecl σ′op = dualise-into σ′op _ σ′
+      Nat-path λ x → ran.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 
   is-co-ran→is-lan
     : ∀ {G : Functor C′ D} {eta}
@@ -154,8 +150,7 @@ module _ (p : Functor C C′) (F : Functor C D) where
         β
     lan .σ-comm = Nat-path λ x → ran.σ-comm ηₚ x
     lan .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → ran.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
-      where unquoteDecl σ′op = dualise-into σ′op _ σ′
+      Nat-path λ x → ran.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 
   is-lan→is-co-ran
     : ∀ {G : Functor C′ D} {eps : F => G F∘ p}
@@ -170,8 +165,7 @@ module _ (p : Functor C C′) (F : Functor C D) where
       unquoteDecl σ′ = dualise-into σ′ (M => Functor.op G) (lan.σ β′)
     ran .σ-comm = Nat-path λ x → lan.σ-comm ηₚ x
     ran .σ-uniq {M = M} {σ′ = σ′} p =
-      Nat-path λ x → lan.σ-uniq {σ′ = σ′op} (Nat-path λ x → p ηₚ x) ηₚ x
-      where unquoteDecl σ′op = dualise-into σ′op _ σ′
+      Nat-path λ x → lan.σ-uniq {σ′ = dualise! σ′} (Nat-path λ x → p ηₚ x) ηₚ x
 
   Co-ran→Lan : Ran (Functor.op p) (Functor.op F) → Lan p F
   Co-ran→Lan ran .Ext = Functor.op (ran .Ext)

--- a/src/Cat/Functor/Kan/Global.lagda.md
+++ b/src/Cat/Functor/Kan/Global.lagda.md
@@ -34,7 +34,7 @@ is a universal solution $\Lan_p(F)$ to extending $F$ to a functor $C'
 \to D$. In particularly happy cases (e.g. when $C$ is [small] and $D$ is
 [cocomplete]), the left Kan extension $\Lan_p(F)$ along $p$ exists for
 **any** $F$; When this happens, the assignment $F \mapsto \Lan_p(F)$
-*extends to a functor, which we call a **global Kan extension**.
+extends to a functor, which we call a **global Kan extension**.
 
 [left Kan extension]: Cat.Functor.Kan.Base.html
 [small]: 1Lab.intro.html#universes-and-size-issues
@@ -113,17 +113,6 @@ adjoint-precompose→Lan F adj G = ext where
     (L-R-adjunct adj _ ∙ x)
 ```
 
-In particular, if $p$ itself has a *right* adjoint $p \dashv r$, then left Kan
-extensions along $p$ are given by `precomposition`{.Agda ident=precompose} with $r$:
+This in turn implies that [adjoints are Kan extensions].
 
-```agda
-adjoint→Lan
-  : (r : Functor C′ C)
-  → (p⊣r : p ⊣ r)
-  → (G : Functor C D)
-  → is-lan p G (G F∘ r) (precomposite-adjunction p⊣r ._⊣_.unit .η G)
-adjoint→Lan r p⊣r = adjoint-precompose→Lan (precompose r) (precomposite-adjunction p⊣r)
-```
-
-Dually, if $p$ has a *left* adjoint $q \dashv p$, then *right* Kan extensions
-along $p$ are given by `precomposition`{.Agda ident=precompose} with $q$.
+[adjoints are Kan extensions]: Cat.Functor.Kan.Adjoint.html

--- a/src/Cat/Functor/Kan/Global.lagda.md
+++ b/src/Cat/Functor/Kan/Global.lagda.md
@@ -94,12 +94,12 @@ And, since adjoints are unique, if $p_!$ has any left adjoint, then its
 values generate Kan extensions:
 
 ```agda
-adjoint→Lan
+adjoint!→Lan
   : (F : Functor Cat[ C , D ] Cat[ C′ , D ])
   → (F⊣p! : F ⊣ p !)
   → (G : Functor C D)
   → is-lan p G (F .F₀ G) (F⊣p! ._⊣_.unit .η G)
-adjoint→Lan F F⊣p! G = ext where
+adjoint!→Lan F F⊣p! G = ext where
   open Lan
   open is-lan
   module F⊣p! = _⊣_ F⊣p!
@@ -112,3 +112,18 @@ adjoint→Lan F F⊣p! G = ext where
   ext .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv F⊣p!)
     (L-R-adjunct F⊣p! _ ∙ x)
 ```
+
+In particular, if $p$ itself has a *right* adjoint $p \dashv r$, then left Kan
+extensions along $p$ are given by `precomposition`{.Agda ident=!} with $r$:
+
+```agda
+adjoint→Lan
+  : (r : Functor C′ C)
+  → (p⊣r : p ⊣ r)
+  → (G : Functor C D)
+  → is-lan p G (G F∘ r) (precomposite-adjunction p⊣r ._⊣_.unit .η G)
+adjoint→Lan r p⊣r = adjoint!→Lan (r !) (precomposite-adjunction p⊣r)
+```
+
+Dually, if $p$ has a *left* adjoint $q \dashv p$, then *right* Kan extensions
+along $p$ are given by `precomposition`{.Agda ident=!} with $q$.

--- a/src/Cat/Functor/Kan/Global.lagda.md
+++ b/src/Cat/Functor/Kan/Global.lagda.md
@@ -67,13 +67,13 @@ extensions are universal: we can map between them in a functorial way
 using only the defining natural transformations in the diagram, without
 appealing to the details of a particular computation. Moreover, the left
 Kan extension functor _itself_ has a universal property: it is a left
-adjoint to the [precomposition] functor $p_!$.
+adjoint to the [precomposition] functor $- \circ p$.
 
 [precomposition]: Cat.Instances.Functor.Compose.html
 
 ```agda
-  Lan⊣! : Lan-functor ⊣ p !
-  Lan⊣! = hom-iso→adjoints f (is-iso→is-equiv eqv) natural where
+  Lan⊣precompose : Lan-functor ⊣ precompose p
+  Lan⊣precompose = hom-iso→adjoints f (is-iso→is-equiv eqv) natural where
     f : ∀ {x : Functor C D} {y : Functor C′ D} → has-lan x .Ext => y → x => y F∘ p
     f {x} {y} θ = (θ ◂ p) ∘nt has-lan x .eta
 
@@ -84,37 +84,37 @@ adjoint to the [precomposition] functor $p_!$.
     eqv {x} {y} .rinv θ = has-lan x .σ-comm
     eqv {x} {y} .linv θ = has-lan _ .σ-uniq refl
 
-    natural : hom-iso-natural {L = Lan-functor} {p !} f
+    natural : hom-iso-natural {L = Lan-functor} {precompose p} f
     natural {b = b} g h x = Nat-path λ a →
       D.pullr (D.pullr (has-lan _ .σ-comm ηₚ a))
       ∙ ap₂ D._∘_ refl (D.pushr refl)
 ```
 
-And, since adjoints are unique, if $p_!$ has any left adjoint, then its
+And, since adjoints are unique, if $- \circ p$ has any left adjoint, then its
 values generate Kan extensions:
 
 ```agda
-adjoint!→Lan
+adjoint-precompose→Lan
   : (F : Functor Cat[ C , D ] Cat[ C′ , D ])
-  → (F⊣p! : F ⊣ p !)
+  → (adj : F ⊣ precompose p)
   → (G : Functor C D)
-  → is-lan p G (F .F₀ G) (F⊣p! ._⊣_.unit .η G)
-adjoint!→Lan F F⊣p! G = ext where
+  → is-lan p G (F .F₀ G) (adj ._⊣_.unit .η G)
+adjoint-precompose→Lan F adj G = ext where
   open Lan
   open is-lan
-  module F⊣p! = _⊣_ F⊣p!
+  module adj = _⊣_ adj
 
   ext : is-lan p G _ _
-  ext .σ α = R-adjunct F⊣p! α
+  ext .σ α = R-adjunct adj α
   ext .σ-comm {M = M} {α = α} = Nat-path λ a →
-      D.pullr   (sym (F⊣p!.unit .is-natural _ _ _) ηₚ a)
-    ∙ D.cancell (F⊣p!.zag ηₚ a)
-  ext .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv F⊣p!)
-    (L-R-adjunct F⊣p! _ ∙ x)
+      D.pullr   (sym (adj.unit .is-natural _ _ _) ηₚ a)
+    ∙ D.cancell (adj.zag ηₚ a)
+  ext .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv adj)
+    (L-R-adjunct adj _ ∙ x)
 ```
 
 In particular, if $p$ itself has a *right* adjoint $p \dashv r$, then left Kan
-extensions along $p$ are given by `precomposition`{.Agda ident=!} with $r$:
+extensions along $p$ are given by `precomposition`{.Agda ident=precompose} with $r$:
 
 ```agda
 adjoint→Lan
@@ -122,8 +122,8 @@ adjoint→Lan
   → (p⊣r : p ⊣ r)
   → (G : Functor C D)
   → is-lan p G (G F∘ r) (precomposite-adjunction p⊣r ._⊣_.unit .η G)
-adjoint→Lan r p⊣r = adjoint!→Lan (r !) (precomposite-adjunction p⊣r)
+adjoint→Lan r p⊣r = adjoint-precompose→Lan (precompose r) (precomposite-adjunction p⊣r)
 ```
 
 Dually, if $p$ has a *left* adjoint $q \dashv p$, then *right* Kan extensions
-along $p$ are given by `precomposition`{.Agda ident=!} with $q$.
+along $p$ are given by `precomposition`{.Agda ident=precompose} with $q$.

--- a/src/Cat/Functor/Kan/Pointwise.lagda.md
+++ b/src/Cat/Functor/Kan/Pointwise.lagda.md
@@ -76,6 +76,24 @@ module _
     ∀ (x : D.Ob) → preserves-ran (Hom-from D x) ran
 ```
 
+Absolute Kan extensions are trivially pointwise, since they are preserved by *all* functors.
+
+```agda
+  absolute-lan→pointwise
+    : {eta : G => E F∘ F}
+    → {lan : is-lan F G E eta}
+    → is-absolute-lan lan
+    → is-pointwise-lan lan
+  absolute-lan→pointwise abs _ = abs _
+
+  absolute-ran→pointwise
+    : {eps : E F∘ F => G}
+    → {ran : is-ran F G E eps}
+    → is-absolute-ran ran
+    → is-pointwise-ran ran
+  absolute-ran→pointwise abs _ = abs _
+```
+
 <!--
 ```agda
 module _

--- a/src/Cat/Functor/Kan/Pointwise.lagda.md
+++ b/src/Cat/Functor/Kan/Pointwise.lagda.md
@@ -22,7 +22,7 @@ import Cat.Reasoning
 module Cat.Functor.Kan.Pointwise where
 ```
 
-# Pointwise Kan Extensions
+# Pointwise Kan extensions
 
 One useful perspective on [Kan extensions] is that they are
 generalizations of (co)limits; in fact, we have defined (co)limits as a

--- a/src/Cat/Functor/Kan/Representable.lagda.md
+++ b/src/Cat/Functor/Kan/Representable.lagda.md
@@ -11,7 +11,7 @@ import Cat.Reasoning
 module Cat.Functor.Kan.Representable where
 ```
 
-## Representability of Kan Extensions
+## Representability of Kan extensions
 
 Like most constructions with a universal property, we can phrase the
 definition of [Kan extensions] in terms of an equivalence of $\hom$

--- a/src/Cat/Functor/Kan/Representable.lagda.md
+++ b/src/Cat/Functor/Kan/Representable.lagda.md
@@ -57,14 +57,14 @@ a candidate for a left extension, as in the following diagram.
 ~~~
 
 Any such pair $(G, \eta)$ induces a natural transformation
-$D^{C'}(G, -) \to D^{C}(F, p(-))$.
+$D^{C'}(G, -) \to D^{C}(F, - \circ p)$.
 
 ```agda
-  Hom-from-!
+  Hom-from-precompose
     : F => G F∘ p
-    → Hom-from Cat[ C' , D ] G => Hom-from Cat[ C , D ] F F∘ (p !)
-  Hom-from-! eta .η H α = (α ◂ p) ∘nt eta
-  Hom-from-! eta .is-natural H K α = funext λ β → [C,D].pushl ◂-distribl
+    → Hom-from Cat[ C' , D ] G => Hom-from Cat[ C , D ] F F∘ precompose p
+  Hom-from-precompose eta .η H α = (α ◂ p) ∘nt eta
+  Hom-from-precompose eta .is-natural H K α = funext λ β → [C,D].pushl ◂-distribl
 ```
 
 If this natural transformation is an isomorphism, then $(G, \eta)$ is a
@@ -73,14 +73,14 @@ left Kan extension of $F$ along $p$.
 ```agda
   represents→is-lan
     : (eta : F => G F∘ p)
-    → is-natural-invertible (Hom-from-! eta)
+    → is-natural-invertible (Hom-from-precompose eta)
     → is-lan p F G eta
   represents→is-lan eta nat-inv = lan where
 ```
 
 This may seem somewhat difficult to prove at first glance, but it ends
 up being an exercise in shuffling data around. We can use the inverse
-to `Hom-from-! eta` to obtain the universal map of the extension, and
+to `Hom-from-precompose eta` to obtain the universal map of the extension, and
 factorization/uniqueness follow directly from the fact that we have
 a natural isomorphism.
 
@@ -94,20 +94,20 @@ a natural isomorphism.
 ```
 
 Furthermore, if $(G, \eta)$ is a left extension, then we can show that
-`Hom-from-! eta` is a natural isomorphism. The proof is yet another
+`Hom-from-precompose eta` is a natural isomorphism. The proof is yet another
 exercise in moving data around.
 
 ```agda
   is-lan→represents
     : {eta : F => G F∘ p}
     → is-lan p F G eta
-    → is-natural-invertible (Hom-from-! eta)
+    → is-natural-invertible (Hom-from-precompose eta)
   is-lan→represents {eta} lan =
     to-is-natural-invertible inv
       (λ M → funext λ α → lan .σ-comm)
       (λ M → funext λ α → lan .σ-uniq refl)
     where
-      inv : Hom-from Cat[ C , D ] F F∘ (p !) => Hom-from Cat[ C' , D ] G
+      inv : Hom-from Cat[ C , D ] F F∘ precompose p => Hom-from Cat[ C' , D ] G
       inv .η M α = lan .σ α
       inv .is-natural M N α = funext λ β →
         lan .σ-uniq (Nat-path λ _ → D.pushr (sym $ lan .σ-comm ηₚ _))
@@ -136,12 +136,12 @@ module _
 -->
 
 ```agda
-  lan→represents : Lan p F → Corepresentation (Hom-from Cat[ C , D ] F F∘ (p !))
+  lan→represents : Lan p F → Corepresentation (Hom-from Cat[ C , D ] F F∘ precompose p)
   lan→represents lan .corep = lan .Ext
   lan→represents lan .corepresents =
     (is-natural-invertible→natural-iso (is-lan→represents (lan .has-lan))) ni⁻¹
 
-  represents→lan : Corepresentation (Hom-from Cat[ C , D ] F F∘ (p !)) → Lan p F
+  represents→lan : Corepresentation (Hom-from Cat[ C , D ] F F∘ precompose p) → Lan p F
   represents→lan has-corep .Ext = has-corep .corep
   represents→lan has-corep .eta = has-corep .corepresents .from .η _ idnt
   represents→lan has-corep .has-lan =

--- a/src/Cat/Instances/Functor.lagda.md
+++ b/src/Cat/Instances/Functor.lagda.md
@@ -405,10 +405,17 @@ F∘-assoc = Functor-path (λ x → refl) λ x → refl
 
 F∘-idl
   : ∀ {o′′ ℓ′′ o₃ ℓ₃}
-      {E : Precategory o′′ ℓ′′} {F : Precategory o₃ ℓ₃}
-      {F : Functor E F}
+      {E : Precategory o′′ ℓ′′} {E′ : Precategory o₃ ℓ₃}
+      {F : Functor E E′}
   → Id F∘ F ≡ F
 F∘-idl = Functor-path (λ x → refl) λ x → refl
+
+F∘-idr
+  : ∀ {o′′ ℓ′′ o₃ ℓ₃}
+      {E : Precategory o′′ ℓ′′} {E′ : Precategory o₃ ℓ₃}
+      {F : Functor E E′}
+  → F F∘ Id ≡ F
+F∘-idr = Functor-path (λ x → refl) λ x → refl
 
 module
   _ {o ℓ o′ ℓ′ o′′ ℓ′′}

--- a/src/Cat/Instances/Functor/Compose.lagda.md
+++ b/src/Cat/Instances/Functor/Compose.lagda.md
@@ -25,12 +25,12 @@ interested in:
 - The functor composition functor itself, having type $[B, C] \times [A,
 B] \to [A,C]$;
 - The _precomposition functor_ associated with any $p : C \to C'$, which
-will be denoted $p_! : [C', D] \to [C,D]$ in TeX and `_!`{.Agda} in Agda;
+will be denoted $- \circ p : [C', D] \to [C,D]$ in TeX and `precompose`{.Agda} in Agda;
 - The _postcomposition functor_ associated with any $p : C \to C'$,
-which will be denoted $p^* : [A,C] \to [A,C']$; In the code, that's
-`_^*`{.Agda}.
+which will be denoted $p \circ - : [A,C] \to [A,C']$; In the code, that's
+`postcompose`{.Agda}.
 
-Note that the precomposition functor $p_!$ is necessarily
+Note that the precomposition functor $- \circ p$ is necessarily
 "contravariant" when compared with $p$, in that it points in the
 opposite direction to $p$.
 
@@ -87,22 +87,21 @@ _▸_ H nt .is-natural x y f =
   sym (H .F-∘ _ _) ∙ ap (H .F₁) (nt .is-natural _ _ _) ∙ H .F-∘ _ _
 ```
 
-
-With the whiskerings already defined, defining $p_!$ and $p^*$ is easy:
+With the whiskerings already defined, defining $- \circ p$ and $p \circ -$ is easy:
 
 ```agda
 module _ (p : Functor C C′) where
-  _! : Functor Cat[ C′ , D ] Cat[ C , D ]
-  _! .F₀ G    = G F∘ p
-  _! .F₁ θ    = θ ◂ p
-  _! .F-id    = Nat-path λ _ → refl
-  _! .F-∘ f g = Nat-path λ _ → refl
+  precompose : Functor Cat[ C′ , D ] Cat[ C , D ]
+  precompose .F₀ G    = G F∘ p
+  precompose .F₁ θ    = θ ◂ p
+  precompose .F-id    = Nat-path λ _ → refl
+  precompose .F-∘ f g = Nat-path λ _ → refl
 
-  _^* : Functor Cat[ D , C ] Cat[ D , C′ ]
-  _^* .F₀ G    = p F∘ G
-  _^* .F₁ θ    = p ▸ θ
-  _^* .F-id    = Nat-path λ _ → p .F-id
-  _^* .F-∘ f g = Nat-path λ _ → p .F-∘ _ _
+  postcompose : Functor Cat[ D , C ] Cat[ D , C′ ]
+  postcompose .F₀ G    = p F∘ G
+  postcompose .F₁ θ    = p ▸ θ
+  postcompose .F-id    = Nat-path λ _ → p .F-id
+  postcompose .F-∘ f g = Nat-path λ _ → p .F-∘ _ _
 ```
 
 Whiskerings are instances of a more general form of composition for

--- a/src/Cat/Univalent/Rezk/Universal.lagda.md
+++ b/src/Cat/Univalent/Rezk/Universal.lagda.md
@@ -48,20 +48,20 @@ univalent categories being the class of _local objects_ for the weak
 equivalences^[a _weak equivalence_ is a fully faithful, essentially
 surjective functor]: A category $\cC$ is univalent _precisely_ if any
 weak equivalence $H : \cA \to \cB$ induces^[by [precomposition]]
-a proper equivalence of categories $H_! : [\cB,\cC] \to [\cA,\cC]$.
+a proper equivalence of categories $- \circ H : [\cB,\cC] \to [\cA,\cC]$.
 
 [precomposition]: Cat.Instances.Functor.Compose.html
 
 The high-level overview of the proof is as follows:
 
 - For any \r{eso} $H : \cA \to \cB$, and for any $\cC$, all
-precategories, the functor $H_! : [\cA,\cB] \to [\cB,\cC]$
+precategories, the functor $- \circ H : [\cA,\cB] \to [\cB,\cC]$
 is faithful. This is the least technical part of the proof, so we do it
 first.
 
-- If $H$ is additionally full, then $H_!$ is \r{fully faithful}.
+- If $H$ is additionally full, then $- \circ H$ is \r{fully faithful}.
 
-- If $H$ is a weak equivalence, and $\cC$ is [univalent], then $H_!$
+- If $H$ is a weak equivalence, and $\cC$ is [univalent], then $- \circ H$
 is essentially surjective. By the principle of unique choice, it is an
 equivalence, and thus^[since both its domain and codomain are univalent]
 an isomorphism.
@@ -118,7 +118,7 @@ full (in addition to eso).
 eso-full→pre-ff
   : (H : Functor A B)
   → is-eso H → is-full H
-  → is-fully-faithful {C = Cat[ B , C ]} (H !)
+  → is-fully-faithful {C = Cat[ B , C ]} (precompose H)
 eso-full→pre-ff {A = A} {B = B} {C = C} H H-eso H-full = res where
 ```
 
@@ -271,7 +271,7 @@ together into a natural transformation. And since we defined $\delta$
 parametrically over the choice of essential fibre, if we're looking at
 some $Hb$, then we can choose the _identity_ isomorphism, from which it
 falls out that $\delta H = \gamma$. Since we had already established that
-$H_!$ is faithful, and now we've shown it is full, it is fully faithful.
+$- \circ H$ is faithful, and now we've shown it is full, it is fully faithful.
 
 ```agda
     δ : F => G
@@ -282,7 +282,7 @@ $H_!$ is faithful, and now we've shown it is full, it is fully faithful.
       (λ _ _ → C.Hom-set _ _ _ _)
       (λ (a′ , h′) (a , h) → naturality f a a′ h h′) (H-eso b′) (H-eso b)
 
-  full : is-full (H !)
+  full : is-full (precompose H)
   full {x = x} {y = y} γ = pure (δ _ _ γ , Nat-path p) where
     p : ∀ b → δ _ _ γ .η (H.₀ b) ≡ γ .η b
     p b = subst
@@ -291,8 +291,8 @@ $H_!$ is faithful, and now we've shown it is full, it is fully faithful.
       (squash (inc (b , B.id-iso)) (H-eso (H.₀ b)))
       (C.eliml (y .F-id) ∙ C.elimr (x .F-id))
 
-  res : is-fully-faithful (H !)
-  res = full+faithful→ff (H !) full λ {F} {G} {γ} {δ} p →
+  res : is-fully-faithful (precompose H)
+  res = full+faithful→ff (precompose H) full λ {F} {G} {γ} {δ} p →
     eso→pre-faithful H H-eso γ δ λ b → p ηₚ b
 ```
 
@@ -300,7 +300,7 @@ $H_!$ is faithful, and now we've shown it is full, it is fully faithful.
 
 The rest of the proof proceeds in this same way: Define a type which
 characterises, up to a compatible space of choices, first the action on
-morphisms of a functor which inverts $H_!$, and in terms of this type,
+morphisms of a functor which inverts $- \circ H$, and in terms of this type,
 the action on morphisms. It's mostly the same trick as above, but a
 _lot_ wilder. We do not comment on it too extensively: the curious
 reader, again, can load this file in Agda and play around.
@@ -612,16 +612,16 @@ hubris, invoke a lot of technical lemmas about the characterisation of
 ```
 
 Since we've shown that $GH = F$, so in particular $GH \cong F$, we've
-now put together proofs that $H_!$ is fully faithful and, since the
+now put together proofs that $- \circ H$ is fully faithful and, since the
 construction above works for any $F$, essentially surjective. Even
 better, since we've actually _constructed_ a functor $G$, we've shown
-that $H_!$ is **split** essentially surjective! Since $[-,\cC]$ is
+that $- \circ H$ is **split** essentially surjective! Since $[-,\cC]$ is
 univalent whenever $\cC$ is, the splitting would be automatic, but
 this is a nice strengthening.
 
 ```agda
-  weak-equiv→pre-equiv : is-equivalence {C = Cat[ B , C ]} (H !)
-  weak-equiv→pre-equiv = ff+split-eso→is-equivalence {F = H !}
+  weak-equiv→pre-equiv : is-equivalence {C = Cat[ B , C ]} (precompose H)
+  weak-equiv→pre-equiv = ff+split-eso→is-equivalence {F = precompose H}
     (eso-full→pre-ff H H-eso λ g → inc (H.from g , H.ε g))
     λ F → G F , path→iso (correct F)
 ```
@@ -631,13 +631,13 @@ isomorphism of categories, we also have that the rule sending $F$ to its
 $G$ is an equivalence of types.
 
 ```agda
-  weak-equiv→pre-iso : is-precat-iso {C = Cat[ B , C ]} (H !)
-  weak-equiv→pre-iso = is-equivalence→is-precat-iso (H !) weak-equiv→pre-equiv
+  weak-equiv→pre-iso : is-precat-iso {C = Cat[ B , C ]} (precompose H)
+  weak-equiv→pre-iso = is-equivalence→is-precat-iso (precompose H) weak-equiv→pre-equiv
     (Functor-is-category c-cat)
     (Functor-is-category c-cat)
 ```
 
-Restating the result that $H_!$ acts on objects as an equivalence of
+Restating the result that $- \circ H$ acts on objects as an equivalence of
 types, we have the following result: If $R : \cC \to \cC^+$ is a
 weak equivalence (a fully faithful and essentially surjective functor),
 then for any category $\cD$ and functor $G : \cC \to \cD$,

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -88,7 +88,7 @@ foldl f x (a ∷ as) = foldl f (f x a) as
 
 ## Functorial action
 
-It's also possible to list a function `A → B` to a function `List A →
+It's also possible to lift a function `A → B` to a function `List A →
 List B`.
 
 ```agda

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -433,10 +433,13 @@ About Kan extensions:
 
 ```agda
 open import Cat.Functor.Kan.Base -- Kan extensions
+open import Cat.Functor.Kan.Duality -- Left and right extensions are dual
 open import Cat.Functor.Kan.Nerve -- The nerve/realisation adjunction
 open import Cat.Functor.Kan.Global -- Global Kan extensions
+open import Cat.Functor.Kan.Adjoint -- Adjoints are Kan extensions
 open import Cat.Functor.Kan.Pointwise -- Pointwise Kan extensions
 open import Cat.Functor.Kan.Unique -- Uniqueness of Kan extensions
+open import Cat.Functor.Kan.Representable -- Kan extensions as Hom isomorphisms
 ```
 
 Properties of Hom-functors, and (direct) consequences of the Yoneda


### PR DESCRIPTION
An adjunction $L ⊣ R$ induces an adjunction $- ∘ R ⊣ - ∘ L$ between precomposition functors, which means that

- $L$ has left Kan extensions given by precomposition with $R$
- $R$ has right Kan extensions given by precomposition with $L$

(There's also a "dual duality" with Kan *lifts* and postcomposition, but we don't have those yet.)

This is an IMO more intuitive rephrasing of the fact that [adjoints are **absolute** Kan extensions](https://ncatlab.org/nlab/show/adjoint+functor#in_terms_of_kan_extensionsliftings), but I couldn't find it anywhere (didn't look very hard).

**Notation issue**: from what I can tell, $f^\*$ usually denotes morphisms that are "flipped" with respect to $f$ whereas $f_!$ and $f_\*$ denote morphisms in the same direction. For example, the nlab page on [Kan extensions](https://ncatlab.org/nlab/show/Kan+extension#OrdinaryKanExtensions) uses $p^\*$ for the precomposition functor $[C', D] \to [C, D]$ and $p_!$ for its left adjoint. The 1lab seems to do the [opposite](https://1lab.dev/Cat.Instances.Functor.Compose.html#functoriality-of-functor-composition), which is a bit confusing. I think we should at least swap them, or just get rid of this confusing convention and call them `_∘-` and `-∘_`.

## Checklist

Before submitting a merge request, please check the items below:

- [ ] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)
  (They weren't before)

- [X] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [X] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.