### PR TITLE
chore: bump Agda

### DIFF
--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -300,24 +300,30 @@ postulate
   commitTC         : TC ⊤
   isMacro          : Name → TC Bool
 
-  -- If the argument is 'true' makes the following primitives also normalise
-  -- their results: inferType, checkType, quoteTC, getType, and getContext
-  withNormalisation : ∀ {a} {A : Type a} → Bool → TC A → TC A
-
-  -- Makes the following primitives to reconstruct hidden arguments
-  -- getDefinition, normalise, reduce, inferType, checkType and getContext
-  withReconstructed : ∀ {a} {A : Type a} → TC A → TC A
-
   formatErrorParts : List ErrorPart → TC String
+
   -- Prints the third argument if the corresponding verbosity level is turned
   -- on (with the -v flag to Agda).
   debugPrint : String → Nat → List ErrorPart → TC ⊤
 
-  -- Only allow reduction of specific definitions while executing the TC computation
-  onlyReduceDefs : ∀ {a} {A : Type a} → List Name → TC A → TC A
+  -- If 'true', makes the following primitives also normalise
+  -- their results: inferType, checkType, quoteTC, getType, and getContext
+  withNormalisation : ∀ {a} {A : Type a} → Bool → TC A → TC A
+  askNormalisation  : TC Bool
 
-  -- Don't allow reduction of specific definitions while executing the TC computation
-  dontReduceDefs : ∀ {a} {A : Type a} → List Name → TC A → TC A
+  -- If 'true', makes the following primitives to reconstruct hidden arguments:
+  -- getDefinition, normalise, reduce, inferType, checkType and getContext
+  withReconstructed : ∀ {a} {A : Type a} → Bool → TC A → TC A
+  askReconstructed  : TC Bool
+
+  -- Whether implicit arguments at the end should be turned into metavariables
+  withExpandLast : ∀ {a} {A : Type a} → Bool → TC A → TC A
+  askExpandLast  : TC Bool
+
+  -- White/blacklist specific definitions for reduction while executing the TC computation
+  -- 'true' for whitelist, 'false' for blacklist
+  withReduceDefs : ∀ {a} {A : Type a} → (Σ Bool λ _ → List Name) → TC A → TC A
+  askReduceDefs  : TC (Σ Bool λ _ → List Name)
 
   -- Fail if the given computation gives rise to new, unsolved
   -- "blocking" constraints.
