### PR TITLE
Show commented-out code

### DIFF
--- a/support/shake/app/Shake/LinkReferences.hs
+++ b/support/shake/app/Shake/LinkReferences.hs
@@ -56,13 +56,10 @@ data Reference =
 parseSymbolRefs :: [Block] -> HashMap Text Reference
 parseSymbolRefs = go mempty . concatMap getHTML where
   getHTML :: Block -> [Tag Text]
-  getHTML (RawBlock "html" xs) = parseTags xs >>= parseTags'
+  getHTML (RawBlock "html" xs) = parseTags xs
   getHTML (BlockQuote bs) = bs >>= getHTML
   getHTML (Div _ bs) = bs >>= getHTML
   getHTML _ = []
-
-  parseTags' (TagComment x) = parseTags x >>= parseTags'
-  parseTags' t = pure t
 
   go :: HashMap Text Reference -> [Tag Text] -> HashMap Text Reference
   go map (TagOpen "a" meta:TagText t:TagClose "a":xs)

--- a/support/web/css/default.scss
+++ b/support/web/css/default.scss
@@ -427,6 +427,20 @@ details.text {
   }
 }
 
+.commented-out {
+  display: none;
+  opacity: 0.6;
+}
+
+.commented-out > pre.Agda {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+body.show-hidden-code .commented-out {
+  display: revert;
+}
+
 
 div.profile {
   &.pfp-left {

--- a/support/web/js/equations.ts
+++ b/support/web/js/equations.ts
@@ -79,6 +79,34 @@ window.addEventListener("DOMContentLoaded", () => {
       saveFontDisplay();
     };
   }
+
+  const showHiddenCode = document.getElementById("sidebar-hidden") as HTMLInputElement | null;
+  if (showHiddenCode) {
+    showHiddenCode.onchange = () => {
+      if (showHiddenCode.checked)
+        body.classList.add("show-hidden-code");
+      else
+        body.classList.remove("show-hidden-code");
+    };
+  }
+
+  scrollToHash();
 });
+
+window.addEventListener("hashchange", scrollToHash);
+
+function scrollToHash() {
+  if (window.location.hash != '') {
+    const id = window.location.hash.slice(1);
+    // #id doesn't work with numerical IDs
+    const elem = document.querySelector(`[id="${id}"]`) as HTMLInputElement | null;
+    const commentedOut = elem?.closest('.commented-out') as HTMLInputElement | null;
+    if (elem && commentedOut) {
+      // The element is in a commented-out block: unhide it and scroll to it.
+      commentedOut.style.display = 'revert';
+      elem.scrollIntoView();
+    }
+  }
+}
 
 export { };

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -102,6 +102,12 @@
           <input name=sidebar-fns type="checkbox" class="inline-footnotes" id=sidebar-fns>
           <label for=sidebar-fns>Inline Footnotes</label>
         </span>
+
+        <!-- Sidebar hidden code control -->
+        <span style="display: flex; align-items: center; gap: 0.25em; flex-wrap: nowrap;">
+          <input name=sidebar-hidden type="checkbox" autocomplete=off id=sidebar-hidden>
+          <label for=sidebar-hidden>Hidden Code</label>
+        </span>
       </div>
 
       <hr />


### PR DESCRIPTION
In case you couldn't [tell](https://github.com/plt-amy/1lab/pull/132), I hate dead links.

Add a checkbox that shows all commented-out code blocks. Additionally, when clicking on a link pointing to a hidden identifier, dynamically unhide the surrounding code block.