### PR TITLE
Generalise regularity tactic

### DIFF
--- a/src/1Lab/Equiv/Embedding.lagda.md
+++ b/src/1Lab/Equiv/Embedding.lagda.md
@@ -50,7 +50,7 @@ To develop this correspondence, we note that, if a map is
 `injective`{.Agda} and its codomain is a [set], then all the
 `fibres`{.Agda} $f^*(x)$ of $f$ are [propositions].
 
-[sets]: 1Lab.HLevel.html#is-set
+[set]: 1Lab.HLevel.html#is-set
 [propositions]: 1Lab.HLevel.html#is-prop
 
 ```agda

--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -470,6 +470,11 @@ Fun A B = A → B
 idfun : ∀ {ℓ} (A : Type ℓ) → A → A
 idfun A x = x
 
+underAbs : ∀ {ℓ} {A : Type ℓ} → Term → TC A → TC A
+underAbs (lam v (abs nm _)) m = extendContext nm (arg (arginfo v (modality relevant quantity-ω)) unknown) m
+underAbs (pi a (abs nm _)) m = extendContext nm a m
+underAbs _ m = m
+
 new-meta : Term → TC Term
 new-meta ty = do
   mv ← checkType unknown ty
@@ -582,10 +587,10 @@ unapply-path red@(def (quote PathP) (l h∷ T v∷ x v∷ y v∷ [])) = do
   pure (just (domain , x , y))
 unapply-path tm = reduce tm >>= λ where
   tm@(meta _ _) → do
-    dom ← new-meta (def (quote Type) [])
+    dom ← new-meta (def (quote Type) (unknown v∷ []))
     l ← new-meta dom
     r ← new-meta dom
-    unify tm (def (quote Type) [ argN dom , argN l , argN r ])
+    unify tm (def (quote Path) (dom v∷ l v∷ r v∷ []))
     traverse wait-for-type (l ∷ r ∷ [])
     pure (just (dom , l , r))
   red@(def (quote PathP) (l h∷ T v∷ x v∷ y v∷ [])) → do

--- a/src/Cat/Displayed/Instances/Diagrams.lagda.md
+++ b/src/Cat/Displayed/Instances/Diagrams.lagda.md
@@ -186,33 +186,9 @@ functor categories $[\cJ, \cE_x]$.
   Fibrewise-diagram : ∀ {x} → Functor Cat[ J , Fibre E x ] (Fibre (Diagrams J) x)
   Fibrewise-diagram .F₀ = Diagram→ConstL
   Fibrewise-diagram .F₁ = Diagram-nat→ConstL-natl
+  Fibrewise-diagram .F-id = Nat-lift-pathp λ _ → sym Regularity.reduce!
+  Fibrewise-diagram .F-∘ _ _ = Nat-lift-pathp λ _ → sym Regularity.reduce!
 ```
-
-<details>
-<summary>The proof of functoriality is a nightmare of transports; only
-the brave should expand out the details.
-</summary>
-
-```agda
-  Fibrewise-diagram {x} .F-id {F} = Nat-lift-pathp λ jx i →
-    transp (λ j →
-      Hom[ id ] (F .F₀
-        (transp (λ _ → J.Ob) (~ i ∨ j) jx))
-        (F .F₀ (transp (λ _ → J.Ob) (~ i ∨ j) jx )))
-      (~ i) id′
-  Fibrewise-diagram .F-∘ {F} {G} {H} f g = Nat-lift-pathp λ jx i →
-    transp (λ j → Hom[ idl id j ]
-      (F .F₀ (transp (λ _ → J.Ob) (~ i ∨ j) jx))
-      (H .F₀ (transp (λ _ → J.Ob) (~ i ∨ j) jx)))
-      i0
-      (transp (λ j → Hom[ id ∘ id ]
-          (F .F₀ (transp (λ _ → J.Ob) (~ i ∨ j) (transp (λ _ → J.Ob) (~ i) jx)))
-          (H .F₀ (transp (λ _ → J.Ob) (~ i ∨ j) (transp (λ _ → J.Ob) (~ i) jx))))
-        (~ i)
-        (f .η (transp (λ _ → J.Ob) (~ i) (transp (λ _ → J.Ob) (~ i) jx))
-         ∘′ g .η (transp (λ _ → J.Ob) (~ i) (transp (λ _ → J.Ob) (~ i) jx))))
-```
-</details>
 
 Again, this isomorphism is *almost* definitional.
 

