### PR TITLE
Add cachebusters to CSS and JS

### DIFF
--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -77,6 +77,7 @@ executable shake
       HTML.Emit
     , Shake.AgdaCompile
     , Shake.Diagram
+    , Shake.Digest
     , Shake.Git
     , Shake.KaTeX
     , Shake.LinkGraph

--- a/support/shake/app/Main.hs
+++ b/support/shake/app/Main.hs
@@ -33,6 +33,7 @@ import Shake.LinkGraph
 import Shake.Markdown
 import Shake.Modules
 import Shake.Diagram
+import Shake.Digest
 import Shake.KaTeX
 import Shake.Git
 import Shake.Utils
@@ -48,6 +49,7 @@ import Timer
 rules :: Rules ()
 rules = do
   agdaRules
+  digestRules
   gitRules
   katexRules
   moduleRules

--- a/support/shake/app/Shake/Digest.hs
+++ b/support/shake/app/Shake/Digest.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE BlockArguments, GeneralizedNewtypeDeriving, TypeFamilies #-}
+
+-- | Compute a truncated hash of a file, useful for computing cache-busters
+-- (or other unique ids) for a file.
+module Shake.Digest (digestRules, getFileDigest) where
+
+import qualified Data.ByteString.Lazy as LazyBS
+import Data.Digest.Pure.SHA
+import Data.Typeable
+
+import Development.Shake.Classes (Hashable, Binary, NFData)
+import Development.Shake
+
+newtype FileDigest = FileDigest FilePath
+  deriving (Show, Typeable, Eq, Hashable, Binary, NFData)
+
+type instance RuleResult FileDigest = String
+
+-- | Shake rules required for computing file digest.
+digestRules :: Rules ()
+digestRules = versioned 1 do
+  _ <- addOracle \(FileDigest f) -> do
+    need [f]
+    take 8 . showDigest . sha256 <$> liftIO (LazyBS.readFile f)
+  pure ()
+
+-- | Compute a short digest of a file.
+getFileDigest :: FilePath -> Action String
+getFileDigest = askOracle . FileDigest

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -7,7 +7,7 @@
 
   <title>$pagetitle$ - 1Lab</title>
 
-  <link rel="stylesheet" href="$base-url$/css/default.css" />
+  <link rel="stylesheet" href="$base-url$/css/default.css?v=$digest.css$" />
   <link rel="stylesheet" href="$base-url$/css/katex.min.css" />
 
   <meta name="twitter:card" content="summary" />
@@ -29,8 +29,8 @@
   <meta name="description" content="A formalised, explorable online resource for Homotopy Type Theory." />
   $endif$
 
-  <script src="$base-url$/start.js"></script>
-  <script defer src="$base-url$/main.js"></script>
+  <script src="$base-url$/start.js?v=$digest.start-js$"></script>
+  <script defer src="$base-url$/main.js?v=$digest.main-js$"></script>
 
   <noscript>
     <style>


### PR DESCRIPTION
Just adds a `?v=filehash` to the CSS and JS files. This does not apply to Agda-only files (so those using the "code" template), but I think that's probably fine for now.

~~This does massively increase build times when changing CSS. It looks like some markdown files are taking >5 seconds to be converted. I'm not sure why this is, want to do some profiling before merging.~~