### PR TITLE
defn: Ordered families of equivalences

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: _build
-          key: shake-3-${{ env.shake_version }}-${{ github.run_id }}
-          restore-keys: shake-3-${{ env.shake_version }}-
+          key: shake-4-${{ env.shake_version }}-${{ github.run_id }}
+          restore-keys: shake-4-${{ env.shake_version }}-
 
       - name: Build 🛠️
         run: |

--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -8,7 +8,7 @@ open import 1Lab.Type hiding (absurd)
 open import Data.Product.NAry
 open import Data.Vec.Base
 open import Data.Bool
-open import Data.List
+open import Data.List.Base
 ```
 -->
 
@@ -27,7 +27,7 @@ open import Meta.Alt public
 
 open Data.Vec.Base using (Vec ; [] ; _∷_ ; lookup ; tabulate) public
 open Data.Product.NAry using ([_]) public
-open Data.List public
+open Data.List.Base public
 open Data.Bool public
 ```
 

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -10,7 +10,7 @@ open import 1Lab.Path
 open import 1Lab.Type
 
 open import Data.Bool
-open import Data.List
+open import Data.List.Base
 
 open import Meta.Foldable
 
@@ -677,11 +677,6 @@ instance
 
   decomp-univalence : ∀ {ℓ} {A B : Type ℓ} → hlevel-decomposition (A ≡ B)
   decomp-univalence = decomp (quote ≡-is-hlevel) (`level ∷ `search ∷ `search ∷ [] )
-
-  -- List isn't really a type on the same footing as all the others, but
-  -- we're here, so we might as well, right?
-  decomp-list : ∀ {ℓ} {A : Type ℓ} → hlevel-decomposition (List A)
-  decomp-list = decomp (quote ListPath.List-is-hlevel) (`level-minus 2 ∷ `search ∷ [])
 
   -- This one really ought to work with instance selection only, but
   -- Agda has trouble with the (1 + k + n) level in H-Level-n-Type. The

--- a/src/1Lab/Reflection/Marker.agda
+++ b/src/1Lab/Reflection/Marker.agda
@@ -3,7 +3,7 @@ open import 1Lab.Path
 open import 1Lab.Type
 
 open import Data.Maybe.Base
-open import Data.List
+open import Data.List.Base
 
 open import Prim.Data.Nat
 

--- a/src/1Lab/Reflection/Record.agda
+++ b/src/1Lab/Reflection/Record.agda
@@ -4,7 +4,6 @@ open import 1Lab.Equiv
 open import 1Lab.Path
 open import 1Lab.Type
 
-open import Data.List
 
 import Prim.Data.Sigma as S
 import Prim.Data.Nat as N

--- a/src/1Lab/Reflection/Variables.agda
+++ b/src/1Lab/Reflection/Variables.agda
@@ -3,7 +3,7 @@ open import 1Lab.Type
 
 open import Data.Fin.Base
 open import Data.Nat.Base
-open import Data.List hiding (reverse)
+open import Data.List.Base hiding (reverse)
 
 module 1Lab.Reflection.Variables where
 

--- a/src/Cat/Instances/OFE.lagda.md
+++ b/src/Cat/Instances/OFE.lagda.md
@@ -1,0 +1,393 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Prelude
+
+open import Data.Nat.Properties
+open import Data.Nat.Order
+open import Data.Nat.Base
+open import Data.List hiding (map)
+```
+-->
+
+```agda
+module Cat.Instances.OFE where
+```
+
+# Ordered families of equivalences
+
+An **ordered family of equivalences** (OFE, for short) is a set $X$
+equipped with a family of equivalence relations, indexed by natural
+numbers $n$ and written $x \within{n} y$, that _approximate_ the
+equality on $X$. The family of equivalence relations can be thought of
+as equipping $X$ with a notion of _fractional distance_: $x \within{n}
+y$ means that $x$ and $y$ are "within distance $2^{-n}$ of each other".
+The axioms of an OFE are essentially that
+
+- The maximal distance between two points is $1$, i.e., $x
+\within{n} y$ is the total relation;
+
+- Points that are within some distance $d$ of eachother are also within
+$d'$, for any $d' \le d$;
+
+- Arbitrarily close points are the same.
+
+Another perspective on OFEs, and indeed a large part for the
+justification of their study, is in the semantics of programming
+languages: in that case, the relation $x \within{n} y$ should be
+interpreted as _equivalent for $n$ steps of computation_: a program
+running for at most $n$ steps can not tell $\within{n}$-related elements
+apart. Our axioms are then that a program running for no steps can not
+distinguish anything, so we have $x \within{0} y$ for any $x, y$, and
+that our approximations become finer with an increasing number of steps:
+with arbitrarily many steps, the only indistinguishable elements must
+actually be equal.
+
+```agda
+record is-ofe {ℓ ℓ'} {X : Type ℓ} (within : Nat → X → X → Type ℓ') : Type (ℓ ⊔ ℓ') where
+  no-eta-equality
+
+  field
+    has-is-prop : ∀ n x y → is-prop (within n x y)
+
+    ≈-refl  : ∀ n {x} → within n x x
+    ≈-sym   : ∀ n {x y} → within n x y → within n y x
+    ≈-trans : ∀ n {x y z} → within n y z → within n x y → within n x z
+
+    bounded : ∀ x y → within 0 x y
+    step    : ∀ n x y → within (suc n) x y → within n x y
+    limit   : ∀ x y → (∀ n → within n x y) → x ≡ y
+
+  ofe→ids : is-identity-system (λ x y → ∀ n → within n x y) (λ x n → ≈-refl n)
+  ofe→ids = set-identity-system
+    (λ x y → Π-is-hlevel 1 λ n → has-is-prop n x y)
+    (limit _ _)
+```
+
+From a HoTT perspective, this definition works extremely smoothly: note
+that since we require the approximate equalities $x \within{n} y$ to be
+propositions, every subsequent field of the record is _also_ a
+proposition, so equality of `is-ofe`{.Agda} is trivial, like we would
+expect. Moreover, since "equality at the limit", the relation
+
+$$
+R(x, y) = \forall n, x \within{n} y
+$$
+
+is a reflexive relation (since each $x \within{n} y$ is reflexive) that
+implies equality, the type underlying a OFE is automatically a set; its
+identity type is _equivalent_ to equality at the limit.
+
+<!--
+```agda
+private unquoteDecl eqv = declare-record-iso eqv (quote is-ofe)
+
+opaque instance
+  H-Level-is-ofe
+    : ∀ {ℓ ℓ'} {X : Type ℓ} {rs : Nat → X → X → Type ℓ'} {n}
+    → H-Level (is-ofe rs) (suc n)
+  H-Level-is-ofe {X = X} {rs = rs} = prop-instance λ x →
+    let
+      instance
+        hlr : ∀ {n k x y} → H-Level (rs x n y) (suc k)
+        hlr = prop-instance (x .is-ofe.has-is-prop _ _ _)
+
+        hs : H-Level X 2
+        hs = basic-instance 2 $
+          identity-system→hlevel 1 (is-ofe.ofe→ids x) (λ x y → hlevel 1)
+    in Iso→is-hlevel 1 eqv (hlevel 1) x
+
+record OFE-on {ℓ} ℓ' (X : Type ℓ) : Type (ℓ ⊔ lsuc ℓ') where
+  field
+    within     : (n : Nat) (x y : X) → Type ℓ'
+    has-is-ofe : is-ofe within
+  open is-ofe has-is-ofe public
+
+module
+  _ {ℓ ℓ₁ ℓ' ℓ₁'} {X : Type ℓ} {Y : Type ℓ₁} (f : X → Y)
+    (O : OFE-on ℓ' X) (P : OFE-on ℓ₁' Y)
+  where
+
+  private
+    module O = OFE-on O
+    module P = OFE-on P
+```
+-->
+
+The correct notion of morphism between OFEs is that of **non-expansive
+maps**, once again appealing to the notion of distance for intuition. A
+function $f : X \to Y$ is non-expansive if points under $f$ do not get
+farther. Apart from the intuitive justification, we note that the
+[structure identity principle][sip] essentially forces non-expansivity
+to be the definition of morphism of OFEs: the type of OFEs is equivalent
+to a $\Sigma$-type that starts
+
+$$
+\Sigma (X : \ty) \Sigma (R : X \to \bN \to X \to \ty) \Sigma ...\text{,}
+$$
+
+where all the components in $...$ are propositional. Its identity type
+can be _computed_ to consist of equivalences between the underlying
+types that preserve the relations $R$, and since the relations are
+propositions, bi-implication suffices: an identification between OFEs is
+a non-expansive equivalence of types with non-expansive inverse.
+
+[sip]: 1Lab.Univalence.SIP.html
+
+```agda
+  record is-non-expansive : Type (ℓ ⊔ ℓ' ⊔ ℓ₁') where
+    no-eta-equality
+    field
+      pres-≈ : ∀ {x y n} → O.within n x y → P.within n (f x) (f y)
+```
+
+<!--
+```agda
+
+module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓa' A) (P : OFE-on ℓb' B)
+  where
+
+  private
+    module O = OFE-on O
+    module P = OFE-on P
+
+  record _→ⁿᵉ_ : Type (ℓa ⊔ ℓb ⊔ ℓa' ⊔ ℓb') where
+    field
+      map    : A → B
+      pres-≈ : ∀ n {x y} → O.within n x y → P.within n (map x) (map y)
+
+open _→ⁿᵉ_ public
+
+module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} {O : OFE-on ℓa' A} {P : OFE-on ℓb' B} where
+  private module P = OFE-on P
+
+  Nonexp-ext : ∀ {f g : O →ⁿᵉ P} → (∀ x → f .map x ≡ g .map x) → f ≡ g
+  Nonexp-ext α i .map z = α z i
+  Nonexp-ext {f = f} {g} α i .pres-≈ n {x} {y} β =
+    is-prop→pathp (λ i → P.has-is-prop n (α x i) (α y i)) (f .pres-≈ n β) (g .pres-≈ n β) i
+
+private unquoteDecl eqv' = declare-record-iso eqv' (quote is-non-expansive)
+
+instance
+  H-Level-is-non-expansive
+    : ∀ {ℓ ℓ₁ ℓ' ℓ₁'} {X : Type ℓ} {Y : Type ℓ₁} {f : X → Y}
+        {O : OFE-on ℓ' X} {P : OFE-on ℓ₁' Y} {n}
+    → H-Level (is-non-expansive f O P) (suc n)
+  H-Level-is-non-expansive {P = P} = prop-instance (Iso→is-hlevel 1 eqv' (hlevel 1)) where
+    module P = OFE-on P
+    instance
+      hlr : ∀ {n k x y} → H-Level (P.within x n y) (suc k)
+      hlr = prop-instance (P .OFE-on.has-is-prop _ _ _)
+
+open is-non-expansive
+
+OFE-structure : ∀ {ℓ ℓ'} → Thin-structure (ℓ ⊔ ℓ') (OFE-on {ℓ} ℓ')
+∣ OFE-structure .is-hom f O P ∣ = is-non-expansive f O P
+OFE-structure .is-hom f O P .is-tr = hlevel 1
+OFE-structure .id-is-hom .pres-≈ w = w
+OFE-structure .∘-is-hom f g α β .pres-≈ w = α .pres-≈ (β .pres-≈ w)
+OFE-structure .id-hom-unique {s = s} {t = t} α β = q where
+  module s = OFE-on s
+  module t = OFE-on t
+
+  p : ∀ x y n → (s.within x n y) ≃ (t.within x n y)
+  p x y n = prop-ext (s.has-is-prop _ _ _) (t.has-is-prop _ _ _)
+    (α .pres-≈) (β .pres-≈)
+
+  q : s ≡ t
+  q i .OFE-on.within x n y = ua (p x y n) i
+  q i .OFE-on.has-is-ofe = is-prop→pathp
+    (λ i → hlevel {T = is-ofe (λ x n y → ua (p x y n) i)} 1)
+    s.has-is-ofe t.has-is-ofe i
+
+OFEs : ∀ ℓ ℓ' → Precategory (lsuc (ℓ ⊔ ℓ')) (ℓ ⊔ ℓ')
+OFEs ℓ ℓ' = Structured-objects (OFE-structure {ℓ} {ℓ'})
+module OFEs {ℓ ℓ'} = Precategory (OFEs ℓ ℓ')
+
+OFE : ∀ ℓ ℓ' → Type (lsuc (ℓ ⊔ ℓ'))
+OFE ℓ ℓ' = OFEs.Ob {ℓ} {ℓ'}
+
+open OFE-on hiding (ofe→ids) public
+open is-ofe public
+open is-non-expansive public
+```
+-->
+
+## Examples
+
+A canonical class of examples for OFEs is given by strings, or, more
+generally, lists: if $X$ is a set, then, for $x, y : \rm{List}(X)$, we
+can define the relations $x \within{n} y$ to mean _the length-$n$
+prefixes of $x$ and $y$ are equal_. Let's quickly go over the axioms
+informally before looking at the formalisation:
+
+- Each relation $\within{n}$ is an equivalence relation, since it is
+  defined to be equality;
+
+- At the limit, suppose we have lists $x, y$: we do not yet know that
+  their lengths agree, but we _do_ know that taking a "prefix" longer than
+  the list gives back the entire list.
+
+  So, writing $l_x$ and $l_y$ for the lengths, we can use our assumption
+  that $x$ and $y$ agree at length $l = \max(l_x, l_y)$: the length $l$
+  prefixes of both $x$ and $y$ are both the entire lists $x$ and $y$, so
+  we have
+
+  $$
+  x = \rm{take}(l,x) = \rm{take}(l,y) = y\text{,}
+  $$
+
+  where the middle step is $x \within{l} y$.
+
+- Finally, since a length $l+1$ prefix is necessarily adding an element
+  onto a length $l$ prefix, we satisfy the monotonicity requirement. In
+  the formalisation, we use a direct inductive argument for this. We'll
+  show that, for all $xs, ys, n$, if $\rm{take}(1 + n, xs) = \rm{take}(1
+  + n, ys)$, then $\rm{take}(n, xs) = \rm{take}(n, ys)$.
+
+  On the _one_ interesting case, we assume that $x :: \rm{take}(1 + n,
+  xs) = y :: \rm{take}(1 + n, ys)$, which we can split into $x = y$ and
+  $\rm{take}(1 + n, xs) = \rm{take}(1 + n, ys)$. The induction
+  hypothesis lets us turn this latter equality into $\rm{take}(n,xs) =
+  \rm{take}(n,ys)$, which pairs up with $x = y$ to conclude exactly what
+  we want.
+
+```agda
+Lists : ∀ {ℓ} {X : Type ℓ} → is-set X → OFE-on ℓ (List X)
+Lists X-set .within n xs ys = take n xs ≡ take n ys
+Lists X-set .has-is-ofe .has-is-prop n xs ys = ListPath.is-set→List-is-set X-set _ _
+Lists X-set .has-is-ofe .≈-refl  n     = refl
+Lists X-set .has-is-ofe .≈-sym   n p   = sym p
+Lists X-set .has-is-ofe .≈-trans n p q = q ∙ p
+Lists X-set .has-is-ofe .bounded x y   = refl
+
+Lists X-set .has-is-ofe .limit x y wit = sym rem₁ ·· agree ·· rem₂ where
+  enough = max (length x) (length y)
+  agree : take enough x ≡ take enough y
+  agree = wit enough
+
+  rem₁ : take enough x ≡ x
+  rem₁ = take-length-more x enough (max-≤l _ _)
+  rem₂ : take enough y ≡ y
+  rem₂ = take-length-more y enough (max-≤r _ _)
+
+Lists X-set .has-is-ofe .step n x y p = steps x y n p where
+  steps : ∀ {ℓ} {A : Type ℓ} (x y : List A) n
+        → take (suc n) x ≡ take (suc n) y → take n x ≡ take n y
+  steps (x ∷ xs) (y ∷ ys) (suc n) p =
+    ap₂ _∷_ (ap (head x) p) (steps xs ys n (ap tail p))
+```
+
+Since the rest of this proof is a simple case bash[^5 cases are
+reflexivity, 2 assume an impossibility], we've hidden it on the website.
+You can choose to display comments on the side bar, or check out this
+module on GitHub.
+
+<!--
+```agda
+  steps []       []       zero    p = refl
+  steps []       []       (suc n) p = refl
+  steps []       (x ∷ ys) zero    p = refl
+  steps (x ∷ xs) (y ∷ ys) zero    p = refl
+  steps (x ∷ xs) []       zero    p = refl
+  steps []       (x ∷ ys) (suc n) p = absurd (∷≠[] (sym p))
+  steps (x ∷ xs) []       (suc n) p = absurd (∷≠[] p)
+```
+-->
+
+This example generalises incredibly straightforwardly to possibly
+infinite sequences in a set: that is, functions $\bN \to X$. Our
+definition of $x \within{n} y$ is now that, for all $k \lt n$, $x(k) =
+y(k)$. Once again we are using equality to approximate equality, so this
+is levelwise an equivalence relation; surprisingly, the other three
+properties are _simpler_ to establish for sequences than for lists!
+
+```agda
+Sequences : ∀ {ℓ} {X : Type ℓ} → is-set X → OFE-on ℓ (Nat → X)
+Sequences _ .within n xs ys = ∀ k (le : k < n) → xs k ≡ ys k
+Sequences {X = X} X-set .has-is-ofe .has-is-prop n xs ys = hlevel 1 where instance
+  _ : H-Level X 2
+  _ = basic-instance 2 X-set
+Sequences _ .has-is-ofe .≈-refl  n k le     = refl
+Sequences _ .has-is-ofe .≈-sym   n p k le   = sym (p k le)
+Sequences _ .has-is-ofe .≈-trans n p q k le = q k le ∙ p k le
+
+Sequences _ .has-is-ofe .bounded xs ys k ()
+Sequences _ .has-is-ofe .step n xs ys p k le = p k (≤-sucr le)
+Sequences _ .has-is-ofe .limit xs ys wit     = funext λ k → wit (suc k) k ≤-refl
+```
+
+# Contractive maps
+
+<!--
+```agda
+module
+  _ {ℓ ℓ₁ ℓ' ℓ₁'} {X : Type ℓ} {Y : Type ℓ₁} (f : X → Y)
+    (O : OFE-on ℓ' X) (P : OFE-on ℓ₁' Y)
+  where
+
+  private
+    module O = OFE-on O
+    module P = OFE-on P
+```
+-->
+
+```agda
+  record is-contractive : Type (ℓ ⊔ ℓ' ⊔ ℓ₁') where
+    no-eta-equality
+    field
+      contract : ∀ {x y n} → O.within n x y → P.within (suc n) (f x) (f y)
+```
+
+<!--
+```agda
+private unquoteDecl eqv'' = declare-record-iso eqv'' (quote is-contractive)
+
+instance
+  H-Level-is-contractive
+    : ∀ {ℓ ℓ₁ ℓ' ℓ₁'} {X : Type ℓ} {Y : Type ℓ₁} {f : X → Y}
+        {O : OFE-on ℓ' X} {P : OFE-on ℓ₁' Y} {n}
+    → H-Level (is-contractive f O P) (suc n)
+  H-Level-is-contractive {P = P} = prop-instance (Iso→is-hlevel 1 eqv'' (hlevel 1)) where
+    module P = OFE-on P
+    instance
+      hlr : ∀ {n k x y} → H-Level (P.within x n y) (suc k)
+      hlr = prop-instance (P .OFE-on.has-is-prop _ _ _)
+
+module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓa' A) (P : OFE-on ℓb' B)
+  where
+
+  private
+    module O = OFE-on O
+    module P = OFE-on P
+
+  record _→ᶜᵒⁿ_ : Type (ℓa ⊔ ℓb ⊔ ℓa' ⊔ ℓb') where
+    field
+      map      : A → B
+      contract : ∀ n {x y} → O.within n x y → P.within (suc n) (map x) (map y)
+
+open _→ᶜᵒⁿ_ public
+open is-contractive public
+```
+-->
+
+<!--
+```agda
+module OFE-Notation {ℓ ℓ'} {X : Type ℓ} ⦃ O : OFE-on ℓ' X ⦄ where
+  private module O = OFE-on O
+  _≈[_]_ : X → Nat → X → Type ℓ'
+  x ≈[ n ] y = O.within n x y
+
+module OFE-H-Level {ℓ ℓ'} {X : Type ℓ} (O : OFE-on ℓ' X) where
+  private module O = OFE-on O
+  open OFE-Notation ⦃ O ⦄
+  instance
+    H-Level-≈ : ∀ {n k x y} → H-Level (x ≈[ n ] y) (suc k)
+    H-Level-≈ = prop-instance (O.has-is-prop _ _ _)
+
+from-ofe-on : ∀ {ℓ ℓ'} {X : Type ℓ} → OFE-on ℓ' X → OFEs.Ob
+∣ from-ofe-on {X = X} O .fst ∣ = X
+from-ofe-on O .fst .is-tr = identity-system→hlevel 1 (OFE-on.ofe→ids O) λ x y → Π-is-hlevel 1 λ n → OFE-on.has-is-prop O n x y
+from-ofe-on O .snd = O
+```
+-->

--- a/src/Cat/Instances/OFE.lagda.md
+++ b/src/Cat/Instances/OFE.lagda.md
@@ -14,10 +14,10 @@ open import Data.List hiding (map)
 module Cat.Instances.OFE where
 ```
 
-# Ordered families of equivalences
+# Ordered families of equivalence relations
 
-An **ordered family of equivalences** (OFE, for short) is a set $X$
-equipped with a family of equivalence relations, indexed by natural
+An **ordered family of equivalence relations** (OFE, for short) is a set
+$X$ equipped with a family of equivalence relations, indexed by natural
 numbers $n$ and written $x \within{n} y$, that _approximate_ the
 equality on $X$. The family of equivalence relations can be thought of
 as equipping $X$ with a notion of _fractional distance_: $x \within{n}
@@ -31,6 +31,16 @@ The axioms of an OFE are essentially that
 $d'$, for any $d' \le d$;
 
 - Arbitrarily close points are the same.
+
+::: warning
+We remark that the term OFE generally stands for ordered family of
+_equivalences_, rather than _equivalence relations_; However, this
+terminology is mathematically incorrect: there is no meaningful sense in
+which an OFE is a family $I \to (A \equiv B)$.
+
+To preserve the connection with the literature, we shall maintain the
+acronym "OFE"; Keep in mind that we do it with disapproval.
+:::
 
 Another perspective on OFEs, and indeed a large part for the
 justification of their study, is in the semantics of programming

--- a/src/Cat/Instances/OFE/Closed.lagda.md
+++ b/src/Cat/Instances/OFE/Closed.lagda.md
@@ -38,7 +38,7 @@ module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓ
 ```
 
 ```agda
-  Function-OFE : OFE-on {!   !} (O →ⁿᵉ P)
+  Function-OFE : OFE-on (ℓa ⊔ ℓb') (O →ⁿᵉ P)
   Function-OFE .within n f g = ∀ x → f .map x ≈[ n ] g .map x
   Function-OFE .has-is-ofe .has-is-prop n x y = hlevel 1
     where open OFE-H-Level P

--- a/src/Cat/Instances/OFE/Closed.lagda.md
+++ b/src/Cat/Instances/OFE/Closed.lagda.md
@@ -1,0 +1,52 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Displayed.Total
+open import Cat.Instances.OFE
+open import Cat.Prelude
+```
+-->
+
+```agda
+module Cat.Instances.OFE.Closed where
+```
+
+# Function OFEs
+
+If $A$ and $B$ are [OFEs], then so is the space of non-expansive
+functions $A \overset{ne}{\to} B$: this makes the category OFE into a
+Cartesian closed category.
+
+[OFEs]: Cat.Instances.OFE.html
+
+<!--
+```agda
+open OFE-Notation
+
+module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓa' A) (P : OFE-on ℓb' B)
+  where
+  private
+    instance
+      _ = O
+      _ = P
+    module O = OFE-on O
+    module P = OFE-on P
+```
+-->
+
+```agda
+```
+
+```agda
+  Function-OFE : OFE-on {!   !} (O →ⁿᵉ P)
+  Function-OFE .within n f g = ∀ x → f .map x ≈[ n ] g .map x
+  Function-OFE .has-is-ofe .has-is-prop n x y = hlevel 1
+    where open OFE-H-Level P
+  Function-OFE .has-is-ofe .≈-refl n x  = P.≈-refl n
+  Function-OFE .has-is-ofe .≈-sym n p x = P.≈-sym n (p x)
+  Function-OFE .has-is-ofe .≈-trans n p q x = P.≈-trans n (p x) (q x)
+  Function-OFE .has-is-ofe .bounded f g x = P.bounded (f .map x) (g .map x)
+  Function-OFE .has-is-ofe .step n f g α x = P.step n (f .map x) (g .map x) (α x)
+  Function-OFE .has-is-ofe .limit f g α = Nonexp-ext λ x →
+    P.limit (f .map x) (g .map x) (λ n → α n x)
+```

--- a/src/Cat/Instances/OFE/Complete.lagda.md
+++ b/src/Cat/Instances/OFE/Complete.lagda.md
@@ -1,0 +1,264 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Displayed.Total
+open import Cat.Instances.OFE
+open import Cat.Prelude
+
+open import Data.Nat.Properties
+open import Data.Nat.Order
+open import Data.Nat.Base
+```
+-->
+
+```agda
+module Cat.Instances.OFE.Complete where
+```
+
+<!--
+```agda
+open OFE-Notation
+
+module _ {ℓ ℓ'} {A : Type ℓ} (P : OFE-on ℓ' A) where
+  private
+    instance _ = P
+    module P = OFE-on P
+```
+-->
+
+# Limits and complete OFEs
+
+Since [OFEs] are metric-space-_like_[^1] structures, there is a natural
+notion of sequences getting closer to a value: we say a sequence $f : \bN
+\to A$ is a _chain_ if, given $n \le m$, we have $f(m) \within{n} f(n)$.
+Looking at the case where $m = 1 + n$, this says that we have a sequence
+
+$$
+f(0) \within{0} f(1) \within{1} f(2) \within{2} f(3) \within{3} \dots
+$$
+
+where the metric interpretation of OFEs lets us read this as the
+_distance_ between successive points approaching
+$\lim_{n\to\infty}2^{-n} = 0$.
+
+```agda
+  is-chain : (x : Nat → A) → Type _
+  is-chain f = ∀ m n → n ≤ m → f m ≈[ n ] f n
+```
+
+[^1]: An OFE is a _1-bounded, bisected ultrametric space_.
+
+[OFEs]: Cat.Instances.OFE.html
+
+However, in a general OFE, there is not necessarily anything "at
+$\infty$": the values of the sequence get closer to each other, but
+there's no specific _point_ they're getting closer to. An example of
+chain without limit is as follows: let $a : A$ be an element of a set,
+and consider the sequence
+
+$$
+f(n) = \underbrace{a,\dots,a}_\text{$n$ times}
+$$
+
+in the OFE of finite sequences. Clearly this satisfies the chain
+condition: w.l.o.g. we can assume $m = n + k$ for some $k$, and $f(n +
+k)$ certainly shares the first $n$ elements with $f(n)$. However, there
+is no single list of $A$s $l$ which shares its first $n$ elements
+with $f(n)$: $l$ must have a definite length, independent of $n$, which
+bounds the size of its prefixes. Choosing any $n > \rm{length}(l)$
+results in a value of $f(n)$ has more elements than the length-$n$
+prefix of $l$.
+
+The previous paragraph contains an unfolding of the definition of a
+sequence having a limit, or, more specifically, it contains a definition
+of what it means for a point to be the limit of a sequence: $a$ is the
+limit of $f$ if, for all $n$, $a \within{n} f(a)$.
+
+```agda
+  is-limit : (x : Nat → A) → A → Type _
+  is-limit f a = ∀ n → a ≈[ n ] f n
+```
+
+It follows at once that _the_ limit of a sequence is uniquely
+determined: if $a$ and $b$ both claim to be limits of $f$, we have, for
+arbitrary $n$, $a \within{n} f(a) \within{n} b$, meaning $a = b$.
+
+```agda
+  limit-is-unique
+    : ∀ (f : Nat → A) {x y}
+    → is-limit f x → is-limit f y → x ≡ y
+  limit-is-unique f l1 l2 = P.limit _ _ λ n →
+    P.≈-trans n (P.≈-sym n (l2 n)) (l1 n)
+```
+
+<!--
+```agda
+  Limit : (Nat → A) → Type _
+  Limit f = Σ A (is-limit f)
+
+  Limit-is-prop : (f : Nat → A) → is-prop (Limit f)
+  Limit-is-prop f (a , α) (b , β) = Σ-prop-path hlevel! (limit-is-unique f α β)
+    where open OFE-H-Level P
+
+  limit-from-tail
+    : ∀ (f : Nat → A) x → is-chain f → is-limit (λ n → f (suc n)) x → is-limit f x
+  limit-from-tail f x chain lim zero = P.bounded _ _
+  limit-from-tail f x chain lim (suc n) = P.≈-trans _
+    (chain (suc (suc n)) (suc n) (≤-sucr ≤-refl))
+    (lim (suc n))
+
+  limit-to-tail
+    : ∀ (f : Nat → A) x → is-chain f → is-limit f x → is-limit (λ n → f (suc n)) x
+  limit-to-tail f x chain lim zero = P.bounded _ _
+  limit-to-tail f x chain lim (suc n) = P.step _ _ _ (lim _)
+```
+-->
+
+However, some OFEs _do_ have limits for all chains: the OFE of infinite
+sequences is one, for example. We refer to such an OFE as a **complete
+ordered family of equivalences**, or COFE^[Feel free to pronounce it
+"coffee".] for short.
+
+```agda
+  is-cofe : Type _
+  is-cofe = ∀ (f : Nat → A) → is-chain f → Limit f
+```
+
+<!--
+```agda
+module _ {ℓ} {X : Type ℓ} (X-set : is-set X) where
+```
+-->
+
+We can actually compute the limit of a sequence of sequences pretty
+easily: we have a function $s : \bN \times \bN \to A$, our sequence, and
+the chain condition says that, given $j \le i$ and $k \lt j$, we get
+$s(i,k) = s(j,k)$. Our limit is the sequence $l(i) = s(1 + i, i)$: we
+must show that $l \within{n} s(n)$, which means that, given
+$k \lt n$, we must have $s(1 + k, k) = s(n,k)$. This follows by the
+chain condition: $k \lt 1 + k$, and $(1 + k) \le n$, so we conclude $s(1
++ k, k) = s(n, k)$.
+
+```agda
+  Sequences-is-cofe : is-cofe (Sequences X-set)
+  Sequences-is-cofe seq chain = (λ j → seq (suc j) j) , λ n k k<n →
+    sym (chain _ _ k<n _ ≤-refl)
+```
+
+<!--
+```agda
+module _ {ℓa ℓa' ℓb ℓb'} {A : Type ℓa} {B : Type ℓb} (P : OFE-on ℓa' A) (Q : OFE-on ℓb' B) where
+  private
+    instance
+      _ = P
+      _ = Q
+    module P = OFE-on P
+    module Q = OFE-on P
+```
+-->
+
+In passing, let us note that non-expansive maps preserve both chains
+_and_ their limits.
+
+```agda
+  non-expansive→chain
+    : (f : A → B) (s : Nat → A)
+    → is-non-expansive f P Q → is-chain P s → is-chain Q (λ n → f (s n))
+  non-expansive→chain f s ne p m n n≤m = ne .pres-≈ (p m n n≤m)
+
+  non-expansive→limit
+    : (f : A → B) (s : Nat → A) (x : A)
+    → is-non-expansive f P Q → is-limit P s x → is-limit Q (λ n → f (s n)) (f x)
+  non-expansive→limit f s x ne lim n = ne .pres-≈ (lim n)
+```
+
+## Banach's fixed point theorem
+
+<!--
+```agda
+module _ {ℓ ℓ'} {A : Type ℓ} (P : OFE-on ℓ' A) (lim : is-cofe P) where
+  private
+    instance _ = P
+    module P = OFE-on P
+```
+-->
+
+**Banach's fixed point theorem**, in our setting, says that any
+contractive $f : P \to P$ on an _inhabited_ COFE has a unique fixed
+point. We'll start with uniqueness: suppose that some $a, b$ satisfy
+$f(a) = a$ and $f(b) = b$. It will suffice to show that $f(a) = f(b)$,
+and, working in an OFE, this further reduces to $f(a) \within{n} f(b)$
+for an arbitrary $n$.
+
+By induction, with a trivial base case, we can assume $f(a) \within{n}
+f(b)$ to show $f(a) \within{1+n} f(b)$: but $f$ is contractive, so it
+acts on the induction hypothesis to produce $f(f(a)) \within{1+n}
+f(f(b))$.  But we assumed both $a$ and $b$ are fixed points, so this is
+exactly what we want.
+
+```agda
+  banach : ∥ A ∥ → (f : P →ᶜᵒⁿ P) → Σ A λ x → f .map x ≡ x
+  banach inhab f = ∥-∥-proj {ap = fp-unique} fp' where
+    fp-unique : is-prop (Σ A λ x → f .map x ≡ x)
+    fp-unique (a , p) (b , q) =
+      Σ-prop-path (λ x → from-ofe-on P .fst .is-tr _ _)
+                  (sym p ·· P.limit _ _ climb ·· q)
+      where
+
+      climb : ∀ n → f .map a ≈[ n ] f .map b
+      climb zero    = P.bounded _ _
+      climb (suc n) = transport (λ i → f .map (p i) ≈[ suc n ] f .map (q i)) (f .contract n (climb n))
+```
+
+The point of showing uniqueness is that the fixed point is independent
+of _how_ $P$ is inhabited: in other words, for a contractive mapping on
+a COFE to have a fixed point, we needn't $x : P$ --- $x : \| P \|$ will
+suffice. That aside justifes this sentence: Fix a starting point $x_0 :
+P$, and consider the sequence
+
+$$
+s = x_0, f(x_0), f(f(x_0)), f(f(f(x_0))), \dots
+$$
+
+which is a chain again by an inductive argument involving contractivity
+(formalised below for the curious).
+
+```agda
+    approx : A → Nat → A
+    approx a zero    = a
+    approx a (suc n) = f .map (approx a n)
+
+    chain : ∀ a → is-chain P (approx a)
+    chain a m zero x                = P.bounded (approx a m) a
+    chain a (suc m) (suc n) (s≤s x) = f .contract n (chain a m n x)
+```
+
+I claim that the limit of $s$ is a fixed point of $f$: we can calculate
+
+$$
+f(\lim_n s(n)) = \lim_n f(s(n)) = \lim_n s(n+1) = \lim_n s(n)
+$$
+
+where we have, in turn, that non-expansive mappings preserve limits, the
+very definition of $s$, and the fact that limits are insensitive to
+dropping an element at the start.
+
+```agda
+    fp' : ∥ _ ∥
+    fp' = do
+      pt ← inhab
+      let
+        (it , is) = lim (approx pt) (chain pt)
+
+        ne : is-non-expansive (f .map) P P
+        ne = record { pres-≈ = λ p → P.step _ _ _ (f .contract _ p) }
+
+        prf : f .map it ≡ it
+        prf =
+          f .map it                               ≡⟨ limit-is-unique P _ (non-expansive→limit _ _ _ _ _ ne is) (lim _ _ .snd) ⟩
+          lim (λ n → f .map (approx pt n)) _ .fst ≡⟨ ap fst (ap (lim _) (λ i → non-expansive→chain _ _ _ _ ne (chain pt))) ⟩
+          lim (λ n → approx pt (suc n)) _ .fst    ≡⟨ limit-is-unique P _ (lim _ _ .snd) (limit-to-tail P (approx pt) _ (chain pt) is) ⟩
+          it                                      ∎
+
+      pure (it , prf)
+```

--- a/src/Cat/Instances/OFE/Coproduct.lagda.md
+++ b/src/Cat/Instances/OFE/Coproduct.lagda.md
@@ -1,0 +1,198 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Diagram.Coproduct
+open import Cat.Displayed.Total
+open import Cat.Instances.OFE
+open import Cat.Prelude
+
+open import Data.Sum.Base
+```
+-->
+
+```agda
+module Cat.Instances.OFE.Coproduct where
+```
+
+# Coroducts of OFEs
+
+The [category of OFEs][OFE] admits binary [coproducts]. Unlike the
+[construction of products][ofe-prod], in which we could define the
+approximations $(a, b) \within{n} (a', b')$ by lifting those of the
+factor OFEs, the definition of coproducts requires a fair bit more
+busywork.
+
+[OFE]: Cat.Instances.OFE.html
+[coproducts]: Cat.Diagram.Coproduct.html
+[ofe-prod]: Cat.Instances.OFE.Product.html
+
+
+
+<!--
+```agda
+open OFE-Notation
+
+module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓa' A) (P : OFE-on ℓb' B)
+  where
+  private
+    instance
+      _ = O
+      _ = P
+    module O = OFE-on O
+    module P = OFE-on P
+    open OFE-H-Level O
+    open OFE-H-Level P
+```
+-->
+
+To get it right, let's use the computational interpretation of OFEs.
+Having done no steps of computation, we have not yet managed to
+distinguish the left summand from the right summand. Motivated by this,
+and to satisfy the boundedness axiom, we simply define $x \within{0} y$
+to be the unit type everywhere.
+
+Having taken some positive number of steps, it is possible to
+distinguish the summands, and we must do so, defining the relations by
+cases. The relations $\rm{in}_d(x) \within{1+n} \rm{in}_d(y)$, where $d
+\in {l,r}$ ranges over the coproduct injections, are defined to be $x
+\within{1+n} y$. Note the index: we do not want to take a step back! In
+case the summands are mismatched, e.g. $\rm{inr}(x) \within{1+n}
+\rm{inl}(y)$, we give back the bottom type: we have taken enough steps
+that it is impossible for them to be equal.
+
+```agda
+  ⊎-OFE : OFE-on (ℓa' ⊔ ℓb') (A ⊎ B)
+  ⊎-OFE .within zero p q = Lift (ℓa' ⊔ ℓb') ⊤
+  ⊎-OFE .within (suc n) (inl x) (inl y) = Lift ℓb' (x ≈[ suc n ] y)
+  ⊎-OFE .within (suc n) (inr x) (inr y) = Lift ℓa' (x ≈[ suc n ] y)
+  ⊎-OFE .within (suc n) (inl x) (inr y) = Lift (ℓa' ⊔ ℓb') ⊥
+  ⊎-OFE .within (suc n) (inr x) (inl y) = Lift (ℓa' ⊔ ℓb') ⊥
+```
+
+The proofs of all the axioms will have to make the same case
+distinctions to get at a concrete type for the approximations. Let's see
+it for reflexivity:
+
+- We first distinguish on the number of steps. If we've not taken any
+  yet, then our relation is trivial, and we can (have to!) give back its
+  trivial point.
+
+- Having taken a number of steps, we distinguish on the summand. Having
+  exposed the underlying relation, we can lift its proof of reflexivity to
+  the sum.
+
+```agda
+  ⊎-OFE .has-is-ofe .≈-refl zero            = lift tt
+  ⊎-OFE .has-is-ofe .≈-refl (suc n) {inl _} = lift (O.≈-refl (suc n))
+  ⊎-OFE .has-is-ofe .≈-refl (suc n) {inr _} = lift (P.≈-refl (suc n))
+```
+
+<details>
+<summary>The other fields are essentially the same, so there's not a lot
+to write about.</summary>
+
+```agda
+  ⊎-OFE .has-is-ofe .has-is-prop zero x y _ _ = refl
+  ⊎-OFE .has-is-ofe .has-is-prop (suc n) (inl _) (inl _) = hlevel!
+  ⊎-OFE .has-is-ofe .has-is-prop (suc n) (inr _) (inr _) = hlevel!
+
+  ⊎-OFE .has-is-ofe .≈-sym zero p = lift tt
+  ⊎-OFE .has-is-ofe .≈-sym (suc n) {inl _} {inl _} p = lift (O.≈-sym _ (p .Lift.lower))
+  ⊎-OFE .has-is-ofe .≈-sym (suc n) {inr _} {inr _} p = lift (P.≈-sym _ (p .Lift.lower))
+
+  ⊎-OFE .has-is-ofe .≈-trans zero p q = lift tt
+  ⊎-OFE .has-is-ofe .≈-trans (suc n) {inl _} {inl _} {inl _} p q = lift (O.≈-trans _ (p .Lift.lower) (q .Lift.lower))
+  ⊎-OFE .has-is-ofe .≈-trans (suc n) {inr _} {inr _} {inr _} p q = lift (P.≈-trans _ (p .Lift.lower) (q .Lift.lower))
+
+  ⊎-OFE .has-is-ofe .bounded a b  = lift tt
+  ⊎-OFE .has-is-ofe .step zero _ _ p = lift tt
+  ⊎-OFE .has-is-ofe .step (suc n) (inl x) (inl y) p = lift (O.step _ x y (p .Lift.lower))
+  ⊎-OFE .has-is-ofe .step (suc n) (inr x) (inr y) p = lift (P.step _ x y (p .Lift.lower))
+```
+
+This minor quibble might be of note to the reader curious enough to
+expand this note: To prove that our approximations converge, we _also_
+need a case distinction. At the zeroth entry, we appeal to boundedness
+of the summand OFEs to get a witness of $x \within{0} y$, since
+$\rm{inr}(x) \within{0} \rm{inr}(y)$ is uninformative.
+
+```agda
+  ⊎-OFE .has-is-ofe .limit (inl x) (inl y) f = ap inl (O.limit x y f') where
+    f' : ∀ n → O.within n x y
+    f' zero    = O.bounded x y
+    f' (suc n) = f (suc n) .Lift.lower
+  ⊎-OFE .has-is-ofe .limit (inr x) (inr y) f = ap inr (P.limit x y f') where
+    f' : ∀ n → P.within n x y
+    f' zero    = P.bounded x y
+    f' (suc n) = f (suc n) .Lift.lower
+  ⊎-OFE .has-is-ofe .limit (inl x) (inr y) f = absurd (f 1 .Lift.lower)
+  ⊎-OFE .has-is-ofe .limit (inr x) (inl y) f = absurd (f 1 .Lift.lower)
+```
+
+</details>
+
+<!--
+```agda
+open Coproduct
+open is-coproduct
+open Total-hom
+```
+-->
+
+We now prove that this construction, which despite my best efforts may
+still feel unmotivated, _is_ the categorical product in OFEs. We start
+by defining the coproduct of morphisms, the operation taking $f : A \to
+Q$ and $g : B \to Q$ to $[f,g] : A \uplus B \to Q$. Once again, it's a
+case bash, and we have to use boundedness of the codomain when showing
+that points with distance 1 stay with distance 1.
+
+```agda
+OFE-Coproduct : ∀ {ℓ ℓ'} A B → Coproduct (OFEs ℓ ℓ') A B
+OFE-Coproduct A B = mk where
+  module A = OFE-on (A .snd)
+  module B = OFE-on (B .snd)
+
+  it = from-ofe-on (⊎-OFE (A .snd) (B .snd))
+
+  disj : ∀ {Q} → OFEs.Hom A Q → OFEs.Hom B Q → OFEs.Hom it Q
+  disj f g .hom (inl x) = f # x
+  disj f g .hom (inr x) = g # x
+  disj {Q = Q} f g .preserves .pres-≈ {n = zero} _ = OFE-on.bounded (Q .snd) _ _
+  disj f g .preserves .pres-≈ {inl x} {inl y} {suc n} (lift α) =
+    f .preserves .pres-≈ α
+  disj f g .preserves .pres-≈ {inr x} {inr y} {suc n} (lift α) =
+    g .preserves .pres-≈ α
+```
+
+We can then define the coprojections: since we must now produce an
+approximation _in_ the sum, if our points have distance 1, we can
+produce a trivial datum.
+
+```agda
+  in0 : OFEs.Hom A it
+  in0 .hom = inl
+  in0 .preserves .pres-≈ {n = zero}  _ = lift tt
+  in0 .preserves .pres-≈ {n = suc n} α = lift α
+
+  in1 : OFEs.Hom B it
+  in1 .hom = inr
+  in1 .preserves .pres-≈ {n = zero}  _ = lift tt
+  in1 .preserves .pres-≈ {n = suc n} α = lift α
+```
+
+It suffices to show that all the relevant diagrams in the definition of
+a coproduct actually commute, and that the coproduct of morphisms is
+unique: but it suffices to reason at the level of sets.
+
+```agda
+  mk : Coproduct (OFEs _ _) A B
+  mk .coapex = it
+  mk .in₀ = in0
+  mk .in₁ = in1
+  mk .has-is-coproduct .is-coproduct.[_,_] {Q = Q} f g = disj f g
+  mk .has-is-coproduct .in₀∘factor = Homomorphism-path λ x → refl
+  mk .has-is-coproduct .in₁∘factor = Homomorphism-path λ x → refl
+  mk .has-is-coproduct .unique other p q = Homomorphism-path λ where
+    (inl x) → p #ₚ x
+    (inr x) → q #ₚ x
+```

--- a/src/Cat/Instances/OFE/Discrete.lagda.md
+++ b/src/Cat/Instances/OFE/Discrete.lagda.md
@@ -1,0 +1,43 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Displayed.Total
+open import Cat.Instances.OFE
+open import Cat.Prelude
+```
+-->
+
+```agda
+module Cat.Instances.OFE.Discrete where
+```
+
+# Discrete OFEs
+
+Given a set $X$, we can make it into a **discrete [OFE]** by equipping
+it with the relation that _takes one step_ to approximate equality: $x
+\within{0} y$ is trivial, but $x \within{1 + n} y$ is defined to be $x =
+y$, no matter what $n$ is.
+
+[OFE]: Cat.Instances.OFE.html
+
+```agda
+Discrete-OFE : ∀ {ℓ} (A : Type ℓ) → is-set A → OFE-on ℓ A
+Discrete-OFE A A-set .within zero x y = Lift _ ⊤
+Discrete-OFE A A-set .within (suc n) x y = x ≡ y
+Discrete-OFE A A-set .has-is-ofe .has-is-prop zero _ _ _ _ _ = _
+Discrete-OFE A A-set .has-is-ofe .has-is-prop (suc n) = A-set
+
+Discrete-OFE A A-set .has-is-ofe .≈-refl zero = _
+Discrete-OFE A A-set .has-is-ofe .≈-refl (suc n) = refl
+
+Discrete-OFE A A-set .has-is-ofe .≈-sym zero = _
+Discrete-OFE A A-set .has-is-ofe .≈-sym (suc n) p = sym p
+
+Discrete-OFE A A-set .has-is-ofe .≈-trans zero = _
+Discrete-OFE A A-set .has-is-ofe .≈-trans (suc n) p q = q ∙ p
+
+Discrete-OFE A A-set .has-is-ofe .bounded = _
+Discrete-OFE A A-set .has-is-ofe .step zero = _
+Discrete-OFE A A-set .has-is-ofe .step (suc n) x y p = p
+Discrete-OFE A A-set .has-is-ofe .limit x y α = α 1
+```

--- a/src/Cat/Instances/OFE/Later.lagda.md
+++ b/src/Cat/Instances/OFE/Later.lagda.md
@@ -1,0 +1,130 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Instances.OFE.Complete
+open import Cat.Displayed.Total
+open import Cat.Instances.OFE
+open import Cat.Prelude
+```
+-->
+
+```agda
+module Cat.Instances.OFE.Later where
+```
+
+# The "Later" OFE
+
+Given a [OFE] $A$, we define an OFE $\later A$, the **later** modality
+of systems of guarded recursion. The idea is that $\later A$ is like
+$A$, but we have to wait a bit to think about it: at level zero, $\later
+A$ is an indiscrete blob, but at positive time steps, it looks just like
+$A$.
+
+The $\later A$ construction extends to an endofunctor of OFE, equipped
+with a natural transformation $\rm{next} : A \to \later A$, expressing
+that if we have something now, we can very well stop thinking about it
+for a step. This natural transformation actually has a universal
+property, within the category of OFEs: Non-expansive maps $\later A \to
+B$ are equivalent to contractive maps $A \to B$.
+
+[OFE]: Cat.Instances.OFE.html
+[complete OFE]: Cat.Instances.OFE.Complete.html
+[bfpt]: Cat.Instances.OFE.Complete.html#banachs-fixed-point-theorem
+
+<!--
+```agda
+open OFE-Notation
+
+module _ {ℓ ℓ'} {A : Type ℓ} (P : OFE-on ℓ' A) where
+  private
+    instance _ = P
+    module P = OFE-on P
+```
+-->
+
+To emphasize that the distinction between $A$ and $\later A$ is entirely
+in skipping a step, we have formatted the construction below so the
+cases are split between time zero and positive time.
+
+```agda
+  Later : OFE-on ℓ' A
+  Later .within zero x y    = Lift ℓ' ⊤
+  Later .within (suc n) x y = x ≈[ n ] y
+
+  -- Trivial!
+  Later .has-is-ofe .has-is-prop zero = λ _ _ _ _ _ → _
+  Later .has-is-ofe .≈-trans     zero = _
+  Later .has-is-ofe .≈-refl      zero = _
+  Later .has-is-ofe .≈-sym       zero = _
+  Later .has-is-ofe .step        zero = _
+
+  -- Just like A!
+  Later .has-is-ofe .has-is-prop (suc n) = P.has-is-prop n
+  Later .has-is-ofe .≈-trans     (suc n) = P.≈-trans     n
+  Later .has-is-ofe .≈-refl      (suc n) = P.≈-refl      n
+  Later .has-is-ofe .≈-sym       (suc n) = P.≈-sym       n
+  Later .has-is-ofe .step        (suc n) = P.step        n
+
+  Later .has-is-ofe .bounded x y = _
+  Later .has-is-ofe .limit x y a = P.limit x y λ n → a (suc n)
+```
+
+```agda
+▶ : ∀ {ℓ ℓ'} → OFE ℓ ℓ' → OFE ℓ ℓ'
+▶ (A , O) = from-ofe-on (Later O)
+
+to-later : ∀ {ℓ ℓ'} (A : OFE ℓ ℓ') → OFEs.Hom A (▶ A)
+to-later A .hom x = x
+to-later A .preserves .pres-≈ {n = zero} α  = lift tt
+to-later A .preserves .pres-≈ {n = suc n} α = A .snd .OFE-on.step n _ _ α
+```
+
+<!--
+```
+module
+  _ {ℓa ℓa' ℓb ℓb'} {A : Type ℓa} {B : Type ℓb}
+    (P : OFE-on ℓa' A) (Q : OFE-on ℓb' B)
+  where
+
+  private
+    instance
+      _ = P
+      _ = Q
+    module P = OFE-on P
+    module Q = OFE-on Q
+```
+-->
+
+The universal property promised, that $\later P$ represents the
+contractive maps with domain $P$, is a short exercise in shuffling
+indices:
+
+```agda
+  later-contractive
+    : (f : A → B)
+    → is-non-expansive f (Later P) Q ≃ is-contractive f P Q
+  later-contractive f = prop-ext! {A = is-non-expansive _ _ _} {B = is-contractive _ _ _}
+    (λ { r .contract {n = n} α → r .pres-≈ {n = suc n} α })
+    (λ { r .pres-≈ {n = zero} α  → Q.bounded _ _
+       ; r .pres-≈ {n = suc n} α → r .contract α
+       })
+```
+
+<!--
+```agda
+module _ {ℓa ℓa'} {A : Type ℓa} (P : OFE-on ℓa' A) where
+  private
+    instance _ = P
+    module P = OFE-on P
+```
+-->
+
+We can put this together to define something akin to **Löb induction**:
+if $A$ is an inhabited, [complete OFE], Banach's fixed point theorem
+implies that non-expansive functions $\later P \to P$ have fixed points.
+
+```agda
+  löb : ∥ A ∥ → is-cofe P → (f : Later P →ⁿᵉ P) → Σ A λ x → f .map x ≡ x
+  löb pt lim f = banach P lim pt record {
+    contract = λ n p → f .pres-≈ (suc n) p }
+```

--- a/src/Cat/Instances/OFE/Product.lagda.md
+++ b/src/Cat/Instances/OFE/Product.lagda.md
@@ -35,13 +35,15 @@ module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓ
       _ = P
     module O = OFE-on O
     module P = OFE-on P
+  open OFE-H-Level O
+  open OFE-H-Level P
 ```
 -->
 
 ```agda
   ×-OFE : OFE-on (ℓa' ⊔ ℓb') (A × B)
   ×-OFE .within n (x , y) (x' , y') = (x ≈[ n ] x') × (y ≈[ n ] y')
-  ×-OFE .has-is-ofe .has-is-prop n x y = ×-is-hlevel 1 (hlevel 1) (hlevel 1)
+  ×-OFE .has-is-ofe .has-is-prop n x y = hlevel 1
 
   ×-OFE .has-is-ofe .≈-refl  n = O.≈-refl n , P.≈-refl n
   ×-OFE .has-is-ofe .≈-sym   n (p , q) = O.≈-sym n p , P.≈-sym n q
@@ -96,6 +98,7 @@ module
       P-ofe : ∀ {i} → OFE-on ℓr (F i)
       P-ofe {i} = P i
     module P {i} = OFE-on (P i)
+    module _ {i} where open OFE-H-Level (P i) public
 ```
 -->
 
@@ -151,7 +154,7 @@ about to get the actual inhabitant of $(1)$ that we're interested in.
   Π-OFE .has-is-ofe .limit x y wit i j = P.limit (x j) (y j) (λ n → wit' n j) i
     where
       wit' : ∀ n i → within (P i) n (x i) (y i)
-      wit' n i = out! {pa = Π-is-hlevel 1 λ _ → hlevel 1} (wit n .Lift.lower) i
+      wit' n i = out! {pa = hlevel 1} (wit n .Lift.lower) i
 ```
 
 <!--

--- a/src/Cat/Instances/OFE/Product.lagda.md
+++ b/src/Cat/Instances/OFE/Product.lagda.md
@@ -1,0 +1,185 @@
+<!--
+```agda
+open import Cat.Displayed.Univalence.Thin
+open import Cat.Diagram.Product.Indexed
+open import Cat.Displayed.Total
+open import Cat.Diagram.Product
+open import Cat.Instances.OFE
+open import Cat.Prelude
+```
+-->
+
+```agda
+module Cat.Instances.OFE.Product where
+```
+
+# Products of OFEs
+
+The [category of OFEs][OFE] admits [products]: the relations are,
+levelwise, pairwise! That is, $(x, y) \within{n} (x', y')$ if $x
+\within{n} x'$ and $y \within{n} y'$.  Distributing the axioms over
+products is enough to establish that this is actually an OFE.
+
+[OFE]: Cat.Instances.OFE.html
+[products]: Cat.Diagram.Product.html
+
+<!--
+```agda
+open OFE-Notation
+
+module _ {ℓa ℓb ℓa' ℓb'} {A : Type ℓa} {B : Type ℓb} (O : OFE-on ℓa' A) (P : OFE-on ℓb' B)
+  where
+  private
+    instance
+      _ = O
+      _ = P
+    module O = OFE-on O
+    module P = OFE-on P
+```
+-->
+
+```agda
+  ×-OFE : OFE-on (ℓa' ⊔ ℓb') (A × B)
+  ×-OFE .within n (x , y) (x' , y') = (x ≈[ n ] x') × (y ≈[ n ] y')
+  ×-OFE .has-is-ofe .has-is-prop n x y = ×-is-hlevel 1 (hlevel 1) (hlevel 1)
+
+  ×-OFE .has-is-ofe .≈-refl  n = O.≈-refl n , P.≈-refl n
+  ×-OFE .has-is-ofe .≈-sym   n (p , q) = O.≈-sym n p , P.≈-sym n q
+  ×-OFE .has-is-ofe .≈-trans n (p , q) (p' , q') =
+    O.≈-trans n p p' , P.≈-trans n q q'
+
+  ×-OFE .has-is-ofe .bounded (a , b) (a' , b') = O.bounded a a' , P.bounded b b'
+  ×-OFE .has-is-ofe .step n _ _ (p , p') = O.step n _ _ p , P.step n _ _ p'
+  ×-OFE .has-is-ofe .limit x y f =
+    ap₂ _,_ (O.limit _ _ λ n → f n .fst) (P.limit _ _ λ n → f n .snd)
+```
+
+<!--
+```agda
+open Product
+open is-product
+open Total-hom
+```
+-->
+
+By construction, this OFE is actually the proper categorical product of
+the OFE structures we started with: since this is a very concrete
+category, most of the reasoning piggy-backs off of that for types, which
+is almost definitional. Other than the noise inherent to formalisation,
+the argument is immediate:
+
+```agda
+OFE-Product : ∀ {ℓ ℓ'} A B → Product (OFEs ℓ ℓ') A B
+OFE-Product A B .apex = from-ofe-on (×-OFE (A .snd) (B .snd))
+OFE-Product A B .π₁ .hom = fst
+OFE-Product A B .π₁ .preserves .pres-≈ = fst
+
+OFE-Product A B .π₂ .hom = snd
+OFE-Product A B .π₂ .preserves .pres-≈ = snd
+
+OFE-Product A B .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
+OFE-Product A B .has-is-product .⟨_,_⟩ f g .preserves .pres-≈ p =
+  f .preserves .pres-≈ p , g .preserves .pres-≈ p
+
+OFE-Product A B .has-is-product .π₁∘factor = Homomorphism-path λ x → refl
+OFE-Product A B .has-is-product .π₂∘factor = Homomorphism-path λ x → refl
+OFE-Product A B .has-is-product .unique o p q = Homomorphism-path λ x →
+  ap₂ _,_ (p #ₚ x) (q #ₚ x)
+```
+
+<!--
+```agda
+module
+  _ {ℓi ℓf ℓr} {I : Type ℓi} (F : I → Type ℓf) (P : ∀ i → OFE-on ℓr (F i)) where
+  private
+    instance
+      P-ofe : ∀ {i} → OFE-on ℓr (F i)
+      P-ofe {i} = P i
+    module P {i} = OFE-on (P i)
+```
+-->
+
+## Indexed products
+
+We now turn to a slightly more complicated case: _indexed_ products of
+OFEs: because Agda is, by default, a predicative theory, we run into
+some issues with universe levels when defining the indexed product.
+Let's see them:
+
+Suppose we have an index type $I : \ty$ in the $i$th universe, and
+a family $P_i : \ty$, valued now in the $p$th universe. Moreover,
+the family $P_i$ should be pointwise an OFE, with nearness relation
+living in, let's say, the $r$th universe. We will define the relation on
+$\prod P$ to be
+
+$$
+\forall i, f(i) \within{n} g(i) \text{,} \tag 1
+$$
+
+but this type is _too large_: Since we quantify over $i : I$, and return
+one of the approximate equalities, it must live in the $(r \sqcup i)$th
+universe; but if we want indexed products to be in the same category we
+started with, it should live in the $r$th!
+
+Fortunately, to us, this is an annoyance, not an impediment: here in the
+1Lab, we assume [propositional resizing][omega] throughout. Since the
+product type $(1)$ is a proposition, it is equivalent to a small type,
+so we can put it in any universe, including the $r$th.
+
+[omega]: 1Lab.Resizing.html
+
+The construction is essentially the same as for binary products:
+however, since resizing is explicit, we have to do a bit more faffing
+about to get the actual inhabitant of $(1)$ that we're interested in.
+
+```agda
+  Π-OFE : OFE-on ℓr (∀ i → F i)
+  Π-OFE .within n f g = Lift ℓr (□ (∀ i → f i ≈[ n ] g i))
+  Π-OFE .has-is-ofe .has-is-prop n x y = Lift-is-hlevel 1 squash
+  Π-OFE .has-is-ofe .≈-refl n = lift (inc λ i → P.≈-refl n)
+  Π-OFE .has-is-ofe .≈-sym n (lift x) = lift do
+    x ← x
+    pure λ i → P.≈-sym n (x i)
+  Π-OFE .has-is-ofe .≈-trans n (lift p) (lift q) = lift do
+    p ← p
+    q ← q
+    pure λ i → P.≈-trans n (p i) (q i)
+  Π-OFE .has-is-ofe .bounded x y = lift (inc λ i → P.bounded (x i) (y i))
+  Π-OFE .has-is-ofe .step n x y (lift p) = lift do
+    p ← p
+    pure λ i → P.step n (x i) (y i) (p i)
+  Π-OFE .has-is-ofe .limit x y wit i j = P.limit (x j) (y j) (λ n → wit' n j) i
+    where
+      wit' : ∀ n i → within (P i) n (x i) (y i)
+      wit' n i = out! {pa = Π-is-hlevel 1 λ _ → hlevel 1} (wit n .Lift.lower) i
+```
+
+<!--
+```agda
+open is-indexed-product
+open Indexed-product
+```
+-->
+
+And, again, by essentially the same argument, we can establish that this
+is the categorical [_indexed_ product][ip] of $P$ in the category of
+OFEs, as long as all the sizes match up.
+
+[ip]: Cat.Diagram.Product.Indexed.html
+
+```agda
+OFE-Indexed-product
+  : ∀ {ℓo ℓr} {I : Type ℓo} (F : I → OFE ℓo ℓr)
+  → Indexed-product (OFEs ℓo ℓr) F
+OFE-Indexed-product F .ΠF = from-ofe-on $
+  Π-OFE (λ i → ∣ F i .fst ∣) (λ i → F i .snd)
+OFE-Indexed-product F .π i .hom f = f i
+OFE-Indexed-product F .π i .preserves .pres-≈ α =
+  out! {pa = F i .snd .has-is-prop _ _ _} ((_$ i) <$> α .Lift.lower)
+OFE-Indexed-product F .has-is-ip .tuple f .hom x i = f i # x
+OFE-Indexed-product F .has-is-ip .tuple f .preserves .pres-≈ wit =
+  lift $ inc λ i → f i .preserves .pres-≈ wit
+OFE-Indexed-product F .has-is-ip .commute = Homomorphism-path λ x → refl
+OFE-Indexed-product F .has-is-ip .unique f prf =
+  Homomorphism-path λ x → funext λ y → prf y #ₚ x
+```

--- a/src/Data/List.lagda.md
+++ b/src/Data/List.lagda.md
@@ -1,11 +1,13 @@
 <!--
 ```agda
+open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Retracts
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
 open import 1Lab.Type
 
+open import Data.Nat.Base
 open import Data.Bool
 ```
 -->
@@ -156,37 +158,23 @@ ap-∷ x≡y xs≡ys i = x≡y i ∷ xs≡ys i
 ⚠️ TODO: Explain these ⚠️
 
 ```agda
-mapUp : (Nat → A → B) → Nat → List A → List B
-mapUp f _ [] = []
-mapUp f n (x ∷ xs) = f n x ∷ mapUp f (suc n) xs
 
-length : List A → Nat
-length [] = zero
-length (x ∷ x₁) = suc (length x₁)
+take-length : ∀ {ℓ} {A : Type ℓ} (xs : List A) → take (length xs) xs ≡ xs
+take-length [] = refl
+take-length (x ∷ xs) = ap (x ∷_) (take-length xs)
 
-concat : List (List A) → List A
-concat [] = []
-concat (x ∷ xs) = x ++ concat xs
+take-length-more
+  : ∀ {ℓ} {A : Type ℓ} (xs : List A) (n : Nat)
+  → length xs ≤ n
+  → take n xs ≡ xs
+take-length-more [] zero wit = refl
+take-length-more [] (suc n) wit = refl
+take-length-more (x ∷ xs) (suc n) (s≤s wit) = ap (x ∷_) (take-length-more xs n wit)
 
-reverse : List A → List A
-reverse = go [] where
-  go : List A → List A → List A
-  go acc [] = acc
-  go acc (x ∷ xs) = go (x ∷ acc) xs
-
-_∷r_ : List A → A → List A
-xs ∷r x = xs ++ (x ∷ [])
-
-all=? : (A → A → Bool) → List A → List A → Bool
-all=? eq=? [] [] = true
-all=? eq=? [] (x ∷ ys) = false
-all=? eq=? (x ∷ xs) [] = false
-all=? eq=? (x ∷ xs) (y ∷ ys) = and (eq=? x y) (all=? eq=? xs ys)
-
-enumerate : ∀ {ℓ} {A : Type ℓ} → List A → List (Nat × A)
-enumerate = go 0 where
-  go : Nat → List _ → List (Nat × _)
-  go x [] = []
-  go x (a ∷ b) = (x , a) ∷ go (suc x) b
+instance
+  -- List isn't really a type on the same footing as all the others, but
+  -- we're here, so we might as well, right?
+  decomp-list : ∀ {ℓ} {A : Type ℓ} → hlevel-decomposition (List A)
+  decomp-list = decomp (quote ListPath.List-is-hlevel) (`level-minus 2 ∷ `search ∷ [])
 ```
 -->

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -4,6 +4,7 @@ open import 1Lab.Path
 open import 1Lab.Type
 
 open import Data.Product.NAry
+open import Data.Bool
 ```
 -->
 
@@ -111,4 +112,42 @@ _++_ : ∀ {ℓ} {A : Type ℓ} → List A → List A → List A
 (x ∷ xs) ++ ys = x ∷ (xs ++ ys)
 
 infixr 5 _++_
+
+mapUp : (Nat → A → B) → Nat → List A → List B
+mapUp f _ [] = []
+mapUp f n (x ∷ xs) = f n x ∷ mapUp f (suc n) xs
+
+length : List A → Nat
+length [] = zero
+length (x ∷ x₁) = suc (length x₁)
+
+concat : List (List A) → List A
+concat [] = []
+concat (x ∷ xs) = x ++ concat xs
+
+reverse : List A → List A
+reverse = go [] where
+  go : List A → List A → List A
+  go acc [] = acc
+  go acc (x ∷ xs) = go (x ∷ acc) xs
+
+_∷r_ : List A → A → List A
+xs ∷r x = xs ++ (x ∷ [])
+
+all=? : (A → A → Bool) → List A → List A → Bool
+all=? eq=? [] [] = true
+all=? eq=? [] (x ∷ ys) = false
+all=? eq=? (x ∷ xs) [] = false
+all=? eq=? (x ∷ xs) (y ∷ ys) = and (eq=? x y) (all=? eq=? xs ys)
+
+enumerate : ∀ {ℓ} {A : Type ℓ} → List A → List (Nat × A)
+enumerate = go 0 where
+  go : Nat → List _ → List (Nat × _)
+  go x [] = []
+  go x (a ∷ b) = (x , a) ∷ go (suc x) b
+
+take : ∀ {ℓ} {A : Type ℓ} → Nat → List A → List A
+take 0 xs = []
+take (suc n) [] = []
+take (suc n) (x ∷ xs) = x ∷ take n xs
 ```

--- a/src/Meta/Traverse.lagda.md
+++ b/src/Meta/Traverse.lagda.md
@@ -48,3 +48,4 @@ instance
   Traverse-Maybe : Traverse (eff Maybe)
   Traverse-Maybe .Traverse.traverse f (just x) = just <$> f x
   Traverse-Maybe .Traverse.traverse f nothing  = pure nothing
+```

--- a/src/Prim/Data/String.lagda.md
+++ b/src/Prim/Data/String.lagda.md
@@ -2,7 +2,7 @@
 ```agda
 open import 1Lab.Type
 
-open import Data.List
+open import Data.List.Base
 
 open import Prim.Data.Maybe
 open import Prim.Literals

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -54,6 +54,7 @@
 \newcommand{\eps}{\varepsilon}
 
 \newcommand{\To}{\Rightarrow}
+\newcommand{\later}{\mathop{\blacktriangleright}}
 \newcommand{\adj}{\rightleftarrows}
 \newcommand{\epi}{\twoheadrightarrow}
 \newcommand{\mono}{\hookrightarrow}
@@ -65,6 +66,7 @@
 \newcommand{\xot}[1]{\xleftarrow{#1}}
 \newcommand{\xepi}[1]{\xtwoheadrightarrow{#1}}
 \newcommand{\xmono}[1]{\xhookrightarrow{#1}}
+\newcommand{\within}[1]{\overset{#1}{\approx}}
 
 \DeclareMathOperator{\coker}{coker}
 \DeclareMathOperator*{\colim}{colim}


### PR DESCRIPTION
OFEs are a presentation of certain metric spaces which see some use in the literature on guarded recursion/step indexing, e.g. the “standard” model of the Iris logic lives in the category of COFEs.