### PR TITLE
More overloading

### DIFF
--- a/src/1Lab/Resizing.lagda.md
+++ b/src/1Lab/Resizing.lagda.md
@@ -184,14 +184,17 @@ instance
   Bind-□ : Bind (eff □)
   Bind-□ .Bind._>>=_ = □-bind
 
-_∈_ : ∀ {ℓ} {A : Type ℓ} → A → (A → Ω) → Type
-x ∈ P = ∣ P x ∣
-
 is-set→locally-small
   : ∀ {ℓ} {A : Type ℓ}
   → is-set A
   → is-identity-system {A = A} (λ x y → □ (x ≡ y)) (λ x → inc refl)
 is-set→locally-small a-set .to-path = out! {pa = a-set _ _}
 is-set→locally-small a-set .to-path-over p = is-prop→pathp (λ _ → squash) _ _
+
+to-is-true
+  : ∀ {P Q : Ω} ⦃ _ : H-Level ∣ Q ∣ 0 ⦄
+  → ∣ P ∣
+  → P ≡ Q
+to-is-true prf = Ω-ua (λ _ → hlevel 0 .centre) (λ _ → prf)
 ```
 -->

--- a/src/1Lab/Underlying.agda
+++ b/src/1Lab/Underlying.agda
@@ -7,16 +7,24 @@ open import 1Lab.Type
 
 module 1Lab.Underlying where
 
+-- Notation class for types which have a chosen projection into a
+-- universe, i.e. a preferred "underlying type".
 record Underlying {ℓ} (T : Type ℓ) : Typeω where
   field
     ℓ-underlying : Level
     ⌞_⌟          : T → Type ℓ-underlying
 
 open Underlying ⦃ ... ⦄ using (⌞_⌟) public
-
 open Underlying using (ℓ-underlying)
 
+-- Workaround for Agda bug https://github.com/agda/agda/issues/6588 —
+-- the principal (instance) argument is reified as visible, so we can
+-- drop it using a display form.
+{-# DISPLAY Underlying.⌞_⌟ f x = ⌞ x ⌟ #-}
+
 instance
+-- For universes, we use the standard notion of "underlying type".
+
   Underlying-Type : ∀ {ℓ} → Underlying (Type ℓ)
   Underlying-Type {ℓ} .ℓ-underlying = ℓ
   Underlying-Type .⌞_⌟ x = x
@@ -29,6 +37,9 @@ instance
   Underlying-prop .ℓ-underlying = lzero
   Underlying-prop .⌞_⌟ x = ∣ x ∣
 
+  -- Lifting instances: for Σ-types, we think of (Σ A B) as "A with
+  -- B-structure", so the underlying type is that of A; For Lift, there
+  -- is no choice.
   Underlying-Σ
     : ∀ {ℓ ℓ′} {A : Type ℓ} {B : A → Type ℓ′}
     → ⦃ ua : Underlying A ⦄
@@ -42,16 +53,69 @@ instance
   Underlying-Lift ⦃ ua ⦄ .ℓ-underlying = ua .ℓ-underlying
   Underlying-Lift .⌞_⌟ x = ⌞ x .Lift.lower ⌟
 
-  -- Workaround for Agda bug https://github.com/agda/agda/issues/6588 —
-  -- the principal (instance) argument is reified as visible, so we can
-  -- drop it using a display form.
-  {-# DISPLAY Underlying.⌞_⌟ f x = ⌞ x ⌟ #-}
-
+-- The converse of to-is-true, generalised slightly. If P and Q are
+-- identical inhabitants of some type of structured types, and Q's
+-- underlying type is contractible, then P is inhabited. P's underlying
+-- type is obviously also contractible, but adding this as an instance
+-- would ruin type inference (I tried.)
 from-is-true
   : ∀ {ℓ} {A : Type ℓ} ⦃ _ : Underlying A ⦄ {P Q : A} ⦃ _ : H-Level ⌞ Q ⌟ 0 ⦄
   → P ≡ Q
   → ⌞ P ⌟
 from-is-true prf = subst ⌞_⌟ (sym prf) (hlevel 0 .centre)
 
-_∈_ : ∀ {ℓ ℓ′} {A : Type ℓ} {P : Type ℓ′} ⦃ u : Underlying P ⦄ → A → (A → P) → Type (u .ℓ-underlying)
+-- Generalised "membership" notation.
+_∈_ : ∀ {ℓ ℓ′} {A : Type ℓ} {P : Type ℓ′} ⦃ u : Underlying P ⦄
+    → A → (A → P) → Type (u .ℓ-underlying)
 x ∈ P = ⌞ P x ⌟
+
+-- Notation class for type families which are "function-like" (always
+-- nondependent). Slight generalisation of the homs of concrete
+-- categories.
+record
+  Funlike {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} (F : A → B → Type ℓ'') : Typeω where
+  infixl 999 _#_
+
+  field
+    -- The domain and codomain of F must both support an underlying-type
+    -- projection, which is determined by the F.
+    overlap ⦃ au ⦄ : Underlying A
+    overlap ⦃ bu ⦄ : Underlying B
+
+    -- The underlying function (infix).
+    _#_ : ∀ {A B} → F A B → ⌞ A ⌟ → ⌞ B ⌟
+
+    -- _#_ must be an injection. Really this should ask for an
+    -- embedding, but the most common use-cases have F valued in sets.
+    ext : ∀ {A B} {f g : F A B} → (∀ x → f # x ≡ g # x) → f ≡ g
+
+open Funlike ⦃ ... ⦄ using ( _#_ ; ext ) public
+{-# DISPLAY Funlike._#_ p f x = f # x #-}
+{-# DISPLAY Funlike.ext p q = ext q #-}
+
+-- Sections of the _#_ operator tend to be badly-behaved since they
+-- introduce an argument x : ⌞ ?0 ⌟ whose Underlying instance meta
+-- "mutually blocks" the Funlike instance meta. Use the prefix version
+-- instead.
+apply
+  : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {F : A → B → Type ℓ''}
+  → ⦃ _ : Funlike F ⦄
+  → ∀ {a b} → F a b → ⌞ a ⌟ → ⌞ b ⌟
+apply = _#_
+
+-- Generalised happly.
+_#ₚ_
+  : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {F : A → B → Type ℓ''}
+  → ⦃ _ : Funlike F ⦄
+  → {a : A} {b : B} {f g : F a b} → f ≡ g → ∀ (x : ⌞ a ⌟) → f # x ≡ g # x
+f #ₚ x = ap₂ _#_ f refl
+
+instance
+  -- Agda really dislikes inferring the level parameters here.
+  Funlike-Fun
+    : ∀ {ℓ ℓ'}
+    → Funlike {lsuc ℓ} {lsuc ℓ'} {ℓ ⊔ ℓ'} {Type ℓ} {Type ℓ'} λ x y → x → y
+  Funlike-Fun = record
+    { _#_ = _$_
+    ; ext = funext
+    }

--- a/src/1Lab/Underlying.agda
+++ b/src/1Lab/Underlying.agda
@@ -1,5 +1,8 @@
 open import 1Lab.HLevel.Universe
+open import 1Lab.HLevel.Retracts
 open import 1Lab.Resizing
+open import 1Lab.HLevel
+open import 1Lab.Path
 open import 1Lab.Type
 
 module 1Lab.Underlying where
@@ -30,10 +33,25 @@ instance
     : ∀ {ℓ ℓ′} {A : Type ℓ} {B : A → Type ℓ′}
     → ⦃ ua : Underlying A ⦄
     → Underlying (Σ A B)
-  Underlying-Σ ⦃ ua ⦄ .ℓ-underlying = ua .Underlying.ℓ-underlying
+  Underlying-Σ ⦃ ua ⦄ .ℓ-underlying = ua .ℓ-underlying
   Underlying-Σ .⌞_⌟ x               = ⌞ x .fst ⌟
+
+  Underlying-Lift
+    : ∀ {ℓ ℓ′} {A : Type ℓ} ⦃ ua : Underlying A ⦄
+    → Underlying (Lift ℓ′ A)
+  Underlying-Lift ⦃ ua ⦄ .ℓ-underlying = ua .ℓ-underlying
+  Underlying-Lift .⌞_⌟ x = ⌞ x .Lift.lower ⌟
 
   -- Workaround for Agda bug https://github.com/agda/agda/issues/6588 —
   -- the principal (instance) argument is reified as visible, so we can
   -- drop it using a display form.
   {-# DISPLAY Underlying.⌞_⌟ f x = ⌞ x ⌟ #-}
+
+from-is-true
+  : ∀ {ℓ} {A : Type ℓ} ⦃ _ : Underlying A ⦄ {P Q : A} ⦃ _ : H-Level ⌞ Q ⌟ 0 ⦄
+  → P ≡ Q
+  → ⌞ P ⌟
+from-is-true prf = subst ⌞_⌟ (sym prf) (hlevel 0 .centre)
+
+_∈_ : ∀ {ℓ ℓ′} {A : Type ℓ} {P : Type ℓ′} ⦃ u : Underlying P ⦄ → A → (A → P) → Type (u .ℓ-underlying)
+x ∈ P = ⌞ P x ⌟

--- a/src/1Lab/Univalence.lagda.md
+++ b/src/1Lab/Univalence.lagda.md
@@ -668,6 +668,7 @@ _ = is-prop
 ```
 -->
 
