### PR TITLE
defn: W-types are initial algebras

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -318,6 +318,27 @@ module _ {ℓ} {A : Type ℓ} {x y : A} {p : x ≡ y} where
     sym-invol i = p
 ```
 
+Given a `Square`{.Agda}, we can "flip" it along either dimension, or along the main diagonal:
+
+```agda
+module _ {ℓ} {A : Type ℓ} {a00 a01 a10 a11 : A}
+  {p : a00 ≡ a01}
+  {q : a00 ≡ a10}
+  {s : a01 ≡ a11}
+  {r : a10 ≡ a11}
+  (α : Square p q s r)
+  where
+
+  flip₁ : Square (sym p) s q (sym r)
+  flip₁ = symP α
+
+  flip₂ : Square r (sym q) (sym s) p
+  flip₂ i j = α i (~ j)
+
+  transpose : Square q p r s
+  transpose i j = α j i
+```
+
 # Paths
 
 While the basic structure of the path type is inherited from its nature

--- a/src/HoTT.lagda.md
+++ b/src/HoTT.lagda.md
@@ -37,6 +37,7 @@ open import Cat.Bi.Base
 open import Cat.Prelude
 
 open import Data.Set.Surjection
+open import Data.Wellfounded.W
 open import Data.Fin.Finite using (Finite-choice)
 open import Data.Dec
 open import Data.Nat using (ℕ-well-ordered ; Discrete-Nat)
@@ -410,6 +411,28 @@ _ = Map-classifier
 * Lemma 4.8.1: `Fibre-equiv`{.Agda}
 * Lemma 4.8.2: `Total-equiv`{.Agda}
 * Theorem 4.8.3: `Map-classifier`{.Agda}
+
+## Chapter 5 Induction
+
+### 5.3 W-types
+
+<!--
+```agda
+_ = W
+```
+-->
+
+* W-types: `W`{.Agda}
+
+### 5.4 Inductive types are initial algebras
+
+<!--
+```agda
+_ = W-initial
+```
+-->
+
+* Theorem 5.4.7: `W-initial`{.Agda}
 
 ## Chapter 6 Higher inductive types
 


### PR DESCRIPTION
# Description

Formalising HoTT book section 5.4 by showing that $W$-types are initial algebras for polynomial endofunctors.

## Checklist

Before submitting a merge request, please check the items below:

- [X] The imports are sorted (use `find -type f -name \*.agda -or -name \*.lagda.md | xargs support/sort-imports.hs`)

- [X] All code blocks have "agda" as their language. This is so that
tools like Tokei can report accurate line counts for proofs vs. text.

- [X] Proofs are explained to a satisfactory degree; This is subjective,
of course, but proofs should be comprehensible to a hypothetical human
whose knowledge is limited to a working understanding of non-cubical
Agda, and the stuff your pages link to.

The following items are encouraged, but optional:

- [ ] If you feel comfortable, add yourself to the Authors page! Add a
profile picture that's recognisably "you" under support/pfps; The
picture should be recognisable at 128x128px, should look good in a
squircle, and shouldn't be more than 200KiB.

- [ ] If your contribution makes mention of a negative statement, but
does not prove the negative (perhaps because it would distract from the
main point), consider adding it to the counterexamples folder.

- [ ] If a proof can be done in both "cubical style", and "book HoTT
style", and you have the energy to do both, consider doing both!
However, it is **completely fine** to only do one! For instance, I
(Amélia) am much better at writing proofs "book-style".

If a commit affects many files without adding any content and you don't
want your name to appear on those pages (for example, treewide refactorings
or reformattings), start the commit message with `chore:` or include the word
`NOAUTHOR` anywhere.
