### PR TITLE
chore: bump agda

### DIFF
--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -3,6 +3,6 @@
   "repo": "agda",
   "branch": "master",
   "private": false,
-  "rev": "8717a7189996410213efb1ef45342a2c77ad5657",
-  "sha256": "1pq9p033wqc72mz7ai4f32nfwryd64ahb03a12agb0sa5r8ax05b"
+  "rev": "e18f853cbfbc25ee454a26b787da9b8bbe78da74",
+  "sha256": "1rx3z7mfwnx4d2vi8lfmfpxhln9i3jfma76zls7774mvw0l8yrdb"
 }


### PR DESCRIPTION
all internal changes this time (comparison: https://github.com/agda/agda/compare/8717a7189996410213efb1ef45342a2c77ad5657...e18f853cbfbc25ee454a26b787da9b8bbe78da74). bumping mainly because i want the fixed printing of extended lambdas on higher inductives. also includes @SquidDev's improvements to the serialisation machinery.