### PR TITLE
Fix an inline math formula

### DIFF
--- a/src/Cat/Functor/Kan/Base.lagda.md
+++ b/src/Cat/Functor/Kan/Base.lagda.md
@@ -78,7 +78,7 @@ transformation $\eta : F \To \Lan_p F \circ p$ witnessing the
 ("directed") commutativity of the triangle (so that it need not commute
 on-the-nose) which is universal among such transformations; Meaning that
 if $M : \ca{C'} \to \cD$ is another functor with a transformation
-$\alpha : M \To M \circ p$, there is a unique natural transformation
+$\alpha : F \To M \circ p$, there is a unique natural transformation
 $\sigma : \Lan_p F \To M$ which commutes with $\alpha$.
 
 Note that in general the triangle commutes "weakly", but when $p$ is


### PR DESCRIPTION
# Description

A trivial fix in an math formula.

## Checklist

Before submitting a merge request, please check the items below:

- [x] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [x] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [x] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".

If a commit affects many files without adding any content and you don't
want your name to appear on those pages (for example, treewide refactorings
or reformattings), start the commit message with `chore:` or include the word
`NOAUTHOR` anywhere.