+:::{.definition #map-classifier}
 Since the type of "maps into B with variable domain and P fibres" has a
 very unwieldy description --- both in words or in Agda syntax --- we
 abbreviate it by $\ell /_{[P]} B$. The notation is meant to evoke the
@@ -676,6 +677,7 @@ category $C$ equipped with choices of maps into $c$. Similarly, the
 objects of $\ell/_{[P]}B$ are objects of the universe $\ty\
 \ell$, with a choice of map $f$ into $B$, such that $P$ holds for all
 the fibres of $f$.
+:::
 
 ```agda
 _/[_]_ : ∀ {ℓ' ℓ''} (ℓ : Level) → (Type (ℓ ⊔ ℓ') → Type ℓ'') → Type ℓ' → Type _

--- a/src/Algebra/Group/Ab/Abelianisation.lagda.md
+++ b/src/Algebra/Group/Ab/Abelianisation.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS --show-implicit #-}
 open import Algebra.Group.Cat.Base
 open import Algebra.Group.Ab
 open import Algebra.Group
@@ -197,9 +198,9 @@ for some $\hat f : G^{ab} \to H$ derived from $f$.
 
 ```agda
 make-free-abelian : ∀ {ℓ} → make-left-adjoint (Ab↪Grp {ℓ = ℓ})
-make-free-abelian = go where
+make-free-abelian {ℓ} = go where
   open make-left-adjoint
-  go : make-left-adjoint Ab↪Grp
+  go : make-left-adjoint (Ab↪Grp {ℓ = ℓ})
   go .free G = Abelianise G
 
   go .unit G .hom = inc^ab G

--- a/src/Algebra/Group/Ab/Hom.lagda.md
+++ b/src/Algebra/Group/Ab/Hom.lagda.md
@@ -57,20 +57,20 @@ Abelian-group-on-hom A B = to-abelian-group-on make-ab-on-hom module Hom-ab wher
 -->
 
 ```agda
-  make-ab-on-hom .mul f g .hom x = f .hom x B.* g .hom x
+  make-ab-on-hom .mul f g .hom x = f # x B.* g # x
   make-ab-on-hom .mul f g .preserves .pres-⋆ x y =
-    f .hom (x A.* y) B.* g .hom (x A.* y)                ≡⟨ ap₂ B._*_ (f .preserves .pres-⋆ x y) (g .preserves .pres-⋆ x y) ⟩
-    (f .hom x B.* f .hom y) B.* (g .hom x B.* g .hom y)  ≡⟨ B.pullr (B.pulll refl)  ⟩
-    f .hom x B.* (f .hom y B.* g .hom x) B.* g .hom y    ≡⟨ (λ i → f .hom x B.* B.commutes {x = f .hom y} {y = g .hom x} i B.* (g .hom y)) ⟩
-    f .hom x B.* (g .hom x B.* f .hom y) B.* g .hom y    ≡⟨ B.pushr (B.pushl refl) ⟩
-    (f .hom x B.* g .hom x) B.* (f .hom y B.* g .hom y)  ∎
+    f # (x A.* y) B.* g # (x A.* y)          ≡⟨ ap₂ B._*_ (f .preserves .pres-⋆ x y) (g .preserves .pres-⋆ x y) ⟩
+    (f # x B.* f # y) B.* (g # x B.* g # y)  ≡⟨ B.pullr (B.pulll refl)  ⟩
+    f # x B.* (f # y B.* g # x) B.* g # y    ≡⟨ (λ i → f # x B.* B.commutes {x = f # y} {y = g # x} i B.* (g # y)) ⟩
+    f # x B.* (g # x B.* f # y) B.* g # y    ≡⟨ B.pushr (B.pushl refl) ⟩
+    (f # x B.* g # x) B.* (f # y B.* g # y)  ∎
 
-  make-ab-on-hom .inv f .hom x = B._⁻¹ (f .hom x)
+  make-ab-on-hom .inv f .hom x = B._⁻¹ (f # x)
   make-ab-on-hom .inv f .preserves .pres-⋆ x y =
-    f .hom (x A.* y) B.⁻¹               ≡⟨ ap B._⁻¹ (f .preserves .pres-⋆ x y) ⟩
-    (f .hom x B.* f .hom y) B.⁻¹        ≡⟨ B.inv-comm ⟩
-    (f .hom y B.⁻¹) B.* (f .hom x B.⁻¹) ≡⟨ B.commutes ⟩
-    (f .hom x B.⁻¹) B.* (f .hom y B.⁻¹) ∎
+    f # (x A.* y) B.⁻¹            ≡⟨ ap B._⁻¹ (f .preserves .pres-⋆ x y) ⟩
+    (f # x B.* f # y) B.⁻¹        ≡⟨ B.inv-comm ⟩
+    (f # y B.⁻¹) B.* (f # x B.⁻¹) ≡⟨ B.commutes ⟩
+    (f # x B.⁻¹) B.* (f # y B.⁻¹) ∎
 
   make-ab-on-hom .1g .hom x = B.1g
   make-ab-on-hom .1g .preserves .pres-⋆ x y = B.introl refl

--- a/src/Algebra/Group/Ab/Tensor.lagda.md
+++ b/src/Algebra/Group/Ab/Tensor.lagda.md
@@ -113,9 +113,9 @@ homomorphisms $A \to [B,C]$.
   curry-bilinear-is-equiv : is-equiv curry-bilinear
   curry-bilinear-is-equiv = is-iso→is-equiv morp where
     morp : is-iso curry-bilinear
-    morp .is-iso.inv uc .Bilinear.map x y = uc .hom x .hom y
+    morp .is-iso.inv uc .Bilinear.map x y = uc # x # y
     morp .is-iso.inv uc .Bilinear.pres-*l x y z = ap (_# _) (uc .preserves .is-group-hom.pres-⋆ _ _)
-    morp .is-iso.inv uc .Bilinear.pres-*r x y z = uc .hom _ .preserves .is-group-hom.pres-⋆ _ _
+    morp .is-iso.inv uc .Bilinear.pres-*r x y z = (uc # _) .preserves .is-group-hom.pres-⋆ _ _
     morp .is-iso.rinv uc = Homomorphism-path λ x → Homomorphism-path λ y → refl
     morp .is-iso.linv uc = Bilinear-path λ x y → refl
 ```
@@ -277,11 +277,11 @@ an equivalence requires appealing to an induction principle of
 
 ```agda
   to-bilinear-map : Ab.Hom (A ⊗ B) C → Bilinear A B C
-  to-bilinear-map gh .Bilinear.map x y = gh .hom (x , y)
+  to-bilinear-map gh .Bilinear.map x y = gh # (x , y)
   to-bilinear-map gh .Bilinear.pres-*l x y z =
-    ap (gh .hom) t-pres-*l ∙ gh .preserves .is-group-hom.pres-⋆ _ _
+    ap (apply gh) t-pres-*l ∙ gh .preserves .is-group-hom.pres-⋆ _ _
   to-bilinear-map gh .Bilinear.pres-*r x y z =
-    ap (gh .hom) t-pres-*r ∙ gh .preserves .is-group-hom.pres-⋆ _ _
+    ap (apply gh) t-pres-*r ∙ gh .preserves .is-group-hom.pres-⋆ _ _
 
   from-bilinear-map-is-equiv : is-equiv from-bilinear-map
   from-bilinear-map-is-equiv = is-iso→is-equiv morp where
@@ -328,9 +328,9 @@ Ab-tensor-functor : Functor (Ab ℓ ×ᶜ Ab ℓ) (Ab ℓ)
 Ab-tensor-functor .F₀ (A , B) = A ⊗ B
 Ab-tensor-functor .F₁ (f , g) = from-bilinear-map _ _ _ bilin where
   bilin : Bilinear _ _ _
-  bilin .Bilinear.map x y       = f .hom x , g .hom y
-  bilin .Bilinear.pres-*l x y z = ap (_, g .hom z) (f .preserves .is-group-hom.pres-⋆ _ _) ∙ t-pres-*l
-  bilin .Bilinear.pres-*r x y z = ap (f .hom x ,_) (g .preserves .is-group-hom.pres-⋆ _ _) ∙ t-pres-*r
+  bilin .Bilinear.map x y       = f # x , g # y
+  bilin .Bilinear.pres-*l x y z = ap (_, g # z) (f .preserves .is-group-hom.pres-⋆ _ _) ∙ t-pres-*l
+  bilin .Bilinear.pres-*r x y z = ap (f # x ,_) (g .preserves .is-group-hom.pres-⋆ _ _) ∙ t-pres-*r
 Ab-tensor-functor .F-id    = Hom≃Bilinear.injective _ _ _ (Bilinear-path λ x y → refl)
 Ab-tensor-functor .F-∘ f g = Hom≃Bilinear.injective _ _ _ (Bilinear-path λ x y → refl)
 

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -127,7 +127,7 @@ proj₂ .hom = snd
 proj₂ .preserves .pres-⋆ x y = refl
 
 factor : Groups.Hom G H → Groups.Hom G K → Groups.Hom G (Direct-product H K)
-factor f g .hom x = f .hom x , g .hom x
+factor f g .hom x = f # x , g # x
 factor f g .preserves .pres-⋆ x y = ap₂ _,_ (f .preserves .pres-⋆ _ _) (g .preserves .pres-⋆ _ _)
 
 Direct-product-is-product : is-product {G} {H} proj₁ proj₂
@@ -151,12 +151,12 @@ a coproduct.
 inj₁ : G Groups.↪ Direct-product G H
 inj₁ {G} {H} .mor .hom x = x , H .snd .unit
 inj₁ {G} {H} .mor .preserves .pres-⋆ x y = ap (_ ,_) (sym (H .snd .idl))
-inj₁ {G} {H} .monic g h x = Forget-is-faithful (funext λ e i → x i .hom e .fst)
+inj₁ {G} {H} .monic g h x = Forget-is-faithful (funext λ e i → (x i # e) .fst)
 
 inj₂ : H Groups.↪ Direct-product G H
 inj₂ {H} {G} .mor .hom x = G .snd .unit , x
 inj₂ {H} {G} .mor .preserves .pres-⋆ x y = ap (_, _) (sym (G .snd .idl))
-inj₂ {H} {G} .monic g h x = Forget-is-faithful (funext λ e i → x i .hom e .snd)
+inj₂ {H} {G} .monic g h x = Forget-is-faithful (funext λ e i → (x i # e) .snd)
 ```
 
 ## Equalisers
@@ -197,16 +197,16 @@ follows from $f$ and $g$ being group homomorphisms:
   Equaliser-group = to-group equ-group where
     equ-⋆ : ∣ seq.apex ∣ → ∣ seq.apex ∣ → ∣ seq.apex ∣
     equ-⋆ (a , p) (b , q) = (a G.⋆ b) , r where abstract
-      r : f .hom (G .snd ._⋆_ a b) ≡ g .hom (G .snd ._⋆_ a b)
+      r : f # (G .snd ._⋆_ a b) ≡ g # (G .snd ._⋆_ a b)
       r = f.pres-⋆ a b ·· ap₂ H._⋆_ p q ·· sym (g.pres-⋆ _ _)
 
     equ-inv : ∣ seq.apex ∣ → ∣ seq.apex ∣
     equ-inv (x , p) = x G.⁻¹ , q where abstract
-      q : f .hom (G.inverse x) ≡ g .hom (G.inverse x)
+      q : f # (G.inverse x) ≡ g # (G.inverse x)
       q = f.pres-inv ·· ap H._⁻¹ p ·· sym g.pres-inv
 
     abstract
-      invs : f .hom G.unit ≡ g .hom G.unit
+      invs : f # G.unit ≡ g # G.unit
       invs = f.pres-id ∙ sym g.pres-id
 ```
 

--- a/src/Algebra/Group/Concrete.lagda.md
+++ b/src/Algebra/Group/Concrete.lagda.md
@@ -298,7 +298,7 @@ $(y, p(\refl) : \point{H} \equiv y)$, which means it is contractible.
     f≡p ω = ∙-filler (f # ω) (p refl) ▷ (sym (f-p ω refl) ∙ ap p (∙-idr ω))
 
     □≡□ : PathP (λ i → ∀ ω α → f≡p (ω ∙ α) i ≡ f # ω ∙ f≡p α i) (f .preserves .pres-⋆) f-p
-    □≡□ = prop!
+    □≡□ = is-prop→pathp (λ i → hlevel 1) _ _
 ```
 
 We can now apply the elimination principle and unpack our data:

--- a/src/Algebra/Group/Subgroup.lagda.md
+++ b/src/Algebra/Group/Subgroup.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS -vtc.def:10 #-}
 open import Algebra.Group.Cat.FinitelyComplete
 open import Algebra.Group.Cat.Base
 open import Algebra.Prelude
@@ -128,11 +129,11 @@ module _ {ℓ} {A B : Group ℓ} (f : Groups.Hom A B) where
     module B = Group-on (B .snd)
     module f = is-group-hom (f .preserves)
 
-    Tpath : {x y : image (f #_)} → x .fst ≡ y .fst → x ≡ y
+    Tpath : {x y : image (apply f)} → x .fst ≡ y .fst → x ≡ y
     Tpath {x} {y} p = Σ-prop-path (λ _ → squash) p
 
     abstract
-      Tset : is-set (image (f #_))
+      Tset : is-set (image (apply f))
       Tset = hlevel 2
 
     module Kerf = Kernel (Ker f)
@@ -150,7 +151,7 @@ reader.</summary>
 
 ```agda
     T : Type ℓ
-    T = image (f #_)
+    T = image (apply f)
 
   A/ker[_] : Group ℓ
   A/ker[_] = to-group grp where
@@ -263,7 +264,7 @@ elide the zero composite $e' \circ 0$.
     elim
       : ∀ {F} {e' : Groups.Hom A F}
           (p : e' Groups.∘ Zero.zero→ ∅ᴳ ≡ e' Groups.∘ Kerf.kernel)
-      → ∀ {x} → ∥ fibre (f #_) x ∥ → _
+      → ∀ {x : ⌞ B ⌟} → ∥ fibre (apply f) x ∥ → _
     elim {F = F} {e' = e'} p {x} =
       ∥-∥-rec-set ((e' #_) ⊙ fst) const (F .snd .Group-on.has-is-set) where abstract
       module e' = is-group-hom (e' .preserves)
@@ -277,13 +278,13 @@ representative". This follows from algebraic manipulation of group
 homomorphisms + the assumed identity $0 = e' \circ \ker f$;
 
 ```agda
-      const′ : ∀ (x y : fibre (f #_) x)
+      const′ : ∀ (x y : fibre (apply f) x)
              → e' # (x .fst) F.— e' # (y .fst) ≡ F.unit
       const′ (y , q) (z , r) =
-        e' # y F.— e' # z  ≡˘⟨ e'.pres-diff ⟩
-        e' # (y A.— z)     ≡⟨ happly (sym (ap hom p)) (y A.— z , aux) ⟩
-        e' # A.unit        ≡⟨ e'.pres-id ⟩
-        F.unit             ∎
+        (e' # y) F.— (e' # z)  ≡˘⟨ e'.pres-diff ⟩
+        e' # (y A.— z)         ≡⟨ happly (sym (ap hom p)) (y A.— z , aux) ⟩
+        e' # A.unit            ≡⟨ e'.pres-id ⟩
+        F.unit                 ∎
         where
 ```
 
@@ -299,7 +300,7 @@ But that's just algebra, hence uninteresting:
             x B.— x           ≡⟨ B.inverser ⟩
             B.unit            ∎
 
-      const : ∀ (x y : fibre (f #_) x) → e' # (x .fst) ≡ e' # (y .fst)
+      const : ∀ (x y : fibre (apply f) x) → e' # (x .fst) ≡ e' # (y .fst)
       const a b = F.zero-diff (const′ a b)
 ```
 
@@ -330,14 +331,14 @@ will compute.
     coeq .factors = Forget-is-faithful refl
 
     coeq .unique {F} {p = p} {colim = colim} prf = Forget-is-faithful (funext path)
-      where abstract
+      where
         module F = Group-on (F .snd)
-        path : ∀ x → colim # x ≡ elim p (x .snd)
+        path : ∀ (x : image (apply f)) → colim # x ≡ elim p (x .snd)
         path (x , t) =
           ∥-∥-elim
             {P = λ q → colim # (x , q) ≡ elim p q}
             (λ _ → F.has-is-set _ _)
-            (λ { (f , fp) → ap (colim #_) (Σ-prop-path (λ _ → squash) (sym fp))
+            (λ { (f , fp) → ap (apply colim) (Σ-prop-path (λ _ → squash) (sym fp))
                           ∙ (happly (ap hom prf) f) })
             t
 ```
@@ -390,8 +391,8 @@ f(yy^{-1}) = f(1) = 1$$.
     path =
       f # (y A.⋆ (x A.— y))         ≡⟨ ap (f #_) A.associative ⟩
       f # ((y A.⋆ x) A.— y)         ≡⟨ f.pres-diff ⟩
-      ⌜ f # (y A.⋆ x) ⌝ B.— f # y   ≡⟨ ap! (f.pres-⋆ y x) ⟩
-      ⌜ f # y B.⋆ f # x ⌝ B.— f # y ≡⟨ ap! (ap (_ B.⋆_) (ap (f #_) (sym q) ∙ p) ∙ B.idr) ⟩
+      ⌜ f # (y A.⋆ x) ⌝ B.— f # y   ≡⟨ ap₂ B._—_ (f.pres-⋆ y x) refl ⟩
+      ⌜ f # y B.⋆ f # x ⌝ B.— f # y ≡⟨ ap₂ B._—_ (ap (_ B.⋆_) (ap (f #_) (sym q) ∙ p) ∙ B.idr) refl ⟩
       f # y B.— f # y               ≡˘⟨ f.pres-diff ⟩
       f # (y A.— y)                 ≡⟨ ap (f #_) A.inverser ∙ f.pres-id ⟩
       B.unit                        ∎

--- a/src/Algebra/Ring/Module/Action.lagda.md
+++ b/src/Algebra/Ring/Module/Action.lagda.md
@@ -94,7 +94,7 @@ and ring morphisms $R \to [G,G]$ into the [endomorphism ring] of $G$.
 
 ```agda
   Hom→Action G rhom .Ring-action._⋆_ x y = rhom # x # y
-  Hom→Action G rhom .Ring-action.⋆-distribl r x y = rhom .hom r .preserves .is-group-hom.pres-⋆ _ _
+  Hom→Action G rhom .Ring-action.⋆-distribl r x y = (rhom # r) .preserves .is-group-hom.pres-⋆ _ _
   Hom→Action G rhom .Ring-action.⋆-distribr r s x = rhom .preserves .is-ring-hom.pres-+ r s #ₚ x
   Hom→Action G rhom .Ring-action.⋆-assoc r s x    = sym (rhom .preserves .is-ring-hom.pres-* r s #ₚ x)
   Hom→Action G rhom .Ring-action.⋆-id x           = rhom .preserves .is-ring-hom.pres-id #ₚ x

--- a/src/Algebra/Ring/Module/Vec.lagda.md
+++ b/src/Algebra/Ring/Module/Vec.lagda.md
@@ -115,7 +115,7 @@ Fin-vec-is-product .π i .hom k = k i
 Fin-vec-is-product .π i .preserves .linear r m n = refl
 Fin-vec-is-product {n} .has-is-ip .tuple {Y} f = assemble where
   assemble : R-Mod.Hom Y (Fin-vec-module n)
-  assemble .hom yob ix = f ix .hom yob
+  assemble .hom yob ix = f ix # yob
   assemble .preserves .linear r m n = funext λ i → f i .preserves .linear _ _ _
 Fin-vec-is-product .has-is-ip .commute = Homomorphism-path λ _ → refl
 Fin-vec-is-product .has-is-ip .unique {h = h} f ps =

--- a/src/Cat/Displayed/Univalence/Thin.lagda.md
+++ b/src/Cat/Displayed/Univalence/Thin.lagda.md
@@ -128,13 +128,12 @@ module _ {ℓ o′ ℓ′} {S : Type ℓ → Type o′} {spec : Thin-structure �
     module So = Precategory (Structured-objects spec)
     module Som = Cat.Morphism (Structured-objects spec)
 
-  _#_ : ∀ {a b : So.Ob} → So.Hom a b → ⌞ a ⌟ → ⌞ b ⌟
-  f # x = f .Total-hom.hom x
-
-  _#ₚ_ : ∀ {a b : So.Ob} {f g : So.Hom a b } → f ≡ g → ∀ x → f # x ≡ g # x
-  f #ₚ x = happly (ap hom f) x
-
-  infixl 999 _#_
+  instance
+    Funlike-Hom : Funlike So.Hom
+    Funlike-Hom = record
+      { _#_ = Total-hom.hom
+      ; ext = λ p → Structured-hom-path spec (funext p)
+      }
 
   Homomorphism-path
     : ∀ {x y : So.Ob} {f g : So.Hom x y}

--- a/src/Cat/Functor/Kan/Global.lagda.md
+++ b/src/Cat/Functor/Kan/Global.lagda.md
@@ -102,17 +102,17 @@ adjoint-precompose→Lan
   → (adj : F ⊣ precompose p)
   → (G : Functor C D)
   → is-lan p G (F .F₀ G) (adj ._⊣_.unit .η G)
-adjoint-precompose→Lan F adj G = ext where
+adjoint-precompose→Lan F adj G = extn where
   open Lan
   open is-lan
   module adj = _⊣_ adj
 
-  ext : is-lan p G _ _
-  ext .σ α = R-adjunct adj α
-  ext .σ-comm {M = M} {α = α} = Nat-path λ a →
+  extn : is-lan p G _ _
+  extn .σ α = R-adjunct adj α
+  extn .σ-comm {M = M} {α = α} = Nat-path λ a →
       D.pullr   (sym (adj.unit .is-natural _ _ _) ηₚ a)
     ∙ D.cancell (adj.zag ηₚ a)
-  ext .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv adj)
+  extn .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv adj)
     (L-R-adjunct adj _ ∙ x)
 ```
 

--- a/src/Cat/Functor/Subcategory.lagda.md
+++ b/src/Cat/Functor/Subcategory.lagda.md
@@ -91,6 +91,15 @@ module _ {o o' ℓ ℓ'} {C : Precategory o ℓ} {subcat : Subcat C o' ℓ'} whe
     → f ≡ g
   Subcat-hom-path p = Subcat-hom-pathp refl refl p
 
+  instance
+    Funlike-Subcat-hom : ⦃ _ : Funlike Hom ⦄ → Funlike (Subcat-hom subcat)
+    Funlike-Subcat-hom ⦃ i ⦄ = record
+      { au = Underlying-Σ ⦃ i .Funlike.au ⦄
+      ; bu = Underlying-Σ ⦃ i .Funlike.bu ⦄
+      ; _#_ = λ f x → apply (f .hom) x
+      ; ext = λ x → Subcat-hom-path (ext x)
+      }
+
   Subcat-hom-is-set
     : {x y : Σ[ ob ∈ Ob ] (is-ob ob)}
     → is-set (Subcat-hom subcat x y)

--- a/src/Cat/Monoidal/Diagram/Monoid/Representable.lagda.md
+++ b/src/Cat/Monoidal/Diagram/Monoid/Representable.lagda.md
@@ -281,31 +281,31 @@ functor is also [[fully faithful]].
   Nat→internal-mon-hom
     : ∀ {m n} {m-mon : C-Monoid m} {n-mon : C-Monoid n}
     → (α : Mon→PshMon m-mon => Mon→PshMon n-mon)
-    → C-Monoid-hom (α .η m .hom id) m-mon n-mon
+    → C-Monoid-hom (α .η m # id) m-mon n-mon
   Nat→internal-mon-hom {m} {n} {m-mon} {n-mon} α .pres-η =
-    (α .η m .hom id) ∘ (m-mon .η) ≡˘⟨ ap hom (α .is-natural _ _ _) $ₚ _ ⟩
-    α .η top .hom (id ∘ m-mon .η) ≡⟨ ap (α .η _ .hom) (id-comm-sym ∙ ap (m-mon .η ∘_) (sym (!-unique _))) ⟩
-    α .η top .hom (m-mon .η ∘ !)  ≡⟨ α .η _ .preserves .pres-id ⟩
-    n-mon .η ∘ !                  ≡⟨ elimr (!-unique _) ⟩
-    n-mon .η                      ∎
+    (α .η m # id) ∘ (m-mon .η) ≡˘⟨ ap hom (α .is-natural _ _ _) $ₚ _ ⟩
+    α .η top # (id ∘ m-mon .η) ≡⟨ ap (α .η _ #_) (id-comm-sym ∙ ap (m-mon .η ∘_) (sym (!-unique _))) ⟩
+    α .η top # (m-mon .η ∘ !)  ≡⟨ α .η _ .preserves .pres-id ⟩
+    n-mon .η ∘ !               ≡⟨ elimr (!-unique _) ⟩
+    n-mon .η                   ∎
   Nat→internal-mon-hom {m} {n} {m-mon} {n-mon} α .pres-μ =
-    α .η m .hom id ∘ (m-mon .μ)                                  ≡˘⟨ ap hom (α .is-natural _ _ _) $ₚ _ ⟩
-    α .η (m ⊗₀ m) .hom (id ∘ m-mon .μ)                           ≡⟨ ap (α .η _ .hom) (id-comm-sym ∙ ap (m-mon .μ ∘_) (sym ⟨⟩-η)) ⟩
-    α .η (m ⊗₀ m) .hom (m-mon .μ ∘ ⟨ π₁ , π₂ ⟩)                  ≡⟨ α .η _ .preserves .pres-⋆ _ _ ⟩
-    n-mon .μ ∘ ⟨ α .η _ .hom π₁ , α .η _ .hom π₂ ⟩               ≡˘⟨ ap (n-mon .μ ∘_) (ap₂ ⟨_,_⟩ (ap (α .η _ .hom) (idl _)) (ap (α .η _ .hom) (idl _))) ⟩
-    n-mon .μ ∘ ⟨ α .η _ .hom (id ∘ π₁) , α .η _ .hom (id ∘ π₂) ⟩ ≡⟨ ap (n-mon .μ ∘_) (ap₂ ⟨_,_⟩ (ap hom (α .is-natural _ _ _) $ₚ _) (ap hom (α .is-natural _ _ _) $ₚ _)) ⟩
-    n-mon .μ ∘ (α .η m .hom id ⊗₁ α .η m .hom id)                ∎
+    α .η m # id ∘ (m-mon .μ)                               ≡˘⟨ ap hom (α .is-natural _ _ _) $ₚ _ ⟩
+    α .η (m ⊗₀ m) # (id ∘ m-mon .μ)                        ≡⟨ ap (α .η _ #_) (id-comm-sym ∙ ap (m-mon .μ ∘_) (sym ⟨⟩-η)) ⟩
+    α .η (m ⊗₀ m) # (m-mon .μ ∘ ⟨ π₁ , π₂ ⟩)               ≡⟨ α .η _ .preserves .pres-⋆ _ _ ⟩
+    n-mon .μ ∘ ⟨ α .η _ # π₁ , α .η _ # π₂ ⟩               ≡˘⟨ ap (n-mon .μ ∘_) (ap₂ ⟨_,_⟩ (ap (α .η _ #_) (idl _)) (ap (α .η _ #_) (idl _))) ⟩
+    n-mon .μ ∘ ⟨ α .η _ # (id ∘ π₁) , α .η _ # (id ∘ π₂) ⟩ ≡⟨ ap (n-mon .μ ∘_) (ap₂ ⟨_,_⟩ (ap hom (α .is-natural _ _ _) $ₚ _) (ap hom (α .is-natural _ _ _) $ₚ _)) ⟩
+    n-mon .μ ∘ (α .η m # id ⊗₁ α .η m # id)                ∎
 
   open is-iso
 
   Mon→RepPShMon-is-ff : is-fully-faithful Mon→RepPShMon
   Mon→RepPShMon-is-ff = is-iso→is-equiv λ where
-    .inv α .hom       → α .η _ .hom id
+    .inv α .hom       → α .η _ # id
     .inv α .preserves → Nat→internal-mon-hom α
     .rinv α → Nat-path λ _ → Homomorphism-path λ f →
-      α .η _ .hom id ∘ f   ≡˘⟨ ap hom (α .is-natural _ _ _) $ₚ _ ⟩
-      α .η _ .hom (id ∘ f) ≡⟨ ap (α .η _ .hom) (idl f) ⟩
-      α .η _ .hom f        ∎
+      α .η _ # id ∘ f   ≡˘⟨ ap hom (α .is-natural _ _ _) $ₚ _ ⟩
+      α .η _ # (id ∘ f) ≡⟨ ap (α .η _ #_) (idl f) ⟩
+      α .η _ # f        ∎
     .linv h → total-hom-path _
       (idr _)
       (is-prop→pathp (λ _ → is-monoid-hom-is-prop _) _ _)

--- a/src/Cat/Regular/Slice.lagda.md
+++ b/src/Cat/Regular/Slice.lagda.md
@@ -131,7 +131,7 @@ calculate that the inverse to $m$ is still a map over $y$.
     → is-strong-epi C (h .map)
     → is-strong-epi C/y h
   reflect-cover h cover = is-extremal-epi→is-strong-epi C/y C/y-lex λ m g p →
-    let inv = ext (pres-mono m) (g .map) (ap map p)
+    let inv = extn (pres-mono m) (g .map) (ap map p)
     in C/y.make-invertible
       (record
         { map      = inv .is-invertible.inv
@@ -141,7 +141,7 @@ calculate that the inverse to $m$ is still a map over $y$.
       (/-Hom-path (inv .is-invertible.invl))
       (/-Hom-path (inv .is-invertible.invr))
     where
-      ext = is-strong-epi→is-extremal-epi C cover
+      extn = is-strong-epi→is-extremal-epi C cover
 ```
 
 Since the projection functor preserves and reflects strong epimorphisms,

--- a/src/Data/Power.lagda.md
+++ b/src/Data/Power.lagda.md
@@ -76,7 +76,7 @@ maximal : ℙ X
 maximal _ = el ⊤ hlevel!
 
 minimal : ℙ X
-minimal _ = el (Lift _ ⊥) hlevel!
+minimal _ = el ⊥ hlevel!
 
 _∩_ : ℙ X → ℙ X → ℙ X
 (A ∩ B) x = el (x ∈ A × x ∈ B) hlevel!

--- a/src/Data/Power/Complemented.lagda.md
+++ b/src/Data/Power/Complemented.lagda.md
@@ -56,7 +56,7 @@ is-decidable→is-complemented {A = A} p dec = inv , intersection , union where
   inv x = el (¬ (x ∈ p)) hlevel!
 
   intersection : (p ∩ inv) ⊆ minimal
-  intersection x (x∈p , x∉p) = lift (x∉p x∈p)
+  intersection x (x∈p , x∉p) = x∉p x∈p
 
   union : maximal ⊆ (p ∪ inv)
   union x wit with dec x
@@ -74,7 +74,7 @@ intersection $(p \cap p^{-1})$ is empty.
 is-complemented→is-decidable : (p : ℙ A) → is-complemented p → is-decidable p
 is-complemented→is-decidable p (p⁻¹ , intersection , union) elt =
   □-rec!  (λ { (inl x∈p)   → yes x∈p
-             ; (inr x∈p⁻¹) → no λ x∈p → Lift.lower $ intersection elt (x∈p , x∈p⁻¹)
+             ; (inr x∈p⁻¹) → no λ x∈p → intersection elt (x∈p , x∈p⁻¹)
              })
     (union elt tt)
 ```

--- a/src/Data/Set/Material.lagda.md
+++ b/src/Data/Set/Material.lagda.md
@@ -1,7 +1,7 @@
 <!--
 ```agda
 {-# OPTIONS --lossy-unification #-}
-open import 1Lab.Prelude
+open import 1Lab.Prelude hiding (ext)
 
 open import Data.Sum.Base
 open import Data.Image


### PR DESCRIPTION
Cherry-picking of `Funlike` from the frame-refactor branch, and of the generalized `_∈_` from the elementary-topos branch, since that proved not to break anything.