--- a/src/Cat/Instances/Functor/Duality.lagda.md
+++ b/src/Cat/Instances/Functor/Duality.lagda.md
@@ -67,26 +67,10 @@ op-functor← : Functor Cat[ C ^op , D ^op ] (Cat[ C , D ] ^op)
 op-functor← = is-equivalence.F⁻¹ op-functor-is-equiv
 
 op-functor←→ : op-functor← {C = C} {D = D} F∘ op-functor→ ≡ Id
-op-functor←→ {C = C} {D = D} = Functor-path (λ x → refl) λ {X} {Y} f → Nat-path λ x →
-  (_ D.∘ f .η x) D.∘ _ ≡⟨ D.elimr (lemma {Y = Y}) ⟩
-  _ D.∘ f .η x         ≡⟨ D.eliml (lemma {Y = X}) ⟩
-  f .η x               ∎
+op-functor←→ {C = C} {D = D} = Functor-path (λ _ → refl) λ f → Nat-path λ x →
+  Regularity.precise! ((D.id D.∘ f .η x) D.∘ D.id ≡⟨ cat! D ⟩ f .η x ∎)
   where
     module D = Cat.Reasoning D
-    module C = Cat.Reasoning C
-
-    lemma : ∀ {Y : Functor C D} {x}
-      → coe0→1 (λ i → D.Hom (F₀ Y (transp (λ j → C.Ob) i x)) (F₀ Y (transp (λ j → C.Ob) i x))) D.id
-      ≡ D.id
-    lemma {Y} {x} =
-      from-pathp {A = λ i → D.Hom (F₀ Y (transp (λ j → C.Ob) i x)) (F₀ Y (transp (λ j → C.Ob) i x))}
-        λ i → hcomp (∂ i) λ where
-          j (i = i0) → D.id
-          j (i = i1) → transport-filler (λ j → D.Hom (F₀ Y x) (F₀ Y x)) D.id (~ j)
-          j (j = i0) → coe0→i
-            (λ j → D.Hom (F₀ Y (transp (λ j → C.Ob) (i ∨ j) x))
-                         (F₀ Y (transp (λ j → C.Ob) (i ∨ j) x)))
-            i D.id
 
 module _ {o ℓ o′ ℓ′} {C : Precategory o ℓ} {D : Precategory o′ ℓ′} {F G : Functor C D} where
   private

--- a/src/Cat/Instances/Poly.lagda.md
+++ b/src/Cat/Instances/Poly.lagda.md
@@ -24,6 +24,7 @@ module Cat.Instances.Poly where
 <!--
 ```agda
 open Functor
+open Total-hom
 ```
 -->
 
@@ -72,6 +73,20 @@ poly-maps : ∀ {ℓ} {A B} → Iso
   (Poly.Hom {ℓ} A B)
   (Σ[ f ∈ (⌞ A ⌟ → ⌞ B ⌟) ] ∀ x → ∣ B .snd (f x) ∣ → ∣ A .snd x ∣)
 unquoteDef poly-maps = define-record-iso poly-maps (quote Total-hom)
+```
+
+We also derive a convenient characterisation of paths between $\thecat{Poly}$ morphisms
+using regularity:
+
+```agda
+poly-map-path
+  : ∀ {ℓ A B} {f g : Poly.Hom {ℓ} A B}
+  → (hom≡ : f .hom ≡ g .hom)
+  → (pre≡ : ∀ a b → f .preserves a (subst (λ hom → ∣ B .snd (hom a) ∣) (sym hom≡) b)
+                  ≡ g .preserves a b)
+  → f ≡ g
+poly-map-path hom≡ pre≡ = total-hom-path _ hom≡
+  (to-pathp (funext λ a → funext λ b → Regularity.precise! (pre≡ a b)))
 ```
 
 ## Polynomials as functors

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -711,8 +711,11 @@ open import Cat.Displayed.Instances.Identity
 ```
 
 ### Structures in Fibrations
+
+```agda
 open import Cat.Displayed.InternalSum
 -- The fibred equivalent of sigma types and existential quantifiers
+```
 
 ## Bicategories
 


### PR DESCRIPTION
Inspired by a [question](https://agda.zulipchat.com/#narrow/stream/260790-cubical/topic/How.20to.20prove.20equality.20of.20subst'ed.20dependent.20functions.3F/near/351670006) on the Agda Zulip.

Remove the restriction that `φ = i0`, so that the tactic works on general `transp` applications.

This allows proving a characterisation of paths between Poly maps, which involves a nasty goal with nested `transp`s that the tactic previously couldn't solve.