### PR TITLE
fix: Make category reflection code  more precise

### DIFF
--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -549,6 +549,10 @@ _ term=? _ = false
 “refl” : Term
 “refl” = def (quote refl) []
 
+“Path” : Term → Term → Term → Term
+“Path” A x y =
+  def (quote Path) (unknown h∷ A v∷ x v∷ y v∷ [])
+
 wait-for-args : List (Arg Term) → TC (List (Arg Term))
 wait-for-type : Term → TC Term
 

--- a/src/1Lab/Reflection/Solver.agda
+++ b/src/1Lab/Reflection/Solver.agda
@@ -39,7 +39,7 @@ print-var-repr tm repr env =
 --------------------------------------------------------------------------------
 -- Simple Solvers
 
-record SimpleSolver : Type where
+record Simple-solver : Type where
   constructor simple-solver
   field
     dont-reduce : List Name
@@ -47,8 +47,8 @@ record SimpleSolver : Type where
     invoke-solver : Term → Term → Term
     invoke-normaliser : Term → Term
 
-module _ (solver : SimpleSolver) where
-  open SimpleSolver solver
+module _ (solver : Simple-solver) where
+  open Simple-solver solver
 
   mk-simple-solver : Term → TC ⊤
   mk-simple-solver hole =
@@ -79,7 +79,7 @@ module _ (solver : SimpleSolver) where
 --------------------------------------------------------------------------------
 -- Solvers with Variables
 
-record VariableSolver {ℓ} (A : Type ℓ) : Type ℓ where
+record Variable-solver {ℓ} (A : Type ℓ) : Type ℓ where
   constructor var-solver
   field
     dont-reduce : List Name
@@ -87,8 +87,8 @@ record VariableSolver {ℓ} (A : Type ℓ) : Type ℓ where
     invoke-solver : Term → Term → Term → Term
     invoke-normaliser : Term → Term → Term
 
-module _ {ℓ} {A : Type ℓ} (solver : VariableSolver A) where
-  open VariableSolver solver
+module _ {ℓ} {A : Type ℓ} (solver : Variable-solver A) where
+  open Variable-solver solver
 
   mk-var-solver : Term → TC ⊤
   mk-var-solver hole =

--- a/src/Algebra/Group/Solver.agda
+++ b/src/Algebra/Group/Solver.agda
@@ -220,7 +220,7 @@ module Reflection where
   dont-reduce : List Name
   dont-reduce = quote is-group.unit ∷ quote Group-on._⋆_ ∷ quote is-group.inverse ∷ []
 
-  group-solver : ∀ {ℓ} {A : Type ℓ} → Group-on A → TC (VariableSolver A)
+  group-solver : ∀ {ℓ} {A : Type ℓ} → Group-on A → TC (Variable-solver A)
   group-solver {A = A} grp = do
     grp-tm ← quoteTC grp
     returnTC (var-solver {A = A} dont-reduce build-expr (“solve” grp-tm) (“expand” grp-tm))

--- a/src/Algebra/Ring/Solver.agda
+++ b/src/Algebra/Ring/Solver.agda
@@ -470,7 +470,7 @@ module Reflection where
     quote Ring-on._+_ ∷
     []
 
-  cring-solver : ∀ {ℓ} {A : Type ℓ} → CRing-on A → TC (VariableSolver A)
+  cring-solver : ∀ {ℓ} {A : Type ℓ} → CRing-on A → TC (Variable-solver A)
   cring-solver {A = A} cring = do
     cring-tm ← quoteTC cring
     returnTC $ var-solver dont-reduce (build-expr cring-tm) (“solve” cring-tm) (“expand” cring-tm)

--- a/src/Cat/Diagram/Monad/Solver.agda
+++ b/src/Cat/Diagram/Monad/Solver.agda
@@ -352,27 +352,15 @@ module Reflection where
     monad ← quote-monad-terms M
     pure (simple-solver [] (build-hom-expr monad) (invoke-solver monad) (invoke-normaliser monad))
 
-  repr-macro : ∀ {o h} {𝒞 : Precategory o h} → Monad 𝒞 → Term → Term → TC ⊤
-  repr-macro M tm _ = do
-    solver ← monad-solver M
-    mk-simple-repr solver tm
-
-  simplify-macro : ∀ {o h} {𝒞 : Precategory o h} → Monad 𝒞 → Term → Term → TC ⊤
-  simplify-macro M tm hole = do
-    solver ← monad-solver M
-    mk-simple-normalise solver tm hole
-
-  solve-macro : ∀ {o h} {𝒞 : Precategory o h} → Monad 𝒞 → Term → TC ⊤
-  solve-macro M hole = do
-    solver ← monad-solver M
-    mk-simple-solver solver hole
-
 macro
   monad! : ∀ {o h} {C : Precategory o h} → Monad C → Term → TC ⊤
-  monad! = Reflection.solve-macro
+  monad! M = mk-simple-solver (Reflection.monad-solver M)
 
   simpl-monad! : ∀ {o h} {C : Precategory o h} → Monad C → Term → Term → TC ⊤
-  simpl-monad! = Reflection.simplify-macro
+  simpl-monad! M = mk-simple-normalise (Reflection.monad-solver M)
+
+  repr-monad! : ∀ {o h} {C : Precategory o h} → Monad C → Term → Term → TC ⊤
+  repr-monad! M = mk-simple-repr (Reflection.monad-solver M)
 
 private module Test {o h} {𝒞 : Precategory o h} (monad : Monad 𝒞) where
   open Precategory 𝒞

--- a/src/Cat/Diagram/Monad/Solver.agda
+++ b/src/Cat/Diagram/Monad/Solver.agda
@@ -4,6 +4,7 @@ open import 1Lab.Prelude hiding (id; _∘_)
 open import 1Lab.Reflection hiding (_++_)
 
 open import Cat.Base
+open import Cat.Reflection
 open import Cat.Diagram.Monad
 
 import Cat.Functor.Reasoning as FR
@@ -23,7 +24,7 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
   -- Therefore, we introduce a reflected type of object expressions,
   -- which solves the injectivity issue.
 
-  data ‶Ob‶ : Type o where
+  data ‶Ob‶ : Typeω where
     ‶_‶   : Ob → ‶Ob‶
     ‶M₀‶ : ‶Ob‶ → ‶Ob‶
 
@@ -34,13 +35,13 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
   private variable
     W X Y Z : ‶Ob‶
 
