### PR TITLE
Build shakefile with default of `-A128M`

### DIFF
--- a/support/nix/build-shake.nix
+++ b/support/nix/build-shake.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ lua5_3 gmp ];
 
   buildPhase = ''
-  ghc -o ${main} app/${main} -threaded -rtsopts -iapp -O2 -split-sections -DNODE_BIN_PATH="\"${nodeDependencies}/bin\""
+  ghc -o ${main} app/${main} -threaded -with-rtsopts -A128M -rtsopts -iapp -O2 -split-sections -DNODE_BIN_PATH="\"${nodeDependencies}/bin\""
   '';
 
   installPhase = ''


### PR DESCRIPTION
This updates the GHC flags to match those uses in the cabal file, namely adding `-ATM128` to the default RTS options. This significantly reduces the time spent in GC.

We could probably set this a little lower if preferred. There are diminishing returns, so using `-A16M` gives ~44% speedup (compared with the default `-A4M`), while `-A128M` is maybe 53% faster - the numbers are a little fuzzy here.