### PR TITLE
web: search for modules and definitions

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -957,7 +957,7 @@ which are Kan complices. Examples of types which are _not_ fibrant
 include the interval `I`{.Agda}, the partial elements `Partial`{.Agda},
 and the extensions `_[_↦_]`[^notfibrant].
 
-::: {#fibrant}
+::: {.definition #fibrant}
 > **Definition**: A type is _fibrant_ if it supports `hcomp`{.Agda}.
 This word comes up a lot when discussing not only the semantics of
 Cubical type theory, but also its practice! For instance, the specific

--- a/support/shake/app/Main.hs
+++ b/support/shake/app/Main.hs
@@ -108,7 +108,7 @@ rules = do
     let searchFiles = (if skipAgda then [] else ["_build/all-types.json"])
                     ++ map (\(x, _) -> "_build/search" </> x <.> "json") modules
     searchData :: [[SearchTerm]] <- traverse readJSONFile searchFiles
-    liftIO $ encodeFile out (concat searchData)
+    traced "Writing search data" $ encodeFile out (concat searchData)
 
   -- Compile Quiver to SVG. This is used by 'buildMarkdown'.
   "_build/html/light-*.svg" %> \out -> do

--- a/support/shake/app/Shake/Options.hs
+++ b/support/shake/app/Shake/Options.hs
@@ -43,7 +43,7 @@ defaultOptions = Options
   { _optSkipTypes = False
   , _optSkipAgda  = False
   , _optWatching  = Nothing
-  , _optBaseUrl     = "https://1lab.dev"
+  , _optBaseUrl   = ""
   }
 
 data GetOptions = GetOptions deriving (Eq, Show, Typeable, Generic)

--- a/support/shake/app/Shake/SearchData.hs
+++ b/support/shake/app/Shake/SearchData.hs
@@ -10,9 +10,10 @@ import GHC.Generics (Generic)
 -- | Data about a searchable term. This is designed to be compatible with the
 -- type information written by our Agda HTML backend.
 data SearchTerm = SearchTerm
-  { idIdent  :: Text
-  , idAnchor :: Text
-  , idType   :: Maybe Text
-  , idDesc   :: Maybe Text
+  { idIdent   :: Text
+  , idAnchor  :: Text
+  , idType    :: Maybe Text
+  , idDesc    :: Maybe Text
+  , idDefines :: Maybe [Text]
   }
   deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)

--- a/support/web/js/search.tsx
+++ b/support/web/js/search.tsx
@@ -6,6 +6,7 @@ type SearchItem = {
   idAnchor: string,
   idType: string | null,
   idDesc: string | null,
+  idDefines: string[] | null,
 };
 
 const highlight = ({ match, original }: MatchData<SearchItem>): Content => {
@@ -178,7 +179,7 @@ const startSearch = (mirrorInput: HTMLInputElement | null) => {
         index = new Searcher(entries, {
           returnMatchData: true,
           ignoreSymbols: false,
-          keySelector: (x: SearchItem) => x.idIdent,
+          keySelector: (x: SearchItem) => [x.idIdent].concat(x.idDefines ?? []),
         });
 
         doSearch();

--- a/support/web/js/search.tsx
+++ b/support/web/js/search.tsx
@@ -51,18 +51,31 @@ const startSearch = (mirrorInput: HTMLInputElement | null) => {
       searchResults.innerHTML = "";
 
       const list = <ul>
-        {results.slice(0, 20).map(match => <li>
-          <a class="search-result" href={`/${match.item.idAnchor}`}>
-            <h3 class="sourceCode search-header">
-              <span>
-                {highlight(match)}
-              </span>
-              <span class="search-module">{match.item.idAnchor.replace(/.html(#.+)?$/, "")}</span>
-            </h3>
-            {match.item.idType && <p class="search-type sourceCode">{match.item.idType}</p>}
-            {match.item.idDesc && <p class="search-desc">{match.item.idDesc}</p>}
-          </a>
-        </li>)}
+        {results.slice(0, 20).map(match => {
+          let desc: HTMLElement | null = null;
+
+          /* The item has a description which can't be handled as plain
+           * text, since it might include rendered markup. Therefore, we
+           * can't use a JSX splice to insert it.
+           */
+          if (match.item.idDesc) {
+            desc = <p class="search-desc"></p>
+            desc.insertAdjacentHTML('afterbegin', match.item.idDesc);
+          };
+
+          return <li>
+            <a class="search-result" href={match.item.idAnchor}>
+              <h3 class="sourceCode search-header">
+                <span>
+                  {highlight(match)}
+                </span>
+                <span class="search-module">{match.item.idAnchor.replace(/.html(#.+)?$/, "")}</span>
+              </h3>
+              {match.item.idType && <p class="search-type sourceCode">{match.item.idType}</p>}
+              {desc}
+            </a>
+          </li>
+        })}
       </ul>;
 
 

--- a/support/web/template.html
+++ b/support/web/template.html
@@ -12,7 +12,7 @@
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="$pagetitle$ - 1Lab" />
-  <meta name="twitter:image" content="$base_url$/static/cube-128x.png" />
+  <meta name="twitter:image" content="$base-url$/static/cube-128x.png" />
 
   <meta name="og:title" content="$pagetitle$ - 1Lab" />
   <meta name="og:image" content="$base-url$/static/cube-128x.png" />
@@ -66,7 +66,7 @@
       </h3>
 
       <!-- Cube logo -->
-      <a id=logo href="$base-url$">
+      <a id=logo href="$base-url$/">
         <img alt="1Lab"
             src="$base-url$/static/cube-72x.png"
             style="display: block; margin-bottom: 1em; margin: auto;"
@@ -120,7 +120,7 @@
 
       $if(is-index)$
       $else$
-        <a href="$base-url$">back to index</a> <br />
+        <a href="$base-url$/">back to index</a> <br />
       $endif$
         <a href="all-pages.html">view all pages</a> <br />
         <a href="https://github.com/plt-amy/1lab/blob/$source$">link to source</a> <br />
@@ -138,7 +138,7 @@
       $if(is-index)$
       $else$
       <div id=return>
-        <a href="$base-url$">back to index</a>
+        <a href="$base-url$/">back to index</a>
       </div>
       $endif$
 


### PR DESCRIPTION
Allows searching for modules by name and for definitions.

Extract search data before rendering math to HTML so that the plain writer can render it in descriptions.

Clear the default base URL so that local files are used in development.