@@ -416,9 +422,13 @@ postulate
 {-# BUILTIN AGDATCMWITHNORMALISATION          withNormalisation          #-}
 {-# BUILTIN AGDATCMFORMATERRORPARTS           formatErrorParts           #-}
 {-# BUILTIN AGDATCMDEBUGPRINT                 debugPrint                 #-}
-{-# BUILTIN AGDATCMONLYREDUCEDEFS             onlyReduceDefs             #-}
-{-# BUILTIN AGDATCMDONTREDUCEDEFS             dontReduceDefs             #-}
-{-# BUILTIN AGDATCMWITHRECONSPARAMS           withReconstructed          #-}
+{-# BUILTIN AGDATCMWITHRECONSTRUCTED          withReconstructed          #-}
+{-# BUILTIN AGDATCMWITHEXPANDLAST             withExpandLast             #-}
+{-# BUILTIN AGDATCMWITHREDUCEDEFS             withReduceDefs             #-}
+{-# BUILTIN AGDATCMASKNORMALISATION           askNormalisation           #-}
+{-# BUILTIN AGDATCMASKRECONSTRUCTED           askReconstructed           #-}
+{-# BUILTIN AGDATCMASKEXPANDLAST              askExpandLast              #-}
+{-# BUILTIN AGDATCMASKREDUCEDEFS              askReduceDefs              #-}
 {-# BUILTIN AGDATCMNOCONSTRAINTS              noConstraints              #-}
 {-# BUILTIN AGDATCMRUNSPECULATIVE             runSpeculative             #-}
 {-# BUILTIN AGDATCMGETINSTANCES               getInstances               #-}

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -164,7 +164,7 @@ private
   -- decompose-is-hlevel′.
   decompose-is-hlevel : Term → TC (Term × Term)
   decompose-is-hlevel goal = do
-    ty ← dontReduceDefs hlevel-types $ inferType goal >>= reduce
+    ty ← withReduceDefs (false , hlevel-types) $ inferType goal >>= reduce
     decompose-is-hlevel′ ty
 
   decompose-is-hlevel′ ty = do
@@ -307,7 +307,7 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ′ n) w works.
           -- Note that, since getInstances works by creating a new meta,
           -- we have to commit to the instance ourselves.
           unify solved x
-          dontReduceDefs (quote hlevel ∷ []) $ withReconstructed $
+          withReduceDefs (false , quote hlevel ∷ []) $ withReconstructed true $
             unify goal (def (quote hlevel) (lv v∷ []))
           pure (tt , true)
 
@@ -555,7 +555,8 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ′ n) w works.
     → Term → TC (Term × Term × (TC A → TC A) × (Term → Term))
   decompose-is-hlevel-top goal =
     do
-      ty ← dontReduceDefs hlevel-types $ (inferType goal >>= reduce) >>= wait-just-a-bit
+      ty ← withReduceDefs (false , hlevel-types) $
+        (inferType goal >>= reduce) >>= wait-just-a-bit
       go ty
     where
       go : Term → TC _
@@ -570,7 +571,7 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ′ n) w works.
 -- top-level goal type and enters the search loop.
 hlevel-tactic-worker : Term → TC ⊤
 hlevel-tactic-worker goal = do
-  ty ← dontReduceDefs hlevel-types $ inferType goal >>= reduce
+  ty ← withReduceDefs (false , hlevel-types) $ inferType goal >>= reduce
   (ty , lv , enter , leave) ← decompose-is-hlevel-top goal <|>
     typeError
       ( "hlevel tactic: goal type is not of the form ``is-hlevel A n'':\n"

--- a/src/1Lab/Reflection/Solver.agda
+++ b/src/1Lab/Reflection/Solver.agda
@@ -53,7 +53,7 @@ module _ (solver : SimpleSolver) where
   mk-simple-solver : Term → TC ⊤
   mk-simple-solver hole =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     goal ← inferType hole >>= reduce
     just (lhs , rhs) ← get-boundary goal
       where nothing → typeError $ strErr "Can't determine boundary: " ∷
@@ -65,14 +65,14 @@ module _ (solver : SimpleSolver) where
   mk-simple-normalise : Term → Term → TC ⊤
   mk-simple-normalise tm hole =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     e ← normalise tm >>= build-expr
     unify hole (invoke-normaliser e)
 
   mk-simple-repr : Term → TC ⊤
   mk-simple-repr tm =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     repr ← normalise tm >>= build-expr
     print-repr tm repr
 
@@ -93,7 +93,7 @@ module _ {ℓ} {A : Type ℓ} (solver : VariableSolver A) where
   mk-var-solver : Term → TC ⊤
   mk-var-solver hole =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     goal ← inferType hole >>= reduce
     just (lhs , rhs) ← get-boundary goal
       where nothing → typeError $ strErr "Can't determine boundary: " ∷
@@ -110,7 +110,7 @@ module _ {ℓ} {A : Type ℓ} (solver : VariableSolver A) where
   mk-var-normalise : Term → Term → TC ⊤
   mk-var-normalise tm hole =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     e , vs ← normalise tm >>= build-expr empty-vars
     size , env ← environment vs
     soln ← reduce (invoke-normaliser e env)
@@ -119,7 +119,7 @@ module _ {ℓ} {A : Type ℓ} (solver : VariableSolver A) where
   mk-var-repr : Term → TC ⊤
   mk-var-repr tm =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     repr , vs ← normalise tm >>= build-expr empty-vars
     size , env ← environment vs
     print-var-repr tm repr env

--- a/src/Cat/Diagram/Monad/Solver.agda
+++ b/src/Cat/Diagram/Monad/Solver.agda
@@ -299,7 +299,7 @@ module Reflection where
   solve-macro : ∀ {o h} {𝒞 : Precategory o h} → Monad 𝒞 → Term → TC ⊤
   solve-macro monad hole =
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
       monad-tm ← quoteTC monad
       goal ← inferType hole >>= reduce
       just (lhs , rhs) ← get-boundary goal

--- a/src/Cat/Diagram/Product/Solver.lagda.md
+++ b/src/Cat/Diagram/Product/Solver.lagda.md
@@ -398,10 +398,9 @@ If we don't do this, Agda will get *very* upset.
     con (quote NbE.Expr.‶_‶) (f v∷ [])
 ```
 
-Now, for the solver interface. This follows the usual pattern:
-we create a list of names that we will pass to `dontReduceDefs`{.Agda},
-which will prevent Agda from normalizing away the things we want to
-reflect upon.
+Now, for the solver interface. This follows the usual pattern: we create
+a list of names that we will pass to `withReduceDefs`{.Agda}, which will
+prevent Agda from normalizing away the things we want to reflect upon.
 
 ```agda
   dont-reduce : List Name
@@ -433,9 +432,9 @@ want to examine the exact quoted representations of objects/homs.
 ```agda
   obj-repr-macro : ∀ {o ℓ} (𝒞 : Precategory o ℓ) (cartesian : ∀ X Y → Product 𝒞 X Y) → Term → Term → TC ⊤
   obj-repr-macro cat cart hom hole =
-    withReconstructed $
+    withReconstructed true $
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     (x , y) ← get-objects hom
     “x” ← build-obj-expr <$> normalise x
     “y” ← build-obj-expr <$> normalise y
@@ -447,9 +446,9 @@ want to examine the exact quoted representations of objects/homs.
 
   hom-repr-macro : ∀ {o ℓ} (𝒞 : Precategory o ℓ) (cartesian : ∀ X Y → Product 𝒞 X Y) → Term → Term → TC ⊤
   hom-repr-macro cat cart hom hole =
-    withReconstructed $
+    withReconstructed true $
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     (x , y) ← get-objects hom
     “x” ← build-obj-expr <$> normalise x
     “y” ← build-obj-expr <$> normalise y
@@ -475,9 +474,9 @@ with their actual values, which then fixes the issue.
 ```agda
   simpl-macro : ∀ {o ℓ} (𝒞 : Precategory o ℓ) (cartesian : ∀ X Y → Product 𝒞 X Y) → Term → Term → TC ⊤
   simpl-macro cat cart hom hole =
-    withReconstructed $
+    withReconstructed true $
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     (x , y) ← get-objects hom
     “x” ← build-obj-expr <$> normalise x
     “y” ← build-obj-expr <$> normalise y
@@ -489,9 +488,9 @@ with their actual values, which then fixes the issue.
   solve-macro : ∀ {o ℓ} (𝒞 : Precategory o ℓ) (cartesian : ∀ X Y → Product 𝒞 X Y) → Term → TC ⊤
   solve-macro cat cart hole =
     noConstraints $
-    withReconstructed $
+    withReconstructed true $
     withNormalisation false $
-    dontReduceDefs dont-reduce $ do
+    withReduceDefs (false , dont-reduce) $ do
     goal ← inferType hole >>= reduce
     just (lhs , rhs) ← get-boundary goal
       where nothing → typeError $ strErr "Can't determine boundary: " ∷

--- a/src/Cat/Functor/Solver.agda
+++ b/src/Cat/Functor/Solver.agda
@@ -185,7 +185,7 @@ module Reflection where
   solve-macro : ∀ {o h o′ h′} {𝒞 : Precategory o h} {𝒟 : Precategory o′ h′} → Functor 𝒞 𝒟 → Term → TC ⊤
   solve-macro functor hole =
    withNormalisation false $
-   dontReduceDefs dont-reduce $ do
+   withReduceDefs (false , dont-reduce) $ do
      functor-tm ← quoteTC functor
      goal ← inferType hole >>= reduce
      just (lhs , rhs) ← get-boundary goal

--- a/src/Data/Image.lagda.md
+++ b/src/Data/Image.lagda.md
@@ -1,4 +1,5 @@
 ```agda
+{-# OPTIONS -vtc.def:10 -vtc.ip.boundary:30 #-}
 open import 1Lab.Prelude
 
 open import Data.Id.Base
@@ -286,7 +287,7 @@ first step, and deal only with untruncated data from then on.
       p
     where
       work′ : (f⁻¹x : A) → is-contr (fibre Image→image (f f⁻¹x , inc (_ , refl)))
-      work′ f⁻¹x .centre = inc f⁻¹x , refl
+      work′ f⁻¹x .centre = inc f⁻¹x , refl -- inc f⁻¹x , refl
 ```
 
 Contracting the fibres is where we get some mileage out of having gotten
@@ -298,5 +299,5 @@ what we need.
 ```agda
       work′ f⁻¹x .paths (i , α) = Σ-pathp (quot (ls.from (sym (ap fst α)))) $
         Σ-prop-square (λ _ → squash) $ commutes→square $
-        ap₂ _∙_ (ls.ε _) refl ∙ ∙-inv-l _ ∙ sym (∙-id-l _)
+          (ap₂ _∙_ (ls.ε (sym (ap fst α))) refl ∙ ∙-inv-l _ ∙ sym (∙-id-l _))
 ```

--- a/src/Data/Nat/Solver.lagda.md
+++ b/src/Data/Nat/Solver.lagda.md
@@ -561,7 +561,7 @@ Now, the actual reflection API calls. In order to keep drawing this file
 out, we start by defining some useful debugging macros. As we noted a
 looong time ago, we don't want to unfold the `_+_`{.Agda} or
 `_*_`{.Agda} functions, so let's make a list of those names so that we
-can call `dontReduceDefs`{.Agda} more easily.
+can call `withReduceDefs`{.Agda} more easily.
 
 ```agda
 private
@@ -576,7 +576,7 @@ expression of type `Nat`. This is _very_ useful when we are debugging.
 repr-macro : Nat → Term → TC ⊤
 repr-macro n hole =
   withNormalisation false $
-  dontReduceDefs don't-reduce $ do
+  withReduceDefs (false , don't-reduce) $ do
   tm ← quoteTC n
   e , vs ← build-expr empty-vars tm
   size , env ← environment vs
@@ -603,7 +603,7 @@ which is bound to `C-c RET` by default.
 expand-macro : Nat → Term → TC ⊤
 expand-macro n hole =
   withNormalisation false $
-  dontReduceDefs don't-reduce $ do
+  withReduceDefs (false , don't-reduce) $ do
   tm ← quoteTC n
   e , vs ← build-expr empty-vars tm
   size , env ← environment vs
@@ -622,7 +622,7 @@ to automatically solve equations involving natural numbers.
 solve-macro : Term → TC ⊤
 solve-macro hole =
   withNormalisation false $
-  dontReduceDefs don't-reduce $ do
+  withReduceDefs (false , don't-reduce) $ do
   goal ← inferType hole >>= reduce
 
   just (lhs , rhs) ← get-boundary goal

--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -3,6 +3,6 @@
   "repo": "agda",
   "branch": "master",
   "private": false,
-  "rev": "71a6396ba727768910ed48e2da910532fdb66a63",
-  "sha256": "141dk2isfjjb45794cs1jdisxd3ll2vxj7l7a80qf6j2lk8pk7i5"
+  "rev": "8717a7189996410213efb1ef45342a2c77ad5657",
+  "sha256": "1pq9p033wqc72mz7ai4f32nfwryd64ahb03a12agb0sa5r8ax05b"
 }


### PR DESCRIPTION
Diff: https://github.com/agda/agda/compare/71a6396ba727768910ed48e2da910532fdb66a63...8717a7189996410213efb1ef45342a2c77ad5657

- New reflection interface for TCEnv bits and bobs https://github.com/agda/agda/commit/1c4731fb8dbc85d2482aa0b32c6dfa7aa9e37bcb
- Implicit argument puns https://github.com/agda/agda/commit/6c7d9d08417d74b99a29af24ac787f979bae4f16
- New instance search semantics https://github.com/agda/agda/commit/2af2ff114d167d9931034ca16d1bf6ba04efe661
- Interaction point boundaries https://github.com/agda/agda/commit/75b64295ef751545bd61aa645e684c5c7080cf73

Most relevant for us are the new reflection interface (I had to fix some stuff) and the implicit argument puns, I think — though the new instance search code should improve error messages in `do` blocks significantly, at least if I understand it correctly. `LevelUniv` was also added in that span, but that's incompatible with cubical ATM, and it's definitely incompatible with some of our weirder level things.