### PR TITLE
Gaunt cats

### DIFF
--- a/src/1Lab/HLevel.lagda.md
+++ b/src/1Lab/HLevel.lagda.md
@@ -463,5 +463,13 @@ abstract
 _ : ∀ {A : Type} {a b c d : A} (p : a ≡ c) (q : a ≡ b) (s : c ≡ d) (r : b ≡ d)
   → Square p q s r ≡ SquareP (λ _ _ → A) p q s r
 _ = λ _ _ _ _ → refl
+
+is-set→cast-pathp
+  : ∀ {ℓ ℓ′} {A : Type ℓ} {x y : A} {p q : x ≡ y} (P : A → Type ℓ′) {px : P x} {py : P y}
+  → is-set A
+  → PathP (λ i → P (p i)) px py
+  → PathP (λ i → P (q i)) px py
+is-set→cast-pathp {p = p} {q = q} P {px} {py} set  r =
+  coe0→1 (λ i → PathP (λ j → P (set _ _ p q i j)) px py) r
 ```
 -->

--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -193,8 +193,8 @@ faces.
   a && b
   \arrow["p", from=1-1, to=1-3]
   \arrow["p"', from=3-1, to=3-3]
-  \arrow["{\rm{refl}}"{description}, from=1-1, to=3-1]
-  \arrow["{\rm{refl}}"{description}, from=1-3, to=3-3]
+  \arrow["{\refl}"{description}, from=1-1, to=3-1]
+  \arrow["{\refl}"{description}, from=1-3, to=3-3]
 \end{tikzcd}\]
 ~~~
 
@@ -203,8 +203,8 @@ faces.
   a && a \\
   \\
   b && b
-  \arrow["{\rm{refl}}", from=1-1, to=1-3]
-  \arrow["{\rm{refl}}"', from=3-1, to=3-3]
+  \arrow["{\refl}", from=1-1, to=1-3]
+  \arrow["{\refl}"', from=3-1, to=3-3]
   \arrow["p"{description}, from=1-1, to=3-1]
   \arrow["p"{description}, from=1-3, to=3-3]
 \end{tikzcd}\]
@@ -233,9 +233,9 @@ These correspond to the following two squares:
   a && a \\
   \\
   a && b
-  \arrow["{\rm{refl}}", from=1-1, to=1-3]
+  \arrow["{\refl}", from=1-1, to=1-3]
   \arrow["p"', from=3-1, to=3-3]
-  \arrow["{\rm{refl}}"{description}, from=1-1, to=3-1]
+  \arrow["{\refl}"{description}, from=1-1, to=3-1]
   \arrow["{p}"{description}, from=1-3, to=3-3]
 \end{tikzcd}\]
 ~~~
@@ -246,9 +246,9 @@ These correspond to the following two squares:
   \\
   b && b
   \arrow["{p}", from=1-1, to=1-3]
-  \arrow["{\rm{refl}}"', from=3-1, to=3-3]
+  \arrow["{\refl}"', from=3-1, to=3-3]
   \arrow["p"{description}, from=1-1, to=3-1]
-  \arrow["{\rm{refl}}"{description}, from=1-3, to=3-3]
+  \arrow["{\refl}"{description}, from=1-3, to=3-3]
 \end{tikzcd}\]
 ~~~
 
@@ -729,7 +729,7 @@ the interval (in fact, it is `true`{.Agda} everywhere), so we say that
 ~~~{.quiver .short-1}
 \[\begin{tikzcd}
   \textcolor{rgb,255:red,214;green,92;blue,92}{\rm{true}} && {\rm{true}}
-  \arrow["{\rm{refl}}", from=1-1, to=1-3]
+  \arrow["{\refl}", from=1-1, to=1-3]
 \end{tikzcd}\]
 ~~~
 
@@ -999,7 +999,7 @@ be reflexivity. For definiteness, we chose the left face:
   \\
   x && z
   \arrow["{p}", from=1-1, to=1-3]
-  \arrow["{\rm{refl}}"', from=1-1, to=3-1]
+  \arrow["{\refl}"', from=1-1, to=3-1]
   \arrow["{q}", from=1-3, to=3-3]
   \arrow["{p \bullet q}"', from=3-1, to=3-3, dashed]
 \end{tikzcd}\]

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -111,9 +111,9 @@ to-path-refl {r = r} {a = a} ids = ap (ap fst) $ to-path-refl-coh ids a
 
 If we have a relation $R$ together with reflexivity witness $r$, then
 any equivalence $f : R(a, b) \simeq (a \equiv b)$ which maps $f(r) =
-\rm{refl}$ equips $(R, r)$ with the structure of an identity system. Of
+\refl$ equips $(R, r)$ with the structure of an identity system. Of
 course if we do not particularly care about the specific reflexivity
-witness, we can simply define $r$ as $f^{-1}(\rm{refl})$.
+witness, we can simply define $r$ as $f^{-1}(\refl)$.
 
 ```agda
 equiv-path→identity-system

--- a/src/1Lab/Path/IdentitySystem/Strict.lagda.md
+++ b/src/1Lab/Path/IdentitySystem/Strict.lagda.md
@@ -15,47 +15,54 @@ open import Data.Dec.Base
 module 1Lab.Path.IdentitySystem.Strict where
 ```
 
+<!--
+```agda
+private variable
+  ℓ ℓ′ ℓ′′ : Level
+  A : Type ℓ′
+  R : A → A → Type ℓ′
+  r : ∀ a → R a a
+```
+-->
+
 # Strict Identity Systems
 
-[Identity systems] on `Sets`{.Agda ident=is-set} not only have their
-own J eliminator, but also have their own version of the K eliminator!
-This eliminator is normally added as an axiom to MLTT to squash any
-homotopical content, but if the type already has no higher dimensional
-structure, then we get it as a theorem.
+Since [identity systems] are a tool for classifying identity _types_,
+the relation underlying an identity system enjoys any additional
+property that the type's own identity type enjoys. As a prominent
+example, if $(R, r)$ is an identity system on a [set], then $R$
+satisfies not only J, but also K: any property $P(x)$ for $x : R(a,a)$,
+for _fixed_ $a$, follows from $P(r)$.
 
-[Identity systems]: 1Lab.Path.IdentitySystem.html
+[identity systems]: 1Lab.Path.IdentitySystem.html
+[set]: 1Lab.HLevel.html#is-set
 
-We begin by noting that if $A$ is a set equipped with an identity system
-$R, r$, then the relation $R$ must be a proposition. We do this by
-constructing a `PathP`{.Agda} from $s$ to $t$ that lies over some loop
-$b = b$, and then using the fact that $A$ is a set to contract the loop
-down to the reflexive path.
+Since $(R, r)$ is equivalent to $(\equiv_A, \refl)$, if $A$ is a set,
+then $R$ must be a proposition as well.
 
 ```agda
-strict-identity-system→is-prop
-  : ∀ {ℓ ℓ′} {A : Type ℓ} {R : A → A → Type ℓ′} {r : ∀ a → R a a} {a b : A}
+set-identity-is-prop
+  : ∀ {r : (a : A) → R a a} {a b : A}
   → is-identity-system R r
   → is-set A
   → is-prop (R a b)
-strict-identity-system→is-prop {R = R} {a = a} {b = b} ids set s t =
-  is-set→cast-pathp (λ b' → R a b') set $
-  _∙P_ {B = λ b' → R a b'} (symP (ids .to-path-over s)) (ids .to-path-over t)
+set-identity-is-prop {R = R} {a = a} {b = b} ids set =
+  is-hlevel≃ 1 (identity-system-gives-path ids) (set a b)
 ```
 
-This immediately gives us the K eliminator for an identity system over a set:
-given a family $P : A \to Type$, an element of that family at $r(a)$, and some
-$s : R(a, a)$, we can transport the $P(r(a))$ to $P(s)$, as $R$ must be a proposition.
+This immediately gives us the K eliminator for an identity system over a
+set: Given a type family $P : R(a, a) \to \ty$ and a witness $w :
+P(r(a))$, since $R(-,-)$ is a proposition, we can transport $w$ to
+$P(s)$ for an arbitrary $s : R(a,a)$.
 
 ```agda
 IdsK
-  : ∀ {ℓ ℓ′ ℓ′′} {A : Type ℓ} {R : A → A → Type ℓ′} {r : ∀ a → R a a} {a : A}
+  : {r : (a : A) → R a a} {a : A}
   → is-identity-system R r
   → is-set A
-  → (P : R a a → Type ℓ′′)
-  → P (r a)
-  → ∀ s → P s
+  → (P : R a a → Type ℓ′′) → P (r a) → ∀ s → P s
 IdsK {r = r} {a = a} ids set P pr s =
-  transport (λ i → P (strict-identity-system→is-prop ids set (r a) s i)) pr
+  transport (λ i → P (set-identity-is-prop ids set (r a) s i)) pr
 ```
 
 <!--
@@ -68,13 +75,13 @@ IdsK-refl
   → (x : P (r a))
   → IdsK ids set P x (r a) ≡ x
 IdsK-refl {R = R} {r = r} {a = a} ids set P x =
-  transport (λ i → P (strict-identity-system→is-prop ids set (r a) (r a) i)) x ≡⟨⟩
-  subst P (strict-identity-system→is-prop ids set (r a) (r a)) x               ≡⟨ ap (λ ϕ → subst P ϕ x) lemma ⟩
-  transport (λ i → P (r a)) x                                                  ≡⟨ transport-refl x ⟩
+  transport (λ i → P (set-identity-is-prop ids set (r a) (r a) i)) x ≡⟨⟩
+  subst P (set-identity-is-prop ids set (r a) (r a)) x               ≡⟨ ap (λ ϕ → subst P ϕ x) lemma ⟩
+  transport (λ i → P (r a)) x                                        ≡⟨ transport-refl x ⟩
   x ∎
   where
-    lemma : strict-identity-system→is-prop ids set (r a) (r a) ≡ refl
-    lemma = is-prop→is-set (strict-identity-system→is-prop ids set) (r a) (r a) _ _
+    lemma : set-identity-is-prop ids set (r a) (r a) ≡ refl
+    lemma = is-prop→is-set (set-identity-is-prop ids set) (r a) (r a) _ _
 ```
 -->
 
@@ -94,6 +101,6 @@ module StrictIds
 
   instance
     R-H-level : ∀ {a b} {n} → H-Level (R a b) (1 + n)
-    R-H-level = prop-instance (strict-identity-system→is-prop ids set)
+    R-H-level = prop-instance (set-identity-is-prop ids set)
 ```
 -->

--- a/src/1Lab/Path/IdentitySystem/Strict.lagda.md
+++ b/src/1Lab/Path/IdentitySystem/Strict.lagda.md
@@ -1,0 +1,99 @@
+<!--
+```agda
+open import 1Lab.Path.IdentitySystem
+open import 1Lab.HLevel.Retracts
+open import 1Lab.HLevel
+open import 1Lab.Equiv
+open import 1Lab.Path
+open import 1Lab.Type
+
+open import Data.Dec.Base
+```
+-->
+
+```agda
+module 1Lab.Path.IdentitySystem.Strict where
+```
+
+# Strict Identity Systems
+
+[Identity systems] on `Sets`{.Agda ident=is-set} not only have their
+own J eliminator, but also have their own version of the K eliminator!
+This eliminator is normally added as an axiom to MLTT to squash any
+homotopical content, but if the type already has no higher dimensional
+structure, then we get it as a theorem.
+
+[Identity systems]: 1Lab.Path.IdentitySystem.html
+
+We begin by noting that if $A$ is a set equipped with an identity system
+$R, r$, then the relation $R$ must be a proposition. We do this by
+constructing a `PathP`{.Agda} from $s$ to $t$ that lies over some loop
+$b = b$, and then using the fact that $A$ is a set to contract the loop
+down to the reflexive path.
+
+```agda
+strict-identity-system→is-prop
+  : ∀ {ℓ ℓ′} {A : Type ℓ} {R : A → A → Type ℓ′} {r : ∀ a → R a a} {a b : A}
+  → is-identity-system R r
+  → is-set A
+  → is-prop (R a b)
+strict-identity-system→is-prop {R = R} {a = a} {b = b} ids set s t =
+  is-set→cast-pathp (λ b' → R a b') set $
+  _∙P_ {B = λ b' → R a b'} (symP (ids .to-path-over s)) (ids .to-path-over t)
+```
+
+This immediately gives us the K eliminator for an identity system over a set:
+given a family $P : A \to Type$, an element of that family at $r(a)$, and some
+$s : R(a, a)$, we can transport the $P(r(a))$ to $P(s)$, as $R$ must be a proposition.
+
+```agda
+IdsK
+  : ∀ {ℓ ℓ′ ℓ′′} {A : Type ℓ} {R : A → A → Type ℓ′} {r : ∀ a → R a a} {a : A}
+  → is-identity-system R r
+  → is-set A
+  → (P : R a a → Type ℓ′′)
+  → P (r a)
+  → ∀ s → P s
+IdsK {r = r} {a = a} ids set P pr s =
+  transport (λ i → P (strict-identity-system→is-prop ids set (r a) s i)) pr
+```
+
+<!--
+```agda
+IdsK-refl
+  : ∀ {ℓ ℓ′ ℓ′′} {A : Type ℓ} {R : A → A → Type ℓ′} {r : ∀ a → R a a} {a : A}
+  → (ids : is-identity-system R r)
+  → (set : is-set A)
+  → (P : R a a → Type ℓ′′)
+  → (x : P (r a))
+  → IdsK ids set P x (r a) ≡ x
+IdsK-refl {R = R} {r = r} {a = a} ids set P x =
+  transport (λ i → P (strict-identity-system→is-prop ids set (r a) (r a) i)) x ≡⟨⟩
+  subst P (strict-identity-system→is-prop ids set (r a) (r a)) x               ≡⟨ ap (λ ϕ → subst P ϕ x) lemma ⟩
+  transport (λ i → P (r a)) x                                                  ≡⟨ transport-refl x ⟩
+  x ∎
+  where
+    lemma : strict-identity-system→is-prop ids set (r a) (r a) ≡ refl
+    lemma = is-prop→is-set (strict-identity-system→is-prop ids set) (r a) (r a) _ _
+```
+-->
+
+<!--
+```agda
+module StrictIds
+  {ℓ ℓ′} {A : Type ℓ} {R : A → A → Type ℓ′} {r : ∀ a → R a a}
+  (ids : is-identity-system R r)
+  (set : is-set A)
+  where
+
+  K : ∀ {ℓ′′} {a} → (P : R a a → Type ℓ′′) → P (r a) → ∀ s → P s
+  K = IdsK ids set
+
+  K-refl : ∀ {ℓ′′} {a} → (P : R a a → Type ℓ′′) → (x : P (r a)) → K P x (r a) ≡ x
+  K-refl = IdsK-refl ids set
+
+  instance
+    R-H-level : ∀ {a b} {n} → H-Level (R a b) (1 + n)
+    R-H-level = prop-instance (strict-identity-system→is-prop ids set)
+```
+-->

--- a/src/1Lab/Univalence.lagda.md
+++ b/src/1Lab/Univalence.lagda.md
@@ -265,7 +265,7 @@ identity equivalence, so nothing changes (for this example).
   A && B \\
   \\
   B && B
-  \arrow["{\rm{refl}}"', from=3-1, to=3-3]
+  \arrow["{\refl}"', from=3-1, to=3-3]
   \arrow["f"', "\text{\rotatebox[origin=c]{90}{$\sim$}}", from=1-1, to=3-1]
   \arrow["{\id}", "\text{\rotatebox[origin=c]{270}{$\sim$}}"', from=1-3, to=3-3]
   \arrow["{\rm{ua}(f)}", dashed, from=1-1, to=1-3]

--- a/src/1Lab/intro.lagda.md
+++ b/src/1Lab/intro.lagda.md
@@ -1085,7 +1085,7 @@ identity morphism. The rest of the groupoid structure is here too! Any
 path $p : x \equiv y$ has an inverse $p^{-1} : y \equiv x$, and for any
 $p : x \equiv_A y$ and $q : y \equiv_A z$, there is a composite path $p
 \bullet q : x \equiv_A z$. There are paths between paths which express
-the groupoid identities (e.g. $p \bullet p^{-1} \equiv \rm{refl}$),
+the groupoid identities (e.g. $p \bullet p^{-1} \equiv \refl$),
 and those paths satisfy their own identities (up to a path between paths
 between paths), and so on.
 
@@ -1358,7 +1358,7 @@ endpoints of a path --- so we will write it $(d_0,d_1) : A^\bb{I}
 \to A \times A$, since it is the pairing of the maps which evaluate a
 path at the left and right endpoints of the interval.
 
-As a very quick aside, there is a map $r : \lambda x.\ (x, x, \rm{refl}$
+As a very quick aside, there is a map $r : \lambda x.\ (x, x, \refl$
 making the diagram below commute. This diagram expresses that the
 diagonal $A \to A \times A$ can be factored as a weak equivalence
 followed by a fibration through $A^\bb{I}$, which is the defining

--- a/src/Algebra/Group/Homotopy.lagda.md
+++ b/src/Algebra/Group/Homotopy.lagda.md
@@ -29,7 +29,7 @@ private variable
 
 Given a `pointed type`{.Agda ident=Type∙} $(A, a)$ we refer to the type
 $a = a$ as the **loop space of $A$**, and refer to it in short as
-$\Omega A$. Since we always have $\rm{refl} : a = a$, $\Omega A$ is
+$\Omega A$. Since we always have $\refl : a = a$, $\Omega A$ is
 _itself_ a pointed type, the construction can be iterated, a process
 which we denote $\Omega^n A$.
 
@@ -99,20 +99,20 @@ have `p` and `q` slip by each other.
 
 ~~~{.quiver .tall-2}
 \[\begin{tikzcd}
-	{\rm{refl}} &&& {\rm{refl}} &&& {\rm{refl}} \\
-	& {\rm{refl} \cdot \rm{refl}} && {\rm{refl} \cdot \rm{refl}} && {\rm{refl} \cdot \rm{refl}} \\
+	{\refl} &&& {\refl} &&& {\refl} \\
+	& {\refl \cdot \refl} && {\refl \cdot \refl} && {\refl \cdot \refl} \\
 	\\
-	& {\rm{refl} \cdot \rm{refl}} && {\rm{refl} \cdot \rm{refl}} && {\rm{refl} \cdot \rm{refl}} \\
-	{\rm{refl}} &&& {\rm{refl}} &&& {\rm{refl}}
+	& {\refl \cdot \refl} && {\refl \cdot \refl} && {\refl \cdot \refl} \\
+	{\refl} &&& {\refl} &&& {\refl}
 	\arrow[from=2-2, to=4-2]
 	\arrow["{p\ \neg i \cdot q\ i}"{description}, color={rgb,255:red,214;green,92;blue,214}, from=2-4, to=4-4]
 	\arrow[from=2-6, to=4-6]
 	\arrow[from=1-1, to=5-1]
 	\arrow[from=1-7, to=5-7]
-	\arrow[""{name=0, anchor=center, inner sep=0}, "{p\ j \cdot \rm{refl}}"', color={rgb,255:red,214;green,92;blue,92}, from=2-2, to=2-4]
-	\arrow[""{name=1, anchor=center, inner sep=0}, "{\rm{refl} \cdot q\ j}"', color={rgb,255:red,153;green,92;blue,214}, from=2-4, to=2-6]
-	\arrow[""{name=2, anchor=center, inner sep=0}, "{\rm{refl} \cdot q\ j}", color={rgb,255:red,153;green,92;blue,214}, from=4-2, to=4-4]
-	\arrow[""{name=3, anchor=center, inner sep=0}, "{p\ j \cdot \rm{refl}}", color={rgb,255:red,214;green,92;blue,92}, from=4-4, to=4-6]
+	\arrow[""{name=0, anchor=center, inner sep=0}, "{p\ j \cdot \refl}"', color={rgb,255:red,214;green,92;blue,92}, from=2-2, to=2-4]
+	\arrow[""{name=1, anchor=center, inner sep=0}, "{\refl \cdot q\ j}"', color={rgb,255:red,153;green,92;blue,214}, from=2-4, to=2-6]
+	\arrow[""{name=2, anchor=center, inner sep=0}, "{\refl \cdot q\ j}", color={rgb,255:red,153;green,92;blue,214}, from=4-2, to=4-4]
+	\arrow[""{name=3, anchor=center, inner sep=0}, "{p\ j \cdot \refl}", color={rgb,255:red,214;green,92;blue,92}, from=4-4, to=4-6]
 	\arrow[""{name=4, anchor=center, inner sep=0}, "{p\ j}", color={rgb,255:red,214;green,92;blue,92}, from=1-1, to=1-4]
 	\arrow[""{name=5, anchor=center, inner sep=0}, "{q\ j}", color={rgb,255:red,153;green,92;blue,214}, from=1-4, to=1-7]
 	\arrow[""{name=6, anchor=center, inner sep=0}, "{q\ j}"', color={rgb,255:red,153;green,92;blue,214}, from=5-1, to=5-4]
@@ -183,7 +183,7 @@ that `path`{.Agda} is a group homomorphism. More specifically,
   \bullet && \bullet \\
   \\
   \bullet && \bullet
-  \arrow["{\rm{refl}}"', from=1-1, to=3-1]
+  \arrow["{\refl}"', from=1-1, to=3-1]
   \arrow["{\rm{path}(x)}", from=1-1, to=1-3]
   \arrow["{\rm{path}(y)}", from=1-3, to=3-3]
   \arrow["{\rm{path}(x \star y)}"', from=3-1, to=3-3]

--- a/src/Cat/Gaunt.lagda.md
+++ b/src/Cat/Gaunt.lagda.md
@@ -15,11 +15,12 @@ import Cat.Reasoning
 module Cat.Gaunt where
 ```
 
-# Gaunt Categories
+# Gaunt (pre)categories
 
-A precategory $\cC$ is **gaunt** if the only isomorphism are the identity
-morphisms. Another way of saying this is that the precategory is both
-[univalent] and [strict].
+A precategory $\cC$ is **gaunt** if it is [univalent] and [strict]: its
+type of objects $\rm{Ob}(\cC)$ is a set, and identity in $\rm{Ob}$ is
+equivalent to isomorphism in $\cC$. This is a truncation condition on
+the isomorphisms $a \cong b : \cC$, which must all be trivial.
 
 [univalent]: Cat.Univalent.html
 [strict]: Cat.Strict.html
@@ -30,29 +31,29 @@ record is-gaunt {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ ℓ) where
     has-category : is-category C
     has-strict : is-strict C
 
-  open Univalent.path→iso has-category public
+  open Univalent.path→iso has-category hiding (hlevel) public
   open StrictIds has-category has-strict renaming (K to K-iso) public
 ```
 
-As one would expect, being gaunt is property of a category.
-
+<!--
 ```agda
+unquoteDecl eqv = declare-record-iso eqv (quote is-gaunt)
+
 is-gaunt-is-prop
   : ∀ {o ℓ} {C : Precategory o ℓ}
   → is-prop (is-gaunt C)
-is-gaunt-is-prop p q = worker where
-  open is-gaunt
+is-gaunt-is-prop =
+  Iso→is-hlevel 1 eqv (Σ-is-hlevel 1 hlevel! (λ _ → is-hlevel-is-prop 2))
 
-  worker : p ≡ q
-  worker i .has-category =
-    is-identity-system-is-prop (p .has-category) (q .has-category) i
-  worker i .has-strict = is-hlevel-is-prop 2 (p .has-strict) (q .has-strict) i
+instance
+  H-Level-is-gaunt
+    : ∀ {o ℓ} {C : Precategory o ℓ} {n}
+    → H-Level (is-gaunt C) (suc n)
+  H-Level-is-gaunt = prop-instance is-gaunt-is-prop
 ```
+-->
 
-If $\cC$ is gaunt, then the type of isomorphisms is a proposition.
-This follows from some general facts about [strict identity systems].
-
-[strict identity systems]: 1Lab.Path.IdentitySystem.Strict.html
+As one would expect, being gaunt is property of a category.
 
 ```agda
 module _ {o ℓ} {C : Precategory o ℓ} (gaunt : is-gaunt C) where
@@ -63,41 +64,39 @@ module _ {o ℓ} {C : Precategory o ℓ} (gaunt : is-gaunt C) where
   iso-is-prop = hlevel!
 ```
 
-This implies that gaunt categories are [skeletal], as we can untruncate
-isomorphisms.
+This implies that gaunt categories are [skeletal]: Since there is at
+most one isomorphism $a \cong b$, then given $\| a \cong b \|$, we can
+apply _unique choice_ to retrieve the underlying map.
 
 [skeletal]: Cat.Skeletal.html
 
 ```agda
   gaunt→skeletal : is-skeletal C
-  gaunt→skeletal .to-path = ∥-∥-rec (has-strict _ _) iso→path
-  gaunt→skeletal .to-path-over ∥f∥ = is-prop→pathp (λ _ → squash) (inc id-iso) ∥f∥
+  gaunt→skeletal = set-identity-system (λ _ _ → squash) $
+    ∥-∥-rec (has-strict _ _) (has-category .to-path)
 ```
 
 Furthermore, if a category is skeletal and univalent, it is gaunt.
 
 ```agda
-skeletal+univalent→gaunt
+skeletal-category→is-gaunt
   : ∀ {o ℓ} {C : Precategory o ℓ}
   → is-skeletal C
   → is-category C
   → is-gaunt C
-skeletal+univalent→gaunt skel cat .is-gaunt.has-category = cat
-skeletal+univalent→gaunt skel cat .is-gaunt.has-strict = skeletal→strict _ skel
+skeletal-category→is-gaunt skel cat .is-gaunt.has-category = cat
+skeletal-category→is-gaunt skel cat .is-gaunt.has-strict = skeletal→strict _ skel
 ```
 
 This implies that gaunt categories are **precisely** the skeletal
 univalent categories.
 
 ```agda
-skeletal+univalent≃gaunt
+skeletal-category≃gaunt
   : ∀ {o ℓ} {C : Precategory o ℓ}
   → (is-skeletal C × is-category C) ≃ is-gaunt C
-skeletal+univalent≃gaunt =
-  prop-ext
-    (×-is-hlevel 1 is-identity-system-is-prop is-identity-system-is-prop)
-    is-gaunt-is-prop
-    (λ { (skel , cat) → skeletal+univalent→gaunt skel cat })
-    (λ gaunt → (gaunt→skeletal gaunt) , has-category gaunt)
+skeletal-category≃gaunt = prop-ext (hlevel 1) (hlevel 1)
+    (λ { (skel , cat) → skeletal-category→is-gaunt skel cat })
+    (λ gaunt → gaunt→skeletal gaunt , has-category gaunt)
   where open is-gaunt
 ```

--- a/src/Cat/Gaunt.lagda.md
+++ b/src/Cat/Gaunt.lagda.md
@@ -1,0 +1,103 @@
+<!--
+```agda
+open import 1Lab.Path.IdentitySystem.Strict
+
+open import Cat.Strict
+open import Cat.Skeletal
+open import Cat.Univalent
+open import Cat.Prelude
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Gaunt where
+```
+
+# Gaunt Categories
+
+A precategory $\cC$ is **gaunt** if the only isomorphism are the identity
+morphisms. Another way of saying this is that the precategory is both
+[univalent] and [strict].
+
+[univalent]: Cat.Univalent.html
+[strict]: Cat.Strict.html
+
+```agda
+record is-gaunt {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ ℓ) where
+  field
+    has-category : is-category C
+    has-strict : is-strict C
+
+  open Univalent.path→iso has-category public
+  open StrictIds has-category has-strict renaming (K to K-iso) public
+```
+
+As one would expect, gauntness is a proposition.
+
+```agda
+is-gaunt-is-prop
+  : ∀ {o ℓ} {C : Precategory o ℓ}
+  → is-prop (is-gaunt C)
+is-gaunt-is-prop p q = worker where
+  open is-gaunt
+
+  worker : p ≡ q
+  worker i .has-category =
+    is-identity-system-is-prop (p .has-category) (q .has-category) i
+  worker i .has-strict = is-hlevel-is-prop 2 (p .has-strict) (q .has-strict) i
+```
+
+If $\cC$ is gaunt, then the type of isomorphisms is a proposition.
+This follows from some general facts about [strict identity systems].
+
+[strict identity systems]: 1Lab.Path.IdentitySystem.Strict.html
+
+```agda
+module _ {o ℓ} {C : Precategory o ℓ} (gaunt : is-gaunt C) where
+  open is-gaunt gaunt
+  open Cat.Reasoning C
+
+  iso-is-prop : ∀ {x y} → is-prop (x ≅ y)
+  iso-is-prop = hlevel!
+```
+
+This implies that gaunt categories are [skeletal], as we can untruncate
+isomorphisms.
+
+[skeletal]: Cat.Skeletal.html
+
+```agda
+  gaunt→skeletal : is-skeletal C
+  gaunt→skeletal .to-path = ∥-∥-rec (has-strict _ _) iso→path
+  gaunt→skeletal .to-path-over ∥f∥ = is-prop→pathp (λ _ → squash) (inc id-iso) ∥f∥
+```
+
+Furthermore, if a category is skeletal and univalent, it is gaunt.
+
+```agda
+skeletal+univalent→gaunt
+  : ∀ {o ℓ} {C : Precategory o ℓ}
+  → is-skeletal C
+  → is-category C
+  → is-gaunt C
+skeletal+univalent→gaunt skel cat .is-gaunt.has-category = cat
+skeletal+univalent→gaunt skel cat .is-gaunt.has-strict = skeletal→strict _ skel
+```
+
+This implies that gaunt categories are **precisely** the skeletal
+univalent categories.
+
+```agda
+skeletal+univalent≃gaunt
+  : ∀ {o ℓ} {C : Precategory o ℓ}
+  → (is-skeletal C × is-category C) ≃ is-gaunt C
+skeletal+univalent≃gaunt =
+  prop-ext
+    (×-is-hlevel 1 is-identity-system-is-prop is-identity-system-is-prop)
+    is-gaunt-is-prop
+    (λ { (skel , cat) → skeletal+univalent→gaunt skel cat })
+    (λ gaunt → (gaunt→skeletal gaunt) , has-category gaunt)
+  where open is-gaunt
+```

--- a/src/Cat/Gaunt.lagda.md
+++ b/src/Cat/Gaunt.lagda.md
@@ -34,7 +34,7 @@ record is-gaunt {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ ℓ) where
   open StrictIds has-category has-strict renaming (K to K-iso) public
 ```
 
-As one would expect, gauntness is a proposition.
+As one would expect, being gaunt is property of a category.
 
 ```agda
 is-gaunt-is-prop

--- a/src/Cat/Instances/Discrete.lagda.md
+++ b/src/Cat/Instances/Discrete.lagda.md
@@ -112,8 +112,8 @@ The object part of the functor is the provided $f : X \to
 $f$ respects equality. This is why it's redundant: $f$ automatically
 respects equality, because it's a function! However, by using the
 decision procedure, we get better computational behaviour: Very often,
-$\rm{disc}(x,x)$ will be $\rm{yes}(\rm{refl})$, and
-substitution along $\rm{refl}$ is easy to deal with.
+$\rm{disc}(x,x)$ will be $\rm{yes}(\refl)$, and
+substitution along $\refl$ is easy to deal with.
 
 ```agda
   F : Functor _ _

--- a/src/Cat/Instances/Shape/Involution.lagda.md
+++ b/src/Cat/Instances/Shape/Involution.lagda.md
@@ -15,9 +15,10 @@ module Cat.Instances.Shape.Involution where
 
 # The walking involution
 
-The walking involution is the category with one object, and two morphisms
-$id$ and $i$, such that $i \circ i = id$. We can encode this by defining
-morphisms as booleans, and using `xor`{.Agda} as our composition operation.
+The **walking involution** is the category with a single non-trivial
+morphism $i : x \to x$, satisfying $i \circ i = \id$.  We can encode
+this by defining morphisms as booleans, and using `xor`{.Agda} as our
+composition operation.
 
 ```agda
 ∙⤮∙ : Precategory lzero lzero
@@ -33,8 +34,7 @@ morphisms as booleans, and using `xor`{.Agda} as our composition operation.
 open Cat.Reasoning ∙⤮∙
 ```
 
-A useful feature of this category is that it is the smallest category
-with a non-trivial automorphism.
+This is the smallest precategory with a non-trivial isomorphism.
 
 ```agda
 Bool≃∙⤮∙-isos : Bool ≃ (tt ≅ tt)
@@ -43,7 +43,7 @@ Bool≃∙⤮∙-isos =
   where
     Bool→Iso : Bool → tt ≅ tt
     Bool→Iso true = make-iso true true refl refl
-    Bool→Iso false = id-iso 
+    Bool→Iso false = id-iso
 
     Iso→Bool : tt ≅ tt → Bool
     Iso→Bool i = i .to
@@ -60,7 +60,7 @@ Bool≃∙⤮∙-isos =
     left-inv false = refl
 ```
 
-## Skeletality and Univalence
+## Skeletality and (non)-univalence
 
 As the walking involution only has one object, it is trivially [skeletal].
 
@@ -73,11 +73,10 @@ As the walking involution only has one object, it is trivially [skeletal].
   is-prop→pathp (λ _ → squash) (inc id-iso) _
 ```
 
-However, it is *not* univalent, due to the mismatch between automorphisms
-and paths between objects. If the walking involution was univalent, then
-we would have an isomorphism between paths in the unit type and
-automorphisms. However, as we just saw, there are 2 distinct automorphisms,
-yet the unit type is a proposition.
+However, it is *not* univalent, since its only object has more internal
+automorphisms than it has loops. By definition, univalence for the
+walking involution would mean that there are two paths $\tt{tt} \equiv
+\tt{tt}$ in the booleans: but this contradicts the booleans being a set.
 
 ```agda
 ∙⤮∙-not-univalent : ¬ is-category ∙⤮∙

--- a/src/Cat/Instances/Shape/Involution.lagda.md
+++ b/src/Cat/Instances/Shape/Involution.lagda.md
@@ -1,0 +1,91 @@
+<!--
+```agda
+open import Data.Bool
+
+open import Cat.Prelude
+open import Cat.Skeletal
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Instances.Shape.Involution where
+```
+
+# The walking involution
+
+The walking involution is the category with one object, and two morphisms
+$id$ and $i$, such that $i \circ i = id$. We can encode this by defining
+morphisms as booleans, and using `xor`{.Agda} as our composition operation.
+
+```agda
+∙⤮∙ : Precategory lzero lzero
+∙⤮∙ .Precategory.Ob = ⊤
+∙⤮∙ .Precategory.Hom _ _ = Bool
+∙⤮∙ .Precategory.Hom-set _ _ = Bool-is-set
+∙⤮∙ .Precategory.id = false
+∙⤮∙ .Precategory._∘_ = xor
+∙⤮∙ .Precategory.idr f = xor-falser f
+∙⤮∙ .Precategory.idl f = refl
+∙⤮∙ .Precategory.assoc f g h = xor-associative f g h
+
+open Cat.Reasoning ∙⤮∙
+```
+
+A useful feature of this category is that it is the smallest category
+with a non-trivial automorphism.
+
+```agda
+Bool≃∙⤮∙-isos : Bool ≃ (tt ≅ tt)
+Bool≃∙⤮∙-isos =
+  Iso→Equiv (Bool→Iso , iso Iso→Bool right-inv left-inv)
+  where
+    Bool→Iso : Bool → tt ≅ tt
+    Bool→Iso true = make-iso true true refl refl
+    Bool→Iso false = id-iso 
+
+    Iso→Bool : tt ≅ tt → Bool
+    Iso→Bool i = i .to
+
+    right-inv : is-right-inverse Iso→Bool Bool→Iso
+    right-inv f =
+      Bool-elim (λ b → b ≡ f .to → Bool→Iso b ≡ f)
+        (≅-pathp refl refl)
+        (≅-pathp refl refl)
+        (f .to) refl
+
+    left-inv : is-left-inverse Iso→Bool Bool→Iso
+    left-inv true = refl
+    left-inv false = refl
+```
+
+## Skeletality and Univalence
+
+As the walking involution only has one object, it is trivially [skeletal].
+
+[skeletal]: Cat.Skeletal.html
+
+```agda
+∙⤮∙-skeletal : is-skeletal ∙⤮∙
+∙⤮∙-skeletal .to-path _ = refl
+∙⤮∙-skeletal .to-path-over _ =
+  is-prop→pathp (λ _ → squash) (inc id-iso) _
+```
+
+However, it is *not* univalent, due to the mismatch between automorphisms
+and paths between objects. If the walking involution was univalent, then
+we would have an isomorphism between paths in the unit type and
+automorphisms. However, as we just saw, there are 2 distinct automorphisms,
+yet the unit type is a proposition.
+
+```agda
+∙⤮∙-not-univalent : ¬ is-category ∙⤮∙
+∙⤮∙-not-univalent is-cat = true≠false (Bool-is-prop true false) where
+
+  Bool≃Ob-path : Bool ≃ (tt ≡ tt)
+  Bool≃Ob-path = Bool≃∙⤮∙-isos ∙e identity-system-gives-path is-cat
+
+  Bool-is-prop : is-prop Bool
+  Bool-is-prop = is-hlevel≃ 1 Bool≃Ob-path hlevel!
+```

--- a/src/Cat/Instances/Shape/Isomorphism.lagda.md
+++ b/src/Cat/Instances/Shape/Isomorphism.lagda.md
@@ -52,104 +52,104 @@ Note that the space of isomorphisms between any 2 objects is contractible.
 
 The isomorphism category is strict, as its objects form a set.
 
--- ```agda
--- 0≅1-is-strict : is-set 0≅1.Ob
--- 0≅1-is-strict = hlevel!
--- ```
+```agda
+0≅1-is-strict : is-set 0≅1.Ob
+0≅1-is-strict = hlevel!
+```
 
--- # The isomorphism category is not univalent
+# The isomorphism category is not univalent
 
--- The isomorphism category is the canonical example of a non-univalent
--- category. If it were univalent, then we'd get a path between
--- `true`{.Agda} and `false`{.Agda}!
+The isomorphism category is the canonical example of a non-univalent
+category. If it were univalent, then we'd get a path between
+`true`{.Agda} and `false`{.Agda}!
 
--- ```agda
--- 0≅1-not-univalent : ¬ is-category 0≅1
--- 0≅1-not-univalent is-cat =
---   true≠false $ is-cat .to-path $
---   0≅1-iso-contr true false .centre
--- ```
+```agda
+0≅1-not-univalent : ¬ is-category 0≅1
+0≅1-not-univalent is-cat =
+  true≠false $ is-cat .to-path $
+  0≅1-iso-contr true false .centre
+```
 
--- # Functors out of the isomorphism category
+# Functors out of the isomorphism category
 
--- One important fact about the isomorphism category is that it classifies
--- isomorphisms in categories, in the sense that functors out of `0≅1`{.Agda}
--- into some category $\cC$ are equivalent to isomorphisms in $\cC$.
+One important fact about the isomorphism category is that it classifies
+isomorphisms in categories, in the sense that functors out of `0≅1`{.Agda}
+into some category $\cC$ are equivalent to isomorphisms in $\cC$.
 
--- ```agda
--- Isos : ∀ {o ℓ} → Precategory o ℓ → Type (o ⊔ ℓ)
--- Isos 𝒞 = Σ[ A ∈ 𝒞.Ob ] Σ[ B ∈ 𝒞.Ob ] (A 𝒞.≅ B)
---   where module 𝒞 = Cat.Reasoning 𝒞
--- ```
+```agda
+Isos : ∀ {o ℓ} → Precategory o ℓ → Type (o ⊔ ℓ)
+Isos 𝒞 = Σ[ A ∈ 𝒞.Ob ] Σ[ B ∈ 𝒞.Ob ] (A 𝒞.≅ B)
+  where module 𝒞 = Cat.Reasoning 𝒞
+```
 
--- To prove this, we fix some category $\cC$, and construct an
--- isomorphism between functors out of `0≅1`{.Agda} and isomorphisms
--- in $\cC$.
+To prove this, we fix some category $\cC$, and construct an
+isomorphism between functors out of `0≅1`{.Agda} and isomorphisms
+in $\cC$.
 
--- ```agda
--- module _ {o ℓ} {𝒞 : Precategory o ℓ} where
---   private
---     module 𝒞 = Cat.Reasoning 𝒞
---     open Functor
---     open 𝒞._≅_
--- ```
+```agda
+module _ {o ℓ} {𝒞 : Precategory o ℓ} where
+  private
+    module 𝒞 = Cat.Reasoning 𝒞
+    open Functor
+    open 𝒞._≅_
+```
 
--- For the forward direction, we use the fact that all objects in
--- `0≅1`{.Agda} are isomorphic to construct an iso between `true`{.Agda}
--- and `false`{.Agda}, and then use the fact that functors preserve
--- isomorphisms to obtain an isomorphism in $\cC$.
+For the forward direction, we use the fact that all objects in
+`0≅1`{.Agda} are isomorphic to construct an iso between `true`{.Agda}
+and `false`{.Agda}, and then use the fact that functors preserve
+isomorphisms to obtain an isomorphism in $\cC$.
 
--- ```agda
---   functor→iso : (F : Functor 0≅1 𝒞) → Isos 𝒞
---   functor→iso F =
---     _ , _ , F-map-iso F (0≅1-iso-contr true false .centre)
--- ```
+```agda
+  functor→iso : (F : Functor 0≅1 𝒞) → Isos 𝒞
+  functor→iso F =
+    _ , _ , F-map-iso F (0≅1-iso-contr true false .centre)
+```
 
--- For the backwards direction, we are given an isomorphism $X \cong Y$
--- in $\cC$. Our functor will map `true`{.Agda} to $X$, and `false`
--- to $Y$: this is somewhat arbitrary, but lines up with our choices for
--- the forward direction. We then perform a big case bash to construct
--- the mapping of morphisms, and unpack the components of the provided
--- isomorphism into place. Functoriality follows by the fact that the
--- provided isomorphism is indeed an isomorphism.
+For the backwards direction, we are given an isomorphism $X \cong Y$
+in $\cC$. Our functor will map `true`{.Agda} to $X$, and `false`
+to $Y$: this is somewhat arbitrary, but lines up with our choices for
+the forward direction. We then perform a big case bash to construct
+the mapping of morphisms, and unpack the components of the provided
+isomorphism into place. Functoriality follows by the fact that the
+provided isomorphism is indeed an isomorphism.
 
--- ```agda
---   iso→functor : Isos 𝒞 → Functor 0≅1 𝒞
---   iso→functor (X , Y , isom) = fun
---     where
---       fun : Functor _ _
---       fun .F₀ true = X
---       fun .F₀ false = Y
---       fun .F₁ {true} {true} _ = 𝒞.id
---       fun .F₁ {true} {false} _ = to isom
---       fun .F₁ {false} {true} _ = from isom
---       fun .F₁ {false} {false} _ = 𝒞.id
---       fun .F-id {true} = refl
---       fun .F-id {false} = refl
---       fun .F-∘ {true} {true} {z} f g = sym $ 𝒞.idr _
---       fun .F-∘ {true} {false} {true} f g = sym $ invr isom
---       fun .F-∘ {true} {false} {false} f g = sym $ 𝒞.idl _
---       fun .F-∘ {false} {true} {true} f g = sym $ 𝒞.idl _
---       fun .F-∘ {false} {true} {false} f g = sym $ invl isom
---       fun .F-∘ {false} {false} {z} f g = sym $ 𝒞.idr _
--- ```
+```agda
+  iso→functor : Isos 𝒞 → Functor 0≅1 𝒞
+  iso→functor (X , Y , isom) = fun
+    where
+      fun : Functor _ _
+      fun .F₀ true = X
+      fun .F₀ false = Y
+      fun .F₁ {true} {true} _ = 𝒞.id
+      fun .F₁ {true} {false} _ = to isom
+      fun .F₁ {false} {true} _ = from isom
+      fun .F₁ {false} {false} _ = 𝒞.id
+      fun .F-id {true} = refl
+      fun .F-id {false} = refl
+      fun .F-∘ {true} {true} {z} f g = sym $ 𝒞.idr _
+      fun .F-∘ {true} {false} {true} f g = sym $ invr isom
+      fun .F-∘ {true} {false} {false} f g = sym $ 𝒞.idl _
+      fun .F-∘ {false} {true} {true} f g = sym $ 𝒞.idl _
+      fun .F-∘ {false} {true} {false} f g = sym $ invl isom
+      fun .F-∘ {false} {false} {z} f g = sym $ 𝒞.idr _
+```
 
--- Showing that this function is an equivalence is relatively simple:
--- the only tricky part is figuring out which lemmas to use to characterise
--- path spaces!
+Showing that this function is an equivalence is relatively simple:
+the only tricky part is figuring out which lemmas to use to characterise
+path spaces!
 
--- ```agda
---   iso≃functor : is-equiv iso→functor
---   iso≃functor = is-iso→is-equiv (iso functor→iso rinv linv) where
---     rinv : is-right-inverse functor→iso iso→functor
---     rinv F =
---       Functor-path
---         (λ { true → refl ; false → refl })
---         (λ { {true} {true} _ → sym (F-id F)
---            ; {true} {false} tt → refl
---            ; {false} {true} tt → refl
---            ; {false} {false} tt → sym (F-id F) })
+```agda
+  iso≃functor : is-equiv iso→functor
+  iso≃functor = is-iso→is-equiv (iso functor→iso rinv linv) where
+    rinv : is-right-inverse functor→iso iso→functor
+    rinv F =
+      Functor-path
+        (λ { true → refl ; false → refl })
+        (λ { {true} {true} _ → sym (F-id F)
+           ; {true} {false} tt → refl
+           ; {false} {true} tt → refl
+           ; {false} {false} tt → sym (F-id F) })
 
---     linv : is-left-inverse functor→iso iso→functor
---     linv F = Σ-pathp refl $ Σ-pathp refl $ 𝒞.≅-pathp refl refl refl
--- ```
+    linv : is-left-inverse functor→iso iso→functor
+    linv F = Σ-pathp refl $ Σ-pathp refl $ 𝒞.≅-pathp refl refl refl
+```

--- a/src/Cat/Skeletal.lagda.md
+++ b/src/Cat/Skeletal.lagda.md
@@ -17,11 +17,18 @@ module Cat.Skeletal where
 
 # Skeletal Precategories
 
-A precategory $\cC$ is skeletal if all of its isomorphisms are
-automorphisms, or in other words, if there is *any* isomorphism
-$X \cong Y$, then $X$ and $Y$ are equal. We can encode this condition
-by requiring that the propositional truncation of isomorphisms in $\cC$
-is an [identity system].
+A precategory $\cC$ is **skeletal** if objects having _the property of
+being isomorphic_ are identical. The clunky rephrasing is proposital: if
+we had merely said "isomorphic objects are identical", then skeletality
+sounds too much like [univalence], from which it is distinct. Instead,
+skeletality is defined as (equivalent to) the existence of a map
+
+$$
+\| a \cong b \| \to a \equiv b\text{,}
+$$
+
+which we can more concisely summarise as "$(\| - \cong - \|, \| \id \|)$
+is an identity system".
 
 [identity system]: 1Lab.Path.IdentitySystem.html
 
@@ -29,13 +36,20 @@ is an [identity system].
 is-skeletal : ∀ {o ℓ} → Precategory o ℓ → Type (o ⊔ ℓ)
 is-skeletal C =
   is-identity-system (λ x y → ∥ Isomorphism C x y ∥) (λ x → inc (id-iso C))
+
+path-from-has-iso→is-skeletal
+  : ∀ {o ℓ} (C : Precategory o ℓ)
+  → (∀ {a b} → ∥ Isomorphism C a b ∥ → a ≡ b)
+  → is-skeletal C
+path-from-has-iso→is-skeletal C sk = set-identity-system (λ _ _ → squash) sk
 ```
 
-Note that this is distinct from [univalence], which states that
-*untruncated* isomorphisms form an identity system. Univalence is a much
-more useful condition in practice; very few interesting categories are 
-skeletal. In fact, we only define skeletal categories to show that other
-conditions imply it, and therefore should be discounted.
+Skeletality is much rarer than [univalence] in practice, and univalence
+is the more useful condition, since it allows facts about isomorphism to
+transfer to identity^[Indeed, it also allows general facts about
+identity to transfer to isomorphism!]. Skeletality, in our sense, serves
+as a point of comparison for _other_ properties: if a property implies
+skeletality, we can safely regard it as unnatural.
 
 [univalence]: Cat.Univalent.html
 
@@ -45,8 +59,8 @@ module _ {o ℓ} (C : Precategory o ℓ) where
 ```
 -->
 
-One reason skeletality rules out a lot of interesting categories is that
-it implies that the category is [strict].
+One of the reasons skeletality is unnatural is it implies the category
+is [strict].
 
 [strict]: Cat.Strict.html
 
@@ -55,9 +69,10 @@ it implies that the category is [strict].
   skeletal→strict skel = identity-system→hlevel 1 skel (λ _ _ → squash)
 ```
 
-Furthermore, skeletality does *not* imply univalence, as $\cC$ may have
-non-trivial automorphisms. See [here] for an example of such a precategory.
+Furthermore, skeletality does *not* imply univalence, as objects in
+$\cC$ may have non-trivial automorphisms. The [walking involution] is
+the simplest example of a non-univalent, skeletal precategory. In
+general, we prefer to work with [gaunt], not skeletal, categories.
 
-[here]: Cat.Instances.Shape.Involution.html
-
-In general, the "correct" notion of skeletal in HoTT are [gaunt] categories.
+[walking involution]: Cat.Instances.Shape.Involution.html
+[gaunt]: Cat.Gaunt.html

--- a/src/Cat/Skeletal.lagda.md
+++ b/src/Cat/Skeletal.lagda.md
@@ -1,0 +1,65 @@
+<!--
+```agda
+open import Cat.Strict
+open import Cat.Instances.Discrete
+open import Cat.Prelude
+
+open import Homotopy.Space.Circle
+
+import Cat.Reasoning
+
+open Cat.Reasoning using (Isomorphism ; id-iso)
+open Precategory using (Ob)
+```
+-->
+
+```agda
+module Cat.Skeletal where
+```
+
+# Skeletal Precategories
+
+A precategory $\cC$ is skeletal if all of its isomorphisms are
+automorphisms, or in other words, if there is *any* isomorphism
+$X \cong Y$, then $X$ and $Y$ are equal. We can encode this condition
+by requiring that the propositional truncation of isomorphisms in $\cC$
+is an [identity system].
+
+[identity system]: 1Lab.Path.IdentitySystem.html
+
+```agda
+is-skeletal : ∀ {o ℓ} → Precategory o ℓ → Type (o ⊔ ℓ)
+is-skeletal C =
+  is-identity-system (λ x y → ∥ Isomorphism C x y ∥) (λ x → inc (id-iso C))
+```
+
+Note that this is distinct from [univalence], which states that
+*untruncated* isomorphisms form an identity system. Univalence is a much
+more useful condition in practice; very few interesting categories are 
+skeletal. In fact, we only define skeletal categories to show that other
+conditions imply it, and therefore should be discounted.
+
+[univalence]: Cat.Univalent.html
+
+<!--
+```agda
+module _ {o ℓ} (C : Precategory o ℓ) where
+```
+-->
+
+One reason skeletality rules out a lot of interesting categories is that
+it implies that the category is [strict].
+
+[strict]: Cat.Strict.html
+
+```agda
+  skeletal→strict : is-skeletal C → is-strict C
+  skeletal→strict skel = identity-system→hlevel 1 skel (λ _ _ → squash)
+```
+
+Furthermore, skeletality does *not* imply univalence, as $\cC$ may have
+non-trivial automorphisms. See [here] for an example of such a precategory.
+
+[here]: Cat.Instances.Shape.Involution.html
+
+In general, the "correct" notion of skeletal in HoTT are [gaunt] categories.

--- a/src/Cat/Skeletal.lagda.md
+++ b/src/Cat/Skeletal.lagda.md
@@ -4,8 +4,6 @@ open import Cat.Strict
 open import Cat.Instances.Discrete
 open import Cat.Prelude
 
-open import Homotopy.Space.Circle
-
 import Cat.Reasoning
 
 open Cat.Reasoning using (Isomorphism ; id-iso)

--- a/src/Cat/Strict.lagda.md
+++ b/src/Cat/Strict.lagda.md
@@ -12,18 +12,32 @@ module Cat.Strict where
 
 # Strict Precategories
 
-We call a precategory **strict** if it's space of objects is a
-`Set`{.Agda ident=is-set}.j
+We call a precategory **strict** if its type of objects is a `Set`{.Agda
+ident=is-set}.
 
 ```agda
 is-strict : ∀ {o ℓ} → Precategory o ℓ → Type o
 is-strict C = is-set (Precategory.Ob C)
 ```
 
-Strictness is quite a strong condition, and rules out many naturally
-occurring categories (for instance, the category of sets), as they
-are too homotopically interesting. However, this lack of higher
-dimensional structure does have its benefits: for instance,
+Strictness is a very strong condition to impose on categories, since it
+classifies the "categories-as-algebras", or _petit_, view on categories,
+which regards categories _themselves_ as set-level structures, which
+could be compared to [monoids] or [groups]. For example, the [path
+category] on a directed graph is naturally regarded as strict. Moreover,
 [strict categories form a precategory][strcat].
 
 [strcat]: Cat.Instances.StrictCat.html
+[path category]: Cat.Instances.Free.html
+[monoids]: Algebra.Monoid.html
+[groups]: Algebra.Group.html
+
+This is in contrast with the "categories-as-universes", or _gros_, view
+on categories. From this perspective, categories serve to organise
+objects at the set-level, like [$\thecat{Mon}$] or [$\Grp$]. These
+categories tend to be [univalent], with a proper underlying _groupoid_
+of objects.
+
+[$\thecat{Mon}$]: Algebra.Monoid.Category.html
+[$\Grp$]: Algebra.Group.Cat.Base.html
+[univalent]: Cat.Univalent.html

--- a/src/Cat/Strict.lagda.md
+++ b/src/Cat/Strict.lagda.md
@@ -1,0 +1,29 @@
+<!--
+```agda
+open import Cat.Prelude
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Strict where
+```
+
+# Strict Precategories
+
+We call a precategory **strict** if it's space of objects is a
+`Set`{.Agda ident=is-set}.j
+
+```agda
+is-strict : ∀ {o ℓ} → Precategory o ℓ → Type o
+is-strict C = is-set (Precategory.Ob C)
+```
+
+Strictness is quite a strong condition, and rules out many naturally
+occurring categories (for instance, the category of sets), as they
+are too homotopically interesting. However, this lack of higher
+dimensional structure does have its benefits: for instance,
+[strict categories form a precategory][strcat].
+
+[strcat]: Cat.Instances.StrictCat.html

--- a/src/Homotopy/Space/Circle.lagda.md
+++ b/src/Homotopy/Space/Circle.lagda.md
@@ -173,7 +173,7 @@ loop, which we can picture as the boundary of a square.  Namely,
   {\rm{base}} && {\rm{base}}
   \arrow["{\rm{loop}^{1+n}}", from=1-3, to=3-3]
   \arrow["{\rm{loop}}"', from=3-1, to=3-3]
-  \arrow["{\rm{refl}}", from=1-1, to=1-3]
+  \arrow["{\refl}", from=1-1, to=1-3]
   \arrow["{\rm{loop}^n}"', from=1-1, to=3-1]
 \end{tikzcd}\]
 ~~~

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -486,6 +486,28 @@ open import Cat.Skeletal -- Categories where isomorphisms are automorphisms.
 open import Cat.Gaunt -- Strict univalent categories.
 ```
 
+Properties, constructions, and the category of strict categories:
+
+```agda
+-- Strict categories
+open import Cat.Instances.StrictCat
+open import Cat.Instances.StrictCat.Cohesive
+  -- ^ Strict category structure is a sort of "spatial" structure on a
+  -- set
+
+open import Cat.Instances.Free
+-- Free strict categories on a directed graph
+
+open import Cat.Instances.FinSet
+-- Skeleton of the category of finite sets
+
+open import Cat.Instances.Simplex
+-- Skeleton of the simplex category
+
+open import Cat.Instances.Discrete -- Discrete categories
+open import Cat.Instances.Delooping -- Delooping a monoid to give a category
+```
+
 ## Category instances
 
 Category "instances" are constructions of, and proofs associated to, the
@@ -558,28 +580,6 @@ open import Cat.Instances.Comma -- Comma categories
 open import Cat.Instances.Slice -- Slice categories
 open import Cat.Instances.Slice.Presheaf -- PSh(C)/X ≅ PSh(∫ X)
 open import Cat.Instances.Comma.Univalent
-```
-
-Properties, constructions, and the category of strict categories:
-
-```agda
--- Strict categories
-open import Cat.Instances.StrictCat
-open import Cat.Instances.StrictCat.Cohesive
-  -- ^ Strict category structure is a sort of "spatial" structure on a
-  -- set
-
-open import Cat.Instances.Free
--- Free strict categories on a directed graph
-
-open import Cat.Instances.FinSet
--- Skeleton of the category of finite sets
-
-open import Cat.Instances.Simplex
--- Skeleton of the simplex category
-
-open import Cat.Instances.Discrete -- Discrete categories
-open import Cat.Instances.Delooping -- Delooping a monoid to give a category
 ```
 
 ## Allegories

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -182,6 +182,7 @@ open import 1Lab.Path -- Path types
 open import 1Lab.Path.Groupoid  -- Groupoid structure of types
 open import 1Lab.Path.Reasoning -- Combinators for reasoning with path composition
 open import 1Lab.Path.IdentitySystem -- Families R for which R(x,y) ≃ (x ≡ y)
+open import 1Lab.Path.IdentitySystem.Strict -- Identity systems on sets
 
 open import 1Lab.Equiv -- “Contractible fibres” equivalences
 open import 1Lab.Equiv.Biinv -- Biinvertible maps
@@ -472,6 +473,17 @@ open import Cat.Univalent.Rezk.Universal
   -- Universal property of the Rezk completion
 open import Cat.Univalent.Instances.Algebra
   -- Eilenberg-Moore categories preserve univalence
+```
+
+## Strict Categories
+
+In general, precategories do not have a set of objects. We call categories
+that do **strict**.
+
+```agda
+open import Cat.Strict -- Categories with a set of objects.
+open import Cat.Skeletal -- Categories where isomorphisms are automorphisms.
+open import Cat.Gaunt -- Strict univalent categories.
 ```
 
 ## Category instances

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -79,3 +79,4 @@
 \newcommand{\ortho}{\mathrel{\bot}}
 
 \newcommand{\Mod}[1][R]{{#1}\text{-}\thecat{Mod}}
+\newcommand{\refl}{\mathrm{refl}}


### PR DESCRIPTION
# Description

This PR defines strict, gaunt, and skeletal categories, and proves some basic properties about them. These are mainly needed for proving some results involving generic objects, see https://arxiv.org/abs/2210.04202 for more details.
It also defines a notion of "strict identity system", which is an identity system over a set. These extend the custom J eliminators with a custom K, which ends up being handy when dealing with gaunt categories.