### PR TITLE
Drop explicit syb dependency

### DIFF
--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -23,7 +23,6 @@ common common
     mtl,
     SHA,
     split,
-    syb,
     text,
     transformers,
     unicode-collation,

--- a/support/shake/app/Shake/Git.hs
+++ b/support/shake/app/Shake/Git.hs
@@ -12,7 +12,7 @@ import qualified Data.Set as Set
 import Data.Char (isSpace, isDigit)
 import Data.Text (Text)
 import Data.List (sort)
-import Data.Generics
+import Data.Typeable
 
 import Development.Shake.Classes (Hashable, Binary, NFData)
 import Development.Shake


### PR DESCRIPTION
It's still a dependency of Pandoc, but we don't need it anywhere in our code.