-  data ‶Hom‶ : ‶Ob‶ → ‶Ob‶ → Type (o ⊔ h) where
+  data ‶Hom‶ : ‶Ob‶ → ‶Ob‶ → Typeω where
     ‶M₁‶  : ‶Hom‶ X Y → ‶Hom‶ (‶M₀‶ X) (‶M₀‶ Y)
     ‶η‶   : (X : ‶Ob‶) → ‶Hom‶ X (‶M₀‶ X)
     ‶μ‶   : (X : ‶Ob‶) → ‶Hom‶ (‶M₀‶ (‶M₀‶ X)) (‶M₀‶ X)
     _‶∘‶_ : ‶Hom‶ Y Z → ‶Hom‶ X Y → ‶Hom‶ X Z
     ‶id‶  : ‶Hom‶ X X
-    _↑    : ∀ {X Y} → Hom X Y → ‶Hom‶ ‶ X ‶ ‶ Y ‶
+    ↑    : ∀ X Y → Hom ⟦ X ⟧ₒ ⟦ Y ⟧ₒ → ‶Hom‶ X Y
 
   ⟦_⟧ₕ : ‶Hom‶ X Y → Hom ⟦ X ⟧ₒ ⟦ Y ⟧ₒ
   ⟦ ‶M₁‶ f ⟧ₕ = M₁ ⟦ f ⟧ₕ
@@ -48,18 +49,18 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
   ⟦ ‶μ‶ X ⟧ₕ = mult.η ⟦ X ⟧ₒ
   ⟦ e1 ‶∘‶ e2 ⟧ₕ = ⟦ e1 ⟧ₕ ∘ ⟦ e2 ⟧ₕ
   ⟦ ‶id‶ ⟧ₕ = id
-  ⟦ f ↑ ⟧ₕ = f
+  ⟦ ↑ x y f ⟧ₕ = f
 
   --------------------------------------------------------------------------------
   -- Values
 
-  data Frame : ‶Ob‶ → ‶Ob‶ → Type (o ⊔ h) where
-    khom  : ∀ {X Y} → Hom X Y → Frame ‶ X ‶ ‶ Y ‶
+  data Frame : ‶Ob‶ → ‶Ob‶ → Typeω where
+    khom  : ∀ {X Y} → Hom ⟦ X ⟧ₒ ⟦ Y ⟧ₒ → Frame X Y
     kmap  : Frame X Y → Frame (‶M₀‶ X) (‶M₀‶ Y)
     kunit : (X : ‶Ob‶) → Frame X (‶M₀‶ X)
     kmult : (X : ‶Ob‶) → Frame (‶M₀‶ (‶M₀‶ X)) (‶M₀‶ X)
 
-  data Value : ‶Ob‶ → ‶Ob‶ → Type (o ⊔ h) where
+  data Value : ‶Ob‶ → ‶Ob‶ → Typeω where
     [] : Value X X
     _∷_ : Frame Y Z → Value X Y → Value X Z
 
@@ -116,14 +117,17 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
   -- we can simply apply the relevant equations, and potentially keep pushing
   -- frames down.
   enact-laws (khom f) k' v = khom f ∷ k' ∷ v
-  enact-laws (kmap k) (kmap k') v = do-vmap (enact-laws k k' []) ++ v
-  enact-laws (kmap k) (kunit _) v = kunit _ ∷ push-frm k v
-  enact-laws (kmap k) (kmult _) v = kmult _ ∷ push-frm (kmap (kmap k)) v
+  enact-laws (kmap k) (khom f) v = kmap k ∷ khom f ∷ v
+  enact-laws (kmap k) (kmap k') v = do-vmap (enact-laws k k' []) ++ v      -- Functoriality
+  enact-laws (kmap k) (kunit _) v = kunit _ ∷ push-frm k v                 -- Naturality
+  enact-laws (kmap k) (kmult _) v = kmult _ ∷ push-frm (kmap (kmap k)) v   -- Naturality
   enact-laws (kunit _) k' v = kunit _ ∷ k' ∷ v
+  enact-laws (kmult _) (khom f) v = kmult _ ∷ khom f ∷ v
+  enact-laws (kmult _) (kmap (khom f)) v = kmult _ ∷ kmap (khom f) ∷ v
   enact-laws (kmult _) (kmap (kmap k')) v = kmult _ ∷ kmap (kmap k') ∷ v
-  enact-laws (kmult _) (kmap (kunit _)) v = v
-  enact-laws (kmult _) (kmap (kmult _)) v = kmult _ ∷ push-frm (kmult _) v
-  enact-laws (kmult _) (kunit _) v = v
+  enact-laws (kmult _) (kmap (kunit _)) v = v                              -- Left Identity
+  enact-laws (kmult _) (kmap (kmult _)) v = kmult _ ∷ push-frm (kmult _) v -- Associativity
+  enact-laws (kmult _) (kunit _) v = v                                     -- Right Identity
   enact-laws (kmult _) (kmult _) v = kmult _ ∷ kmult _ ∷ v
 
   -- Small shim, used to enact a law against a potentially empty stack.
@@ -141,7 +145,7 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
   eval (‶μ‶ X) = kmult X ∷ []
   eval (e1 ‶∘‶ e2) = do-vcomp (eval e1) (eval e2)
   eval ‶id‶ = []
-  eval (f ↑) = khom f ∷ []
+  eval (↑ x y f) = khom f ∷ []
 
   --------------------------------------------------------------------------------
   -- Soundness
@@ -160,30 +164,33 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
   enact-laws-sound : ∀ (k1 : Frame Y Z) → (k2 : Frame X Y) → (v : Value W X) → ⟦ enact-laws k1 k2 v ⟧ᵥ ≡ ⟦ k1 ⟧ₖ ∘ ⟦ k2 ⟧ₖ ∘ ⟦ v ⟧ᵥ
   push-frm-sound   : ∀ (k : Frame Y Z) → (v : Value X Y) → ⟦ push-frm k v ⟧ᵥ ≡ ⟦ k ⟧ₖ ∘ ⟦ v ⟧ᵥ
 
-  enact-laws-sound (khom x) k2 v = refl
+  enact-laws-sound (khom f) k' v = refl
+  enact-laws-sound (kmap k1) (khom f) v = refl
   enact-laws-sound (kmap k1) (kmap k2) v =
     ⟦ do-vmap (enact-laws k1 k2 []) ++ v ⟧ᵥ     ≡⟨ vconcat-sound (do-vmap (enact-laws k1 k2 [])) v ⟩
     ⟦ do-vmap (enact-laws k1 k2 []) ⟧ᵥ ∘ ⟦ v ⟧ᵥ ≡⟨ vmap-sound (enact-laws k1 k2 []) ⟩∘⟨refl ⟩
     M₁ ⟦ enact-laws k1 k2 [] ⟧ᵥ M.𝒟.∘ ⟦ v ⟧ᵥ    ≡⟨ M.pushl (enact-laws-sound k1 k2 []) ⟩
     M₁ ⟦ k1 ⟧ₖ ∘ M₁ (⟦ k2 ⟧ₖ ∘ id) ∘ ⟦ v ⟧ᵥ     ≡⟨ refl⟩∘⟨ (M.⟨ idr ⟦ k2 ⟧ₖ ⟩ ⟩∘⟨refl) ⟩
     M₁ ⟦ k1 ⟧ₖ ∘ M₁ ⟦ k2 ⟧ₖ ∘ ⟦ v ⟧ᵥ            ∎
-  enact-laws-sound (kmap {Y = Y} k1) (kunit X) v =
-    unit.η ⟦ Y ⟧ₒ ∘ ⟦ push-frm k1 v ⟧ᵥ    ≡⟨ refl⟩∘⟨ push-frm-sound k1 v ⟩
-    unit.η ⟦ Y ⟧ₒ ∘ ⟦ k1 ⟧ₖ ∘ ⟦ v ⟧ᵥ      ≡⟨ extendl (unit.is-natural ⟦ X ⟧ₒ ⟦ Y ⟧ₒ ⟦ k1 ⟧ₖ) ⟩
-    M.F₁ ⟦ k1 ⟧ₖ ∘ unit.η ⟦ X ⟧ₒ ∘ ⟦ v ⟧ᵥ ∎
-  enact-laws-sound (kmap {Y = Y} k1) (kmult X) v =
-    mult.η ⟦ Y ⟧ₒ ∘ ⟦ push-frm (kmap (kmap k1)) v ⟧ᵥ ≡⟨ refl⟩∘⟨ push-frm-sound (kmap (kmap k1)) v ⟩
-    mult.η ⟦ Y ⟧ₒ ∘ M₁ (M₁ ⟦ k1 ⟧ₖ) ∘ ⟦ v ⟧ᵥ         ≡⟨ extendl (mult.is-natural ⟦ X ⟧ₒ ⟦ Y ⟧ₒ ⟦ k1 ⟧ₖ) ⟩
-    M.F₁ ⟦ k1 ⟧ₖ ∘ mult.η ⟦ X ⟧ₒ ∘ ⟦ v ⟧ᵥ            ∎
-  enact-laws-sound (kunit X) k2 v = refl
-  enact-laws-sound (kmult X) (kmap (kmap k2)) v = refl
-  enact-laws-sound (kmult X) (kmap (kunit .X)) v = insertl left-ident
-  enact-laws-sound (kmult X) (kmap (kmult .X)) v =
-    mult.η ⟦ X ⟧ₒ ∘ ⟦ push-frm (kmult (‶M₀‶ X)) v ⟧ᵥ ≡⟨ refl⟩∘⟨ push-frm-sound (kmult (‶M₀‶ X)) v ⟩
-    mult.η ⟦ X ⟧ₒ ∘ mult.η (M₀ ⟦ X ⟧ₒ) ∘ ⟦ v ⟧ᵥ      ≡⟨ extendl (sym mult-assoc) ⟩
-    mult.η ⟦ X ⟧ₒ ∘ M₁ (mult.η ⟦ X ⟧ₒ) ∘ ⟦ v ⟧ᵥ ∎
-  enact-laws-sound (kmult X) (kunit _) v = insertl right-ident
-  enact-laws-sound (kmult X) (kmult _) v = refl
+  enact-laws-sound (kmap k1) (kunit _) v =
+    unit.η _ ∘ ⟦ push-frm k1 v ⟧ᵥ    ≡⟨ refl⟩∘⟨ push-frm-sound k1 v ⟩
+    unit.η _ ∘ ⟦ k1 ⟧ₖ ∘ ⟦ v ⟧ᵥ      ≡⟨ extendl (unit.is-natural _ _ ⟦ k1 ⟧ₖ) ⟩
+    M.F₁ ⟦ k1 ⟧ₖ ∘ unit.η _ ∘ ⟦ v ⟧ᵥ ∎
+  enact-laws-sound (kmap k1) (kmult _) v =
+    mult.η _ ∘ ⟦ push-frm (kmap (kmap k1)) v ⟧ᵥ ≡⟨ refl⟩∘⟨ push-frm-sound (kmap (kmap k1)) v ⟩
+    mult.η _ ∘ M₁ (M₁ ⟦ k1 ⟧ₖ) ∘ ⟦ v ⟧ᵥ         ≡⟨ extendl (mult.is-natural _ _ ⟦ k1 ⟧ₖ) ⟩
+    M.F₁ ⟦ k1 ⟧ₖ ∘ mult.η _ ∘ ⟦ v ⟧ᵥ            ∎
+  enact-laws-sound (kunit _) k2 v = refl
+  enact-laws-sound (kmult _) (khom f) v = refl
+  enact-laws-sound (kmult _) (kmap (khom f)) v = refl
+  enact-laws-sound (kmult _) (kmap (kmap k2)) v = refl
+  enact-laws-sound (kmult _) (kmap (kunit _)) v = insertl left-ident
+  enact-laws-sound (kmult _) (kmap (kmult _)) v =
+    mult.η _ ∘ ⟦ push-frm (kmult _) v ⟧ᵥ ≡⟨ refl⟩∘⟨ push-frm-sound (kmult _) v ⟩
+    mult.η _ ∘ mult.η (M₀ _) ∘ ⟦ v ⟧ᵥ    ≡⟨ extendl (sym mult-assoc) ⟩
+    mult.η _ ∘ M₁ (mult.η _) ∘ ⟦ v ⟧ᵥ    ∎
+  enact-laws-sound (kmult _) (kunit _) v = insertl right-ident
+  enact-laws-sound (kmult _) (kmult _) v = refl
 
   push-frm-sound k [] = refl
   push-frm-sound k (k' ∷ v) = enact-laws-sound k k' v
@@ -207,7 +214,7 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
     ⟦ eval e1 ⟧ᵥ ∘ ⟦ eval e2 ⟧ᵥ       ≡⟨ ap₂ _∘_ (eval-sound e1) (eval-sound e2) ⟩
     ⟦ e1 ⟧ₕ ∘ ⟦ e2 ⟧ₕ                 ∎
   eval-sound ‶id‶ = refl
-  eval-sound (f ↑) = idr f
+  eval-sound (↑ x y f) = idr f
 
   abstract
     solve : ∀ (e1 e2 : ‶Hom‶ X Y) → ⟦ eval e1 ⟧ᵥ ≡ ⟦ eval e2 ⟧ᵥ → ⟦ e1 ⟧ₕ ≡ ⟦ e2 ⟧ₕ
@@ -215,103 +222,141 @@ module NbE {o h} {𝒞 : Precategory o h} (M : Monad 𝒞) where
 
 module Reflection where
 
-  pattern category-args xs =
-    _ hm∷ _ hm∷ _ v∷ xs
-
-  pattern functor-args functor xs =
-    _ hm∷ _ hm∷ _ hm∷ _ hm∷ _ hm∷ _ hm∷ functor v∷ xs
-
-  pattern nat-trans-args nt args =
-    _ hm∷ _ hm∷ _ hm∷ _ hm∷
-    _ hm∷ _ hm∷
-    _ hm∷ _ hm∷
-    nt v∷ args
-
-
   pattern monad-args monad xs =
     _ hm∷ _ hm∷ _ hm∷ monad v∷ xs
 
-  pattern monad-fn-args monad xs =
-    _ h∷ _ h∷ _ h∷ monad v∷ xs
-
-  pattern “id” =
-    def (quote Precategory.id) (category-args (_ h∷ []))
-
-  pattern “∘” f g =
-    def (quote Precategory._∘_) (category-args (_ h∷ _ h∷ _ h∷ f v∷ g v∷ []))
-
-  pattern “M₀” monad x =
-    def (quote Monad.M₀) (monad-fn-args monad (x v∷ []))
-
-  pattern “M₁” monad f =
-    def (quote Monad.M₁) (monad-fn-args monad (_ h∷ _ h∷ f v∷ []))
-
-  pattern “η” monad x =
-    def (quote _=>_.η) (nat-trans-args (def (quote Monad.unit) (monad-args monad [])) (x v∷ []))
-
-  pattern “μ” monad x =
-    def (quote _=>_.η) (nat-trans-args (def (quote Monad.mult) (monad-args monad [])) (x v∷ []))
-
   mk-monad-args : Term → List (Arg Term) → List (Arg Term)
-  mk-monad-args monad args = unknown h∷ unknown h∷ unknown h∷ monad v∷ args
+  mk-monad-args monad xs = infer-hidden 3 $ monad v∷ xs
+
+  record Monad-terms : Type where
+    field
+      cat : Term
+      monad : Term
+
+    functor : Term
+    functor = def (quote Monad.M) (mk-monad-args monad [])
+
+    functor-tms : Functor-terms
+    functor-tms = record
+      { c-cat = cat
+      ; d-cat = cat
+      ; functor = functor
+      }
+
+    unit-tms : Nat-trans-terms
+    unit-tms = record
+      { c-cat = cat
+      ; d-cat = cat
+      ; F-functor = “Id” cat
+      ; G-functor = functor
+      ; nat-trans = def (quote Monad.unit) (mk-monad-args monad [])
+      }
+
+    mult-tms : Nat-trans-terms
+    mult-tms = record
+      { c-cat = cat
+      ; d-cat = cat
+      ; F-functor = functor “F∘” functor
+      ; G-functor = functor
+      ; nat-trans = def (quote Monad.mult) (mk-monad-args monad [])
+      }
+
+  open Monad-terms
+
+  quote-monad-terms : ∀ {o ℓ} {C : Precategory o ℓ} → Monad C → TC Monad-terms
+  quote-monad-terms {C = C} M = do
+    cat ← quoteTC C
+    monad ← quoteTC M
+    pure (record { cat = cat ; monad = monad })
+
+  match-M₀ : Monad-terms → Term → TC Term
+  match-M₀ m tm = match-F₀ (functor-tms m) tm
+
+  match-M₁ : Monad-terms → Term → TC Term
+  match-M₁ m tm = match-F₁ (functor-tms m) tm
+
+  match-unit : Monad-terms → Term → TC Term
+  match-unit m tm = match-η (unit-tms m) tm
+
+  match-mult : Monad-terms → Term → TC Term
+  match-mult m tm = match-η (mult-tms m) tm
 
   “solve” : Term → Term → Term → Term
   “solve” monad lhs rhs =
     def (quote NbE.solve) (mk-monad-args monad $ infer-hidden 2 $ lhs v∷ rhs v∷ def (quote refl) [] v∷ [])
 
-  build-object-expr : Term → Term → TC Term
-  build-object-expr monad (“M₀” monad' x) = do
-    unify monad monad'
-    x ← build-object-expr monad x
-    returnTC $ con (quote NbE.‶M₀‶) (x v∷ [])
-  build-object-expr monad x =
-    returnTC $ con (quote NbE.‶_‶) (x v∷ [])
+  {-# TERMINATING #-}
+  build-object-expr : Monad-terms → Term → TC Term
+  build-object-expr m tm =
+    (do
+       x ← match-M₀ m tm
+       x ← build-object-expr m x
+       pure $ con (quote NbE.‶M₀‶) (x v∷ []))
+    <|>
+    (pure $ con (quote NbE.‶_‶) (tm v∷ []))
 
-  build-hom-expr : Term → Term → TC Term
-  build-hom-expr monad “id” =
-    returnTC $ con (quote NbE.‶id‶) []
-  build-hom-expr monad (“∘” f g) = do
-    f ← build-hom-expr monad f
-    g ← build-hom-expr monad g
-    returnTC $ con (quote NbE._‶∘‶_) (f v∷ g v∷ [])
-  build-hom-expr monad (“M₁” monad' f) = do
-    unify monad monad'
-    f ← build-hom-expr monad f
-    returnTC $ con (quote NbE.‶M₁‶) (f v∷ [])
-  build-hom-expr monad (“η” monad' x) = do
-    unify monad monad'
-    x ← build-object-expr monad x
-    returnTC $ con (quote NbE.‶η‶) (x v∷ [])
-  build-hom-expr monad (“μ” monad' x) = do
-    x ← build-object-expr monad x
-    unify monad monad'
-    returnTC $ con (quote NbE.‶μ‶) (x v∷ [])
-  build-hom-expr monad f =
-    returnTC $ con (quote NbE._↑) (f v∷ [])
+  build-neu-hom-expr : Monad-terms → Term → TC Term
+  build-neu-hom-expr m f = do
+    x , y ← get-hom-objects (m .cat) =<< inferType f
+    debugPrint "tactic" 50
+      [ "Building neutral hom expression: " , termErr f
+      , "\n  Has type: Hom (" , termErr x , ") (" , termErr y , ")"
+      ]
+    x ← build-object-expr m =<< normalise x
+    y ← build-object-expr m =<< normalise y
+    returnTC $ con (quote NbE.↑) (x v∷ y v∷ f v∷ [])
 
-  dont-reduce : List Name
-  dont-reduce =
-    quote Precategory.id ∷ quote Precategory._∘_ ∷
-    quote Functor.F₀ ∷ quote Functor.F₁ ∷
-    quote _=>_.η ∷
-    quote Monad.M ∷ quote Monad.unit ∷ quote Monad.mult ∷ []
+  {-# TERMINATING #-}
+  build-hom-expr : Monad-terms → Term → TC Term
+  build-hom-expr m tm =
+    (do
+       match-id (m .cat) tm
+       pure (con (quote NbE.‶id‶) []))
+    <|>
+    (do
+       f , g ← match-∘ (m .cat) tm
+       f ← build-hom-expr m f
+       g ← build-hom-expr m g
+       pure (con (quote NbE._‶∘‶_) (f v∷ g v∷ [])))
+    <|>
+    (do
+       f ← match-M₁ m tm
+       f ← build-hom-expr m f
+       pure (con (quote NbE.‶M₁‶) (f v∷ [])))
+    <|>
+    (do
+       x ← match-unit m tm
+       x ← build-object-expr m x
+       pure (con (quote NbE.‶η‶) (x v∷ [])))
+    <|>
+    (do
+       x ← match-mult m tm
+       x ← build-object-expr m x
+       pure (con (quote NbE.‶μ‶) (x v∷ [])))
+    <|>
+    (build-neu-hom-expr m tm)
 
   solve-macro : ∀ {o h} {𝒞 : Precategory o h} → Monad 𝒞 → Term → TC ⊤
-  solve-macro monad hole =
-    withNormalisation false $
-    withReduceDefs (false , dont-reduce) $ do
-      monad-tm ← quoteTC monad
-      goal ← inferType hole >>= reduce
-      just (lhs , rhs) ← get-boundary goal
-        where nothing → typeError $ strErr "Can't determine boundary: " ∷
-                                    termErr goal ∷ []
-      elhs ← build-hom-expr monad-tm lhs
-      erhs ← build-hom-expr monad-tm rhs
-      noConstraints $ unify hole (“solve” monad-tm elhs erhs)
+  solve-macro M hole = do
+    monad-tms ← quote-monad-terms M
+    goal ← inferType hole >>= reduce
+    just (lhs , rhs) ← get-boundary goal
+      where nothing → typeError $ strErr "Can't determine boundary: " ∷
+                                  termErr goal ∷ []
+    elhs ← build-hom-expr monad-tms =<< normalise lhs
+    erhs ← build-hom-expr monad-tms =<< normalise rhs
+    catchTC
+      (noConstraints $ unify hole (“solve” (monad-tms .monad) elhs erhs))
+      (typeError $
+        strErr "Could not solve monad equation:\n  "
+        ∷ termErr lhs ∷ strErr " ≡ " ∷ termErr rhs
+        ∷ "\nReflected representation:\nRHS: "
+        ∷ termErr elhs ∷ strErr "\nLHS: " ∷ termErr erhs
+        ∷ [])
 
 macro
-  monad! : ∀ {o h} {𝒞 : Precategory o h} → Monad 𝒞 → Term → TC ⊤
-  monad! monad = Reflection.solve-macro monad
+  monad! : ∀ {o h} {C : Precategory o h} → Monad C → Term → TC ⊤
+  monad! M = Reflection.solve-macro M
 
 private module Test {o h} {𝒞 : Precategory o h} (monad : Monad 𝒞) where
   open Precategory 𝒞
@@ -332,3 +377,6 @@ private module Test {o h} {𝒞 : Precategory o h} (monad : Monad 𝒞) where
 
   test-separate : ∀ X → M₁ (mult.η X) ∘ M₁ (unit.η (M₀ X)) ≡ id
   test-separate _ = monad! monad
+
+  test-type : ∀ {x y} → (f : Hom x (M₀ y)) → mult.η y ∘ M₁ f ∘ unit.η x ≡ f
+  test-type _ = monad! monad

--- a/src/Cat/Diagram/Product/Reflection.agda
+++ b/src/Cat/Diagram/Product/Reflection.agda
@@ -1,0 +1,79 @@
+
+open import 1Lab.Prelude hiding (_∘_; id)
+open import 1Lab.Reflection
+
+open import Cat.Base
+open import Cat.Reflection
+open import Cat.Diagram.Product
+
+module Cat.Diagram.Product.Reflection where
+
+record Product-terms : Type where
+  field
+    cat : Term
+    prod : Term -- Proof of 'has-products'
+
+open Product-terms
+
+quote-product-terms
+  : ∀ {o ℓ} (C : Precategory o ℓ) (has-prods : has-products C)
+  → TC Product-terms
+quote-product-terms C has-prods = do
+  cat ← quoteTC C
+  prod ← quoteTC has-prods
+  pure (record { cat = cat ; prod = prod })
+
+product-args : Product-terms → List (Arg Term) → List (Arg Term)
+product-args ptm args =
+  category-args (ptm .cat) (ptm .prod v∷ args)
+
+“⊗₀” : Product-terms → Term → Term → Term
+“⊗₀” ptm x y =
+  def (quote Binary-products._⊗₀_) (product-args ptm (x v∷ y v∷ []))
+
+“π₁” : Product-terms → Term
+“π₁” ptm =
+  def (quote Binary-products.π₁) (product-args ptm [])
+
+“π₂” : Product-terms → Term
+“π₂” ptm =
+  def (quote Binary-products.π₂) (product-args ptm [])
+
+
+“⟨⟩” : Product-terms → Term → Term → Term
+“⟨⟩” ptm f g =
+  def (quote Binary-products.⟨_,_⟩) (product-args ptm (infer-hidden 3 (f v∷ g v∷ [])))
+
+match-⊗₀ : Product-terms → Term → TC (Term × Term)
+match-⊗₀ ptm tm = do
+  x ← new-meta (“Ob” (ptm .cat))
+  y ← new-meta (“Ob” (ptm .cat))
+  unify tm (“⊗₀” ptm x y)
+  debugPrint "tactic" 50 [ "Matched ⊗₀ for " , termErr tm ]
+  x ← reduce x
+  y ← reduce y
+  pure (x , y)
+
+match-π₁ : Product-terms → Term → TC ⊤
+match-π₁ ptm tm = do
+  unify tm (“π₁” ptm)
+  debugPrint "tactic" 50 [ "Matched π₁ for " , termErr tm ]
+
+match-π₂ : Product-terms → Term → TC ⊤
+match-π₂ ptm tm = do
+  unify tm (“π₂” ptm)
+  debugPrint "tactic" 50 [ "Matched π₂ for " , termErr tm ]
+
+match-⟨⟩ : Product-terms → Term → TC (Term × Term)
+match-⟨⟩ ptm tm = do
+  f ← new-meta (“Hom” (ptm .cat) unknown unknown)
+  g ← new-meta (“Hom” (ptm .cat) unknown unknown)
+  debugPrint "tactic" 100
+    [ "Attempting to match ⟨⟩: " , termErr tm
+    , "\n  Unifying against: " , termErr (“⟨⟩” ptm f g)
+    ]
+  unify tm (“⟨⟩” ptm f g)
+  debugPrint "tactic" 50 [ "Matched ⟨⟩ for " , termErr tm ]
+  f ← reduce f
+  g ← reduce g
+  pure (f , g)

--- a/src/Cat/Displayed/Reflection.agda
+++ b/src/Cat/Displayed/Reflection.agda
@@ -1,0 +1,105 @@
+open import 1Lab.Prelude hiding (_∘_; id)
+open import 1Lab.Reflection
+
+open import Cat.Displayed.Base
+import Cat.Displayed.Reasoning as Dr
+
+open import Cat.Base
+open import Cat.Reflection
+
+module Cat.Displayed.Reflection where
+
+displayed-args : Term → List (Arg Term) → List (Arg Term)
+displayed-args disp xs = infer-hidden 5 $ disp v∷ xs
+
+“Ob[]” : Term → Term → Term
+“Ob[]” disp x =
+  def (quote Displayed.Ob[_]) (displayed-args disp (x v∷ []))
+
+“Hom[]” : Term → Term → Term → Term → Term
+“Hom[]” disp f x y =
+    def (quote Displayed.Hom[_]) (displayed-args disp (infer-hidden 2 (f v∷ x v∷ y v∷ [])))
+
+“id′” : Term → Term → Term → Term
+“id′” disp x x′ =
+  def (quote Displayed.id′) (displayed-args disp (x h∷ x′ h∷ []))
+
+“∘′” : Term → Term → Term → Term → Term → Term
+“∘′” disp f g f′ g′ =
+  def (quote Displayed._∘′_) (displayed-args disp (infer-hidden 6 (f h∷ g h∷ f′ v∷ g′ v∷ [])))
+
+“hom[]” : Term → Term → Term → Term → Term → Term
+“hom[]” disp f g p f′ =
+  def (quote Dr.hom[_]) (displayed-args disp (infer-hidden 4 (f h∷ g h∷ p v∷ f′ v∷ [])))
+
+record Displayed-terms : Type where
+  field
+    cat : Term
+    disp : Term
+
+open Displayed-terms
+
+quote-displayed-terms
+  : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
+  → Displayed B o′′ ℓ′′
+  → TC Displayed-terms
+quote-displayed-terms {B = B} E = do
+  cat ← quoteTC B
+  disp ← quoteTC E
+  pure (record { cat = cat ; disp = disp })
+
+match-id′ : Displayed-terms → Term → TC ⊤
+match-id′ dtm tm = do
+  id′ ← normalise (“id′” (dtm .disp) unknown unknown)
+  unify tm id′
+  debugPrint "tactic" 50 [ "Matched id′ for " , termErr tm ]
+
+match-∘′ : Displayed-terms → Term → TC (Term × Term × Term × Term)
+match-∘′ dtm tm = do
+  f-meta ← new-meta (“Hom” (dtm .cat) unknown unknown)
+  g-meta ← new-meta (“Hom” (dtm .cat) unknown unknown)
+  f′-meta ← new-meta (“Hom[]” (dtm .disp) f-meta unknown unknown)
+  g′-meta ← new-meta (“Hom[]” (dtm .disp) g-meta unknown unknown)
+  ∘′ ← normalise (“∘′” (dtm .disp) f-meta g-meta f′-meta g′-meta)
+  unify tm ∘′
+  debugPrint "tactic" 50 [ "Matched ∘′ for " , termErr tm ]
+  f-meta ← reduce f-meta
+  g-meta ← reduce g-meta
+  f′-meta ← reduce f′-meta
+  g′-meta ← reduce g′-meta
+  pure (f-meta , g-meta , f′-meta , g′-meta)
+
+match-hom[] : Displayed-terms → Term → TC (Term × Term × Term × Term)
+match-hom[] dtm tm = do
+  f-meta ← new-meta (“Hom” (dtm .cat) unknown unknown)
+  g-meta ← new-meta (“Hom” (dtm .cat) unknown unknown)
+  p-meta ← new-meta (“Path” (“Hom” (dtm .cat) unknown unknown) f-meta g-meta)
+  f′-meta ← new-meta (“Hom[]” (dtm .disp) f-meta unknown unknown)
+  let hom[] = “hom[]” (dtm .disp) f-meta g-meta p-meta f′-meta
+  unify tm hom[]
+  f-meta ← reduce f-meta
+  g-meta ← reduce g-meta
+  p-meta ← reduce p-meta
+  f′-meta ← reduce f′-meta
+  debugPrint "tactic" 50
+    [ "Matched hom[] for " , termErr tm
+    , "\n  f  : " , termErr f-meta
+    , "\n  g  : " , termErr g-meta
+    , "\n  p  : " , termErr p-meta
+    , "\n  f′ : " , termErr f′-meta
+    ]
+  pure (f-meta , g-meta , p-meta , f′-meta)
+
+get-hom[]-objects : Displayed-terms → Term → TC (Term × Term × Term)
+get-hom[]-objects dtm tm = do
+  tm ← normalise tm
+  x ← new-meta (“Ob” (dtm .cat))
+  y ← new-meta (“Ob” (dtm .cat))
+  f ← new-meta (“Hom” (dtm .cat) x y)
+  x′ ← new-meta (“Ob[]” (dtm .disp) x)
+  y′ ← new-meta (“Ob[]” (dtm .disp) y)
+  unify tm (“Hom[]” (dtm .disp) f x′ y′)
+  f ← reduce f
+  x′ ← reduce x′
+  y′ ← reduce y′
+  pure (f , x′ , y′)

--- a/src/Cat/Displayed/Solver.agda
+++ b/src/Cat/Displayed/Solver.agda
@@ -194,48 +194,24 @@ module Reflection where
     dtm ← quote-displayed-terms E
     pure (simple-solver (quote Dr.hom[] ∷ []) (build-expr dtm) (invoke-solver dtm) (invoke-normaliser dtm))
 
-  repr-macro
-    : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
-    → Displayed B o′′ ℓ′′
-    → Term → Term → TC ⊤
-  repr-macro E f _ = do
-    solver ← displayed-solver E
-    mk-simple-repr solver f
-
-  simplify-macro
-    : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
-    → Displayed B o′′ ℓ′′
-    → Term → Term → TC ⊤
-  simplify-macro E f hole = do
-    solver ← displayed-solver E
-    mk-simple-normalise solver f hole
-
-  solve-macro
-    : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
-    → Displayed B o′′ ℓ′′
-    → Term → TC ⊤
-  solve-macro E hole = do
-    solver ← displayed-solver E
-    mk-simple-solver solver hole
-
 macro
   repr-disp!
     : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
     → Displayed B o′′ ℓ′′
     → Term → Term → TC ⊤
-  repr-disp! = Reflection.repr-macro
+  repr-disp! E = mk-simple-repr (Reflection.displayed-solver E)
 
   simpl-disp!
     : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
     → Displayed B o′′ ℓ′′
     → Term → Term → TC ⊤
-  simpl-disp! = Reflection.simplify-macro
+  simpl-disp! E = mk-simple-normalise (Reflection.displayed-solver E)
 
   disp!
     : ∀ {o′ ℓ′ o′′ ℓ′′} {B : Precategory o′ ℓ′}
     → Displayed B o′′ ℓ′′
     → Term → TC ⊤
-  disp! = Reflection.solve-macro
+  disp! E = mk-simple-solver (Reflection.displayed-solver E)
 
 private module Test {o ℓ o′ ℓ′} {B : Precategory o ℓ} (E : Displayed B o′ ℓ′) where
   open Precategory B

--- a/src/Cat/Functor/Solver.agda
+++ b/src/Cat/Functor/Solver.agda
@@ -195,43 +195,24 @@ module Reflection where
   functor-solver F = do
     func ← quote-functor-terms F
     pure (simple-solver [] (build-dexpr func) (invoke-solver func) (invoke-normaliser func))
-
-  repr-macro
-    : ∀ {o h o′ h′} {C : Precategory o h} {D : Precategory o′ h′}
-    → Functor C D
-    → Term → Term → TC ⊤
-  repr-macro F tm _ = do
-    solver ← functor-solver F
-    mk-simple-repr solver tm
-
-  simplify-macro
-    : ∀ {o h o′ h′} {C : Precategory o h} {D : Precategory o′ h′}
-    → Functor C D
-    → Term → Term → TC ⊤
-  simplify-macro F tm hole = do
-    solver ← functor-solver F
-    mk-simple-normalise solver tm hole
-
-  solve-macro
-    : ∀ {o h o′ h′} {C : Precategory o h} {D : Precategory o′ h′}
-    → Functor C D
-    → Term → TC ⊤
-  solve-macro F hole = do
-    solver ← functor-solver F
-    mk-simple-solver solver hole
-
 macro
-  functor!
+  repr-functor!
     : ∀ {o h o′ h′} {𝒞 : Precategory o h} {𝒟 : Precategory o′ h′}
     → Functor 𝒞 𝒟
-    → Term → TC ⊤
-  functor! = Reflection.solve-macro
+    → Term → Term → TC ⊤
+  repr-functor! F = mk-simple-repr (Reflection.functor-solver F)
 
   simpl-functor!
     : ∀ {o h o′ h′} {𝒞 : Precategory o h} {𝒟 : Precategory o′ h′}
     → Functor 𝒞 𝒟
     → Term → Term → TC ⊤
-  simpl-functor! = Reflection.simplify-macro
+  simpl-functor! F = mk-simple-normalise (Reflection.functor-solver F)
+
+  functor!
+    : ∀ {o h o′ h′} {𝒞 : Precategory o h} {𝒟 : Precategory o′ h′}
+    → Functor 𝒞 𝒟
+    → Term → TC ⊤
+  functor! F = mk-simple-solver (Reflection.functor-solver F)
 
 private module Test {o h o′ h′} {𝒞 : Precategory o h} {𝒟 : Precategory o′ h′} (F : Functor 𝒞 𝒟) where
   module 𝒞 = Cat 𝒞

--- a/src/Cat/Reflection.agda
+++ b/src/Cat/Reflection.agda
@@ -117,6 +117,7 @@ match-id : Term → Term → TC ⊤
 match-id cat tm = do
   id ← normalise (“id” cat unknown)
   unify tm id
+  commitTC
   debugPrint "tactic" 50 [ "Matched id for " , termErr tm ]
 
 match-∘ : Term → Term → TC (Term × Term)

--- a/src/Cat/Reflection.agda
+++ b/src/Cat/Reflection.agda
@@ -1,0 +1,178 @@
+open import Cat.Base
+
+open import 1Lab.Prelude hiding (_∘_; id)
+open import 1Lab.Reflection
+
+module Cat.Reflection where
+
+--------------------------------------------------------------------------------
+-- Patterns for Category Reflection
+
+pattern category-args cat xs =
+  _ hm∷ _ hm∷ cat v∷ xs
+
+mk-category-args : Term → List (Arg Term) → List (Arg Term)
+mk-category-args cat xs = infer-hidden 2 $ cat v∷ xs
+
+pattern “id” cat =
+  def (quote Precategory.id) (category-args cat (_ h∷ []))
+
+pattern “∘” cat f g =
+  def (quote Precategory._∘_) (category-args cat (_ h∷ _ h∷ _ h∷ f v∷ g v∷ []))
+
+pattern “Hom” C x y =
+  def (quote Precategory.Hom) (category-args C (x v∷ y v∷ []))
+
+pattern functor-args functor xs =
+  _ hm∷ _ hm∷ _ hm∷ _ hm∷ _ hm∷ _ hm∷ functor v∷ xs
+
+mk-functor-args : Term → List (Arg Term) → List (Arg Term)
+mk-functor-args functor xs = infer-hidden 6 $ functor v∷ xs
+
+pattern “F₀” functor x =
+  def (quote Functor.F₀) (functor-args functor (x v∷ []))
+
+pattern “F₁” functor f =
+  def (quote Functor.F₁) (functor-args functor (_ h∷ _ h∷ f v∷ []))
+
+“Id” : Term → Term
+“Id” cat = def (quote Id) (infer-hidden 2 $ cat h∷ [])
+
+_“F∘”_ : Term → Term → Term
+F “F∘” G = def (quote _F∘_) (infer-hidden 9 $ F v∷ G v∷ [])
+
+pattern nat-trans-args nt args =
+  _ hm∷ _ hm∷ _ hm∷ _ hm∷
+  _ hm∷ _ hm∷
+  _ hm∷ _ hm∷
+  nt v∷ args
+
+mk-nat-trans-args : Term → List (Arg Term) → List (Arg Term)
+mk-nat-trans-args nat-trans xs = infer-hidden 8 $ nat-trans v∷ xs
+
+pattern “η” nat-trans x =
+  def (quote _=>_.η) (nat-trans-args nat-trans (x v∷ []))
+
+--------------------------------------------------------------------------------
+-- Term Bundles
+
+record Functor-terms : Type where
+  field
+    c-cat : Term
+    d-cat : Term
+    functor : Term
+
+quote-functor-terms
+  : ∀ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
+  → Functor C D
+  → TC Functor-terms
+quote-functor-terms {C = C} {D = D} F = do
+  c-cat ← quoteTC C
+  d-cat ← quoteTC D
+  functor ← quoteTC F
+  pure (record { c-cat = c-cat ; d-cat = d-cat ; functor = functor })
+  where open Functor-terms
+
+record Nat-trans-terms : Type where
+  field
+    c-cat : Term
+    d-cat : Term
+    F-functor : Term
+    G-functor : Term
+    nat-trans : Term
+
+  F-terms : Functor-terms
+  F-terms = record { c-cat = c-cat ; d-cat = d-cat ; functor = F-functor }
+
+  G-terms : Functor-terms
+  G-terms = record { c-cat = c-cat ; d-cat = d-cat ; functor = G-functor }
+
+quote-nat-trans-terms
+  : ∀ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
+  → {F G : Functor C D}
+  → F => G
+  → TC Nat-trans-terms
+quote-nat-trans-terms {C = C} {D = D} {F = F} {G = G} α = do
+  c-cat ← quoteTC C
+  d-cat ← quoteTC D
+  F-functor ← quoteTC F
+  G-functor ← quoteTC G
+  nat-trans ← quoteTC α
+  pure (record
+         { c-cat = c-cat
+         ; d-cat = d-cat
+         ; F-functor = F-functor
+         ; G-functor = G-functor
+         ; nat-trans = nat-trans
+         })
+
+--------------------------------------------------------------------------------
+-- Name Matchers
+
+new-ob-meta : Term → TC Term
+new-ob-meta cat =
+  new-meta (def (quote Precategory.Ob) (mk-category-args cat []))
+
+new-hom-meta : Term → Term → Term → TC Term
+new-hom-meta cat x y =
+  new-meta (def (quote Precategory.Hom) (mk-category-args cat (x v∷ y v∷ [])))
+
+data Precategory-fields : Type where
+  id-field : Precategory-fields
+  ∘-field  : Term → Term → Precategory-fields
+
+match-id : Term → Term → TC ⊤
+match-id cat tm = do
+  id ← normalise (def (quote Precategory.id) (mk-category-args cat (infer-hidden 1 [])))
+  unify tm id
+  debugPrint "tactic" 50 [ "Matched id for " , termErr tm ]
+
+match-∘ : Term → Term → TC (Term × Term)
+match-∘ cat tm = do
+  f-meta ← new-hom-meta cat unknown unknown
+  g-meta ← new-hom-meta cat unknown unknown
+  comp ← normalise (def (quote Precategory._∘_) (mk-category-args cat (infer-hidden 3 $ f-meta v∷ g-meta v∷ [])))
+  unify tm comp
+  debugPrint "tactic" 50 [ "Matched ∘ for " , termErr tm ]
+  f-meta ← reduce f-meta
+  g-meta ← reduce g-meta
+  pure (f-meta , g-meta)
+
+match-F₀ : Functor-terms → Term → TC Term
+match-F₀ func tm = do
+  x-meta ← new-ob-meta c-cat
+  F₀ ← normalise (def (quote Functor.F₀) (mk-functor-args functor (x-meta v∷ [])))
+  unify tm F₀
+  debugPrint "tactic" 50 [ "Matched F₀ for " , termErr tm ]
+  reduce x-meta
+  where open Functor-terms func
+
+match-F₁ : Functor-terms → Term → TC Term
+match-F₁ func tm = do
+  f-meta ← new-hom-meta c-cat unknown unknown
+  F₁ ← normalise (def (quote Functor.F₁) (mk-functor-args functor (infer-hidden 2 $ f-meta v∷ [])))
+  unify tm F₁
+  debugPrint "tactic" 50 [ "Matched F₁ for " , termErr tm ]
+  reduce f-meta
+  where open Functor-terms func
+
+match-η : Nat-trans-terms → Term → TC Term
+match-η nt tm = do
+  x-meta ← new-ob-meta d-cat
+  η ← normalise (def (quote _=>_.η) (mk-nat-trans-args nat-trans (x-meta v∷ [])))
+  unify tm η
+  debugPrint "tactic" 50 [ "Matched η for " , termErr tm ]
+  reduce x-meta
+  where open Nat-trans-terms nt
+
+--------------------------------------------------------------------------------
+-- Extracting Objects
+
+-- Get the source and target of a 'Hom' for a given category 'cat'.
+get-hom-objects : Term → Term → TC (Term × Term)
+get-hom-objects cat tm = do
+  tm ← normalise tm
+  x ← new-meta (def (quote Precategory.Ob) (infer-hidden 2 (cat v∷ [])))
+  y ← new-meta (def (quote Precategory.Ob) (infer-hidden 2 (cat v∷ [])))
+  unify tm (def (quote Precategory.Hom) (infer-hidden 2 (cat v∷ x v∷ y v∷ [])))
+  pure (x , y)

--- a/src/Cat/Solver.lagda.md
+++ b/src/Cat/Solver.lagda.md
@@ -149,19 +149,13 @@ module Reflection where
     pure (simple-solver [] (build-expr cat) (invoke-solver cat) (invoke-normaliser cat))
 
   repr-macro : ∀ {o ℓ} → Precategory o ℓ → Term → Term → TC ⊤
-  repr-macro cat f _ = do
-    solver ← cat-solver cat
-    mk-simple-repr solver f
+  repr-macro cat = mk-simple-repr (cat-solver cat)
 
   simplify-macro : ∀ {o ℓ} → Precategory o ℓ → Term → Term → TC ⊤
-  simplify-macro cat f hole = do
-    solver ← cat-solver cat
-    mk-simple-normalise solver f hole
+  simplify-macro cat f hole = mk-simple-normalise (cat-solver cat) f hole
 
   solve-macro : ∀ {o ℓ} → Precategory o ℓ → Term → TC ⊤
-  solve-macro cat hole = do
-    solver ← cat-solver cat
-    mk-simple-solver solver hole
+  solve-macro cat hole = mk-simple-solver (cat-solver cat) hole
 
 macro
   cat! : ∀ {o ℓ} → Precategory o ℓ → Term → TC ⊤


### PR DESCRIPTION
# Description

Previously, we were doing category reflection by blocking reduction of *all* category fields. This causes problems for things like Kleisli categories; blocking reduction of all compositions means that we can't unfold composition in the kleisli category, which in turn means that the monad solver fails.

The simplest way to fix this is to leverage unification to determine when we encounter field projections for a *specific* category, which I've done here.