### PR TITLE
Extensionality tactic

### DIFF
--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -241,7 +241,7 @@ private
       `x ← quoteTC x
       `y ← quoteTC y
       typeError
-        [ "trivialᵉ failed: the values\n  "
+        [ "trivial! failed: the values\n  "
         , termErr `x
         , "\nand\n  "
         , termErr `y
@@ -249,7 +249,7 @@ private
         ]
 
 {-
-trivialᵉ serves to replace proofs like
+trivial! serves to replace proofs like
 
   Nat-path λ x → funext λ y → Nat-path λ z → Homomorphism-path λ a → refl
 
@@ -263,12 +263,12 @@ up.
 -}
 
 opaque
-  trivialᵉ
+  trivial!
     : ∀ {ℓ ℓr} {A : Type ℓ} {x y : A}
     → ⦃ r : Extensional A ℓr ⦄
     → {@(tactic trivial-worker r x y) p : Pathᵉ r x y}
     → x ≡ y
-  trivialᵉ ⦃ r ⦄ {p = p} = r .idsᵉ .to-path p
+  trivial! ⦃ r ⦄ {p = p} = r .idsᵉ .to-path p
 
 Pathᵉ-is-hlevel
   : ∀ {ℓ ℓr} {A : Type ℓ} n (sa : Extensional A ℓr)

--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -85,7 +85,7 @@ extensional A goal = do
   unify goal =<< find-extensionality `A
 
 {-
-Unlike extensionalᶠ, which is parametrised by a type, extensionalᶠ
+Unlike extensional, which is parametrised by a type, extensionalᶠ
 can be parametrised by a function (of arbitrary arity) into types,
 even though its type doesn't properly reflect this. It will discharge
 goals like

--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -1,0 +1,220 @@
+open import 1Lab.Reflection.Subst using (applyTC ; raiseTC)
+open import 1Lab.Path.IdentitySystem
+open import 1Lab.Reflection.HLevel
+open import 1Lab.HLevel.Retracts
+open import 1Lab.Reflection
+open import 1Lab.Type.Sigma
+open import 1Lab.Type.Pi
+open import 1Lab.HLevel
+open import 1Lab.Equiv
+open import 1Lab.Path
+open import 1Lab.Type
+
+open import Data.Nat.Base
+
+module 1Lab.Extensionality where
+
+record Extensional {ℓ} (A : Type ℓ) (ℓ-rel : Level) : Typeω where
+  field
+    Pathᵉ : A → A → Type ℓ-rel
+    reflᵉ : ∀ x → Pathᵉ x x
+    idsᵉ : is-identity-system Pathᵉ reflᵉ
+
+open Extensional using (Pathᵉ ; reflᵉ ; idsᵉ) public
+
+Extensional-default : ∀ {ℓ} {A : Type ℓ} → Extensional A ℓ
+Extensional-default .Pathᵉ   = _≡_
+Extensional-default .reflᵉ _ = refl
+Extensional-default .idsᵉ    = Path-identity-system
+
+record Extensionality {ℓ} (A : Type ℓ) : Type where
+  field lemma : Name
+
+find-extensionality : Term → TC Term
+find-extensionality tm = do
+  tm ← reduce =<< wait-for-type tm
+  let search = def (quote Extensionality) [ argN tm ]
+  debugPrint "tactic.extensionality" 10 ("find-extensionality goal:\n  " ∷ termErr search ∷ [])
+
+  runSpeculative do
+    (mv , _) ← new-meta' search
+    soln ← getInstances mv >>= λ where
+      (x ∷ xs) → do
+        it ← unquoteTC {A = Name} =<< normalise (def (quote Extensionality.lemma) (argN x ∷ []))
+        debugPrint "tactic.extensionality" 10 (" ⇒ found lemma " ∷ termErr (def it []) ∷ [])
+        pure (def it [])
+      []       → do
+        debugPrint "tactic.extensionality" 10 " ⇒ using default"
+        pure (def (quote Extensional-default) [])
+
+    pure (soln , false)
+
+extensional : ∀ {ℓ} (A : Type ℓ) → Term → TC ⊤
+extensional A goal = do
+  `A ← quoteTC A
+  candidate ← find-extensionality `A
+  unify goal
+    =<< checkType candidate (def (quote Extensional) [ argN `A , argN unknown ])
+
+extensionalᶠ
+  : ∀ {ℓ} {A : Type ℓ} → A → Term → TC ⊤
+extensionalᶠ {A = A} fun goal = ⦇ wrap (quoteTC A) (quoteTC fun) ⦈ >>= id where
+  work : Term → Term → TC Term
+  work (pi dom@(arg ai _) (abs nm cod)) tm = do
+    prf ← extendContext nm dom do
+      tm ← raiseTC 1 tm
+      tm ← applyTC tm (arg ai (var 0 []))
+      work cod tm
+    pure (lam (ai .ArgInfo.arg-vis) (abs nm prf))
+  work _ tm = find-extensionality tm
+
+  wrap : Term → Term → TC ⊤
+  wrap t fn = do
+    t ← wait-for-type t
+    debugPrint "tactic.extensionality" 10 ("extensionalᶠ goal:\n  " ∷ termErr fn ∷ "\nof type\n  " ∷ termErr t ∷ [])
+    prf ← work t fn
+    unify goal prf
+
+Extensional-Π
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : A → Type ℓ'}
+  → {@(tactic extensionalᶠ B) sb : ∀ x → Extensional (B x) ℓr}
+  → Extensional ((x : A) → B x) (ℓ ⊔ ℓr)
+Extensional-Π {sb = sb} .Pathᵉ f g = ∀ x → Pathᵉ (sb _) (f x) (g x)
+Extensional-Π {sb = sb} .reflᵉ f x = reflᵉ (sb x) (f x)
+Extensional-Π {sb = sb} .idsᵉ .to-path h = funext λ i → sb i .idsᵉ .to-path (h i)
+Extensional-Π {sb = sb} .idsᵉ .to-path-over h = funextP λ i → sb i .idsᵉ .to-path-over (h i)
+
+Extensional-→
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
+  → {@(tactic extensional B) sb : Extensional B ℓr}
+  → Extensional (A → B) (ℓ ⊔ ℓr)
+Extensional-→ {sb = sb} = Extensional-Π {sb = λ _ → sb}
+
+Extensional-×
+  : ∀ {ℓ ℓ' ℓr ℓs} {A : Type ℓ} {B : Type ℓ'}
+  → {@(tactic extensional A) sa : Extensional A ℓr}
+  → {@(tactic extensional B) sb : Extensional B ℓs}
+  → Extensional (A × B) (ℓr ⊔ ℓs)
+Extensional-× {sa = sa} {sb = sb} .Pathᵉ (x , y) (x' , y') = Pathᵉ sa x x' × Pathᵉ sb y y'
+Extensional-× {sa = sa} {sb = sb} .reflᵉ (x , y) = reflᵉ sa x , reflᵉ sb y
+Extensional-× {sa = sa} {sb = sb} .idsᵉ .to-path (p , q) = ap₂ _,_
+  (sa .idsᵉ .to-path p)
+  (sb .idsᵉ .to-path q)
+Extensional-× {sa = sa} {sb = sb} .idsᵉ .to-path-over (p , q) = Σ-pathp-dep
+  (sa .idsᵉ .to-path-over p)
+  (sb .idsᵉ .to-path-over q)
+
+instance
+  extensionality-fun : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+    → Extensionality (A → B)
+  extensionality-fun = record { lemma = quote Extensional-→ }
+
+  extensionality-Π : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+    → Extensionality ((x : A) → B x)
+  extensionality-Π = record { lemma = quote Extensional-Π }
+
+  extensionality-× : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+    → Extensionality (A × B)
+  extensionality-× = record { lemma = quote Extensional-× }
+
+ext
+  : ∀ {ℓ ℓr} {A : Type ℓ} {@(tactic extensional A) r : Extensional A ℓr} {x y : A}
+  → Pathᵉ r x y → x ≡ y
+ext {r = r} p = r .idsᵉ .to-path p
+
+trivial-worker
+  : ∀ {ℓ ℓr} {A : Type ℓ}
+  → (r : Extensional A ℓr)
+  → (x y : A)
+  → Term
+  → TC ⊤
+trivial-worker r x y goal = try where
+  error : ∀ {ℓ} {A : Type ℓ} → TC A
+  error = do
+    `x ← quoteTC x
+    `y ← quoteTC y
+    typeError
+      [ "trivialᵉ failed: the values\n  "
+      , termErr `x
+      , "\nand\n  "
+      , termErr `y
+      , "\nare not extensionally equal by refl."
+      ]
+
+  try : TC ⊤
+  try = do
+    `r ← wait-for-type =<< quoteωTC r
+    ty ← quoteTC (Pathᵉ r x y)
+    `x ← quoteTC x
+    `refl ← checkType (def (quote reflᵉ) [ argN `r , argN `x ]) ty
+      <|> error
+    unify goal `refl
+
+opaque
+  trivialᵉ
+    : ∀ {ℓ ℓr} {A : Type ℓ}
+    → {@(tactic extensional A) r : Extensional A ℓr}
+    → {x y : A}
+    → {@(tactic trivial-worker r x y) p : Pathᵉ r x y}
+    → x ≡ y
+  trivialᵉ {r = r} {p = p} = r .idsᵉ .to-path p
+
+Pathᵉ-is-hlevel
+  : ∀ {ℓ ℓr} {A : Type ℓ} n (sa : Extensional A ℓr)
+  → is-hlevel A (suc n)
+  → ∀ {x y}
+  → is-hlevel (Pathᵉ sa x y) n
+Pathᵉ-is-hlevel n sa hl =
+  is-hlevel≃ _ (identity-system-gives-path (sa .idsᵉ)) (Path-is-hlevel' _ hl _ _)
+
+injection→extensional
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
+  → is-set B
+  → (f : A → B)
+  → (∀ {x y} → f x ≡ f y → x ≡ y)
+  → Extensional B ℓr
+  → Extensional A ℓr
+injection→extensional b-set f inj ext .Pathᵉ x y = Pathᵉ ext (f x) (f y)
+injection→extensional b-set f inj ext .reflᵉ x = reflᵉ ext (f x)
+injection→extensional b-set f inj ext .idsᵉ =
+  set-identity-system
+    (λ x y → Pathᵉ-is-hlevel 1 ext b-set)
+    (λ p → inj (ext .idsᵉ .to-path p))
+
+injection→extensional!
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
+  → {@(tactic hlevel-tactic-worker) sb : is-set B}
+  → {f : A → B}
+  → (∀ {x y} → f x ≡ f y → x ≡ y)
+  → Extensional B ℓr
+  → Extensional A ℓr
+injection→extensional! {sb = sb} {f} = injection→extensional sb f
+
+private
+  record Test : Type where
+    no-eta-equality
+    field
+      foo     : Nat
+      useless : is-equiv {A = Nat} id
+
+  open Test
+
+  t1 t2 : Test
+  t1 .foo = 2
+  t1 .useless = id-equiv
+
+  t2 .foo = 2
+  t2 .useless = id-equiv
+
+  Extensional-Test : Extensional Test lzero
+  Extensional-Test = injection→extensional! {sb = Nat-is-set} p Extensional-default where
+    p : ∀ {x y} → x .foo ≡ y .foo → x ≡ y
+    p r i .foo = r i
+    p {x} {y} _ i .useless = is-equiv-is-prop id (x .useless) (y .useless) i
+
+  instance
+    _ : Extensionality Test
+    _ = record { lemma = quote Extensional-Test }
+
+  _ : t1 ≡ t2
+  _ = trivialᵉ

--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -15,23 +15,48 @@ open import Data.Nat.Base
 module 1Lab.Extensionality where
 
 record Extensional {ℓ} (A : Type ℓ) (ℓ-rel : Level) : Typeω where
+  no-eta-equality
   field
     Pathᵉ : A → A → Type ℓ-rel
     reflᵉ : ∀ x → Pathᵉ x x
     idsᵉ : is-identity-system Pathᵉ reflᵉ
 
+record Extensionality {ℓ} (A : Type ℓ) : Type where
+  field lemma : Name
+
+{-
+The 'Extensional' and 'Extensionality' classes both function to equip a
+type with a preferred choice of identity system. The idea is that
+'Extensional' actually carries the data, and 'Extensionality' is a
+pointer to the 'Extensional' instance.
+
+We use tactic arguments to implement default instances: since Agda will
+happily call tactic arguments inside getInstances, if we had Extensional
+instances with Extensional superclasses, this would lead to a
+super-exponential amount of work being done: *every Extensional
+instance*, including the "instance context", would have its full
+instantiation computed before being added to the list of possible
+instances.
+
+Instead the macro looks for 'Extensionality' instances, which *have no
+'Extensionality' class constraints*, and unfolds those to get the
+"actual" 'Extensional' instance.
+-}
+
 open Extensional using (Pathᵉ ; reflᵉ ; idsᵉ) public
 
+-- Default instance, uses regular paths for the relation.
 Extensional-default : ∀ {ℓ} {A : Type ℓ} → Extensional A ℓ
 Extensional-default .Pathᵉ   = _≡_
 Extensional-default .reflᵉ _ = refl
 Extensional-default .idsᵉ    = Path-identity-system
 
-record Extensionality {ℓ} (A : Type ℓ) : Type where
-  field lemma : Name
-
+-- Find a value of 'Extensional' by looking at instances of 'Extensionality'.
 find-extensionality : Term → TC Term
 find-extensionality tm = do
+  -- We have to block on the full type being available to prevent a
+  -- situation where the default instance (or an incorrect instance!) is
+  -- picked because the type is meta-headed.
   tm ← reduce =<< wait-for-type tm
   let search = def (quote Extensionality) [ argN tm ]
   debugPrint "tactic.extensionality" 10 ("find-extensionality goal:\n  " ∷ termErr search ∷ [])
@@ -39,23 +64,40 @@ find-extensionality tm = do
   runSpeculative do
     (mv , _) ← new-meta' search
     soln ← getInstances mv >>= λ where
-      (x ∷ xs) → do
+      -- In a throw-away TC context, look for solutions to 'Extensionality'
+      -- tm, and choose the first instance if any are available.
+      (x ∷ _) → do
         it ← unquoteTC {A = Name} =<< normalise (def (quote Extensionality.lemma) (argN x ∷ []))
         debugPrint "tactic.extensionality" 10 (" ⇒ found lemma " ∷ termErr (def it []) ∷ [])
         pure (def it [])
-      []       → do
+
+      -- If nothing more specific is available, use paths.
+      [] → do
         debugPrint "tactic.extensionality" 10 " ⇒ using default"
         pure (def (quote Extensional-default) [])
-
     pure (soln , false)
 
+-- Entry point for getting hold of an 'Extensional' instance:
 extensional : ∀ {ℓ} (A : Type ℓ) → Term → TC ⊤
 extensional A goal = do
   `A ← quoteTC A
-  candidate ← find-extensionality `A
-  unify goal
-    =<< checkType candidate (def (quote Extensional) [ argN `A , argN unknown ])
+  checkType goal (def (quote Extensional) [ argN `A , argN unknown ])
+  unify goal =<< find-extensionality `A
 
+{-
+Unlike extensionalᶠ, which is parametrised by a type, extensionalᶠ
+can be parametrised by a function (of arbitrary arity) into types,
+even though its type doesn't properly reflect this. It will discharge
+goals like
+
+   ∀ x → Extensional (P x) ℓ
+
+by getting rid of every Π in the type and looking in an extended
+context. It's also possible to use ⦃ _ : ∀ {x} → Extensional (P x) ℓ ⦄,
+since Agda supports commuting those by itself. However, using
+extensionalᶠ blocks more aggressively, which is required for touchy
+instances like Extensional-natural-transformation.
+-}
 extensionalᶠ
   : ∀ {ℓ} {A : Type ℓ} → A → Term → TC ⊤
 extensionalᶠ {A = A} fun goal = ⦇ wrap (quoteTC A) (quoteTC fun) ⦈ >>= id where
@@ -75,89 +117,158 @@ extensionalᶠ {A = A} fun goal = ⦇ wrap (quoteTC A) (quoteTC fun) ⦈ >>= id 
     prf ← work t fn
     unify goal prf
 
+instance
+  extensional-extensionality
+    : ∀ {ℓ ℓs} {A : Type ℓ} {@(tactic extensional A) sa : Extensional A ℓs}
+    → Extensional A ℓs
+  extensional-extensionality {sa = sa} = sa
+
+{-
+Canonical example of extending the Extensionality tactic:
+
+* The actual 'Extensional' value can have ⦃ Extensional A ℓ ⦄ in its
+  "instance context". These are filled in by the bridge instance above.
+
+* The 'Extensionality' loop-breaker only mentions the things that are
+  actually required to compute the "head" type.
+-}
+Extensional-Lift
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ}
+  → ⦃ sa : Extensional A ℓr ⦄
+  → Extensional (Lift ℓ' A) ℓr
+Extensional-Lift ⦃ sa ⦄ .Pathᵉ (lift x) (lift y) = sa .Pathᵉ x y
+Extensional-Lift ⦃ sa ⦄ .reflᵉ (lift x) = sa .reflᵉ x
+Extensional-Lift ⦃ sa ⦄ .idsᵉ .to-path p = ap lift (sa .idsᵉ .to-path p)
+Extensional-Lift ⦃ sa ⦄ .idsᵉ .to-path-over p = sa .idsᵉ .to-path-over p
+
+instance
+  extensionality-lift : ∀ {ℓ ℓ'} {A : Type ℓ} → Extensionality (Lift ℓ' A)
+  extensionality-lift = record { lemma = quote Extensional-Lift }
+
 Extensional-Π
   : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : A → Type ℓ'}
-  → {@(tactic extensionalᶠ B) sb : ∀ x → Extensional (B x) ℓr}
+  → ⦃ sb : ∀ {x} → Extensional (B x) ℓr ⦄
   → Extensional ((x : A) → B x) (ℓ ⊔ ℓr)
-Extensional-Π {sb = sb} .Pathᵉ f g = ∀ x → Pathᵉ (sb _) (f x) (g x)
-Extensional-Π {sb = sb} .reflᵉ f x = reflᵉ (sb x) (f x)
-Extensional-Π {sb = sb} .idsᵉ .to-path h = funext λ i → sb i .idsᵉ .to-path (h i)
-Extensional-Π {sb = sb} .idsᵉ .to-path-over h = funextP λ i → sb i .idsᵉ .to-path-over (h i)
+Extensional-Π ⦃ sb ⦄ .Pathᵉ f g = ∀ x → Pathᵉ sb (f x) (g x)
+Extensional-Π ⦃ sb ⦄ .reflᵉ f x = reflᵉ sb (f x)
+Extensional-Π ⦃ sb ⦄ .idsᵉ .to-path h = funext λ i → sb .idsᵉ .to-path (h i)
+Extensional-Π ⦃ sb ⦄ .idsᵉ .to-path-over h = funextP λ i → sb .idsᵉ .to-path-over (h i)
 
 Extensional-→
   : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
-  → {@(tactic extensional B) sb : Extensional B ℓr}
+  → ⦃ sb : Extensional B ℓr ⦄
   → Extensional (A → B) (ℓ ⊔ ℓr)
-Extensional-→ {sb = sb} = Extensional-Π {sb = λ _ → sb}
+Extensional-→ ⦃ sb ⦄ = Extensional-Π ⦃ λ {_} → sb ⦄
 
 Extensional-×
   : ∀ {ℓ ℓ' ℓr ℓs} {A : Type ℓ} {B : Type ℓ'}
-  → {@(tactic extensional A) sa : Extensional A ℓr}
-  → {@(tactic extensional B) sb : Extensional B ℓs}
+  → ⦃ sa : Extensional A ℓr ⦄
+  → ⦃ sb : Extensional B ℓs ⦄
   → Extensional (A × B) (ℓr ⊔ ℓs)
-Extensional-× {sa = sa} {sb = sb} .Pathᵉ (x , y) (x' , y') = Pathᵉ sa x x' × Pathᵉ sb y y'
-Extensional-× {sa = sa} {sb = sb} .reflᵉ (x , y) = reflᵉ sa x , reflᵉ sb y
-Extensional-× {sa = sa} {sb = sb} .idsᵉ .to-path (p , q) = ap₂ _,_
+Extensional-× ⦃ sa ⦄ ⦃ sb ⦄ .Pathᵉ (x , y) (x' , y') = Pathᵉ sa x x' × Pathᵉ sb y y'
+Extensional-× ⦃ sa ⦄ ⦃ sb ⦄ .reflᵉ (x , y) = reflᵉ sa x , reflᵉ sb y
+Extensional-× ⦃ sa ⦄ ⦃ sb ⦄ .idsᵉ .to-path (p , q) = ap₂ _,_
   (sa .idsᵉ .to-path p)
   (sb .idsᵉ .to-path q)
-Extensional-× {sa = sa} {sb = sb} .idsᵉ .to-path-over (p , q) = Σ-pathp-dep
+Extensional-× ⦃ sa ⦄ ⦃ sb ⦄ .idsᵉ .to-path-over (p , q) = Σ-pathp-dep
   (sa .idsᵉ .to-path-over p)
   (sb .idsᵉ .to-path-over q)
 
 instance
-  extensionality-fun : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  extensionality-fun
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
     → Extensionality (A → B)
   extensionality-fun = record { lemma = quote Extensional-→ }
 
-  extensionality-Π : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+  extensionality-Π
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
     → Extensionality ((x : A) → B x)
   extensionality-Π = record { lemma = quote Extensional-Π }
 
-  extensionality-× : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  extensionality-×
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
     → Extensionality (A × B)
   extensionality-× = record { lemma = quote Extensional-× }
 
+{-
+Actual user-facing entry point for the tactic: using the 'extensional'
+tactic (through the blanket instance) we can find an identity system for
+the type A, and turn a proof in the computed relation to an identity.
+-}
 ext
-  : ∀ {ℓ ℓr} {A : Type ℓ} {@(tactic extensional A) r : Extensional A ℓr} {x y : A}
+  : ∀ {ℓ ℓr} {A : Type ℓ} ⦃ r : Extensional A ℓr ⦄ {x y : A}
   → Pathᵉ r x y → x ≡ y
-ext {r = r} p = r .idsᵉ .to-path p
+ext ⦃ r ⦄ p = r .idsᵉ .to-path p
 
-trivial-worker
-  : ∀ {ℓ ℓr} {A : Type ℓ}
-  → (r : Extensional A ℓr)
-  → (x y : A)
-  → Term
-  → TC ⊤
-trivial-worker r x y goal = try where
-  error : ∀ {ℓ} {A : Type ℓ} → TC A
-  error = do
-    `x ← quoteTC x
-    `y ← quoteTC y
-    typeError
-      [ "trivialᵉ failed: the values\n  "
-      , termErr `x
-      , "\nand\n  "
-      , termErr `y
-      , "\nare not extensionally equal by refl."
-      ]
+{-
+Using the extensionality tactic we can define a "more general refl",
+where the terms being compared are not definitionally equal, but they
+inhabit a type with a good identity system for which 'r x : R x y' type
+checks.
 
-  try : TC ⊤
-  try = do
-    `r ← wait-for-type =<< quoteωTC r
-    ty ← quoteTC (Pathᵉ r x y)
-    `x ← quoteTC x
-    `refl ← checkType (def (quote reflᵉ) [ argN `r , argN `x ]) ty
-      <|> error
-    unify goal `refl
+The idea is to write a function wrapping
+
+  ext : ⦃ r : Extensional A ℓ ⦄ (p : Pathᵉ r x y) → x ≡ y
+
+so that it gives (reflᵉ r x) as the default argument for p. We can use a
+tactic argument to accomplish this.
+-}
+
+private
+  trivial-worker
+    : ∀ {ℓ ℓr} {A : Type ℓ}
+    → (r : Extensional A ℓr)
+    → (x y : A)
+    → Term
+    → TC ⊤
+  trivial-worker r x y goal = try where
+    error : ∀ {ℓ} {A : Type ℓ} → TC A
+
+    -- We already have our r : Extensional A ℓr, and this is a macro, so
+    -- we can just check that r .reflᵉ x : R x y. If that's the case
+    -- then we can use that as the argument, otherwise we can give a
+    -- slightly better error message than what Agda would yell.
+    try : TC ⊤
+    try = do
+      `r ← wait-for-type =<< quoteωTC r
+      ty ← quoteTC (Pathᵉ r x y)
+      `x ← quoteTC x
+      `refl ← checkType (def (quote reflᵉ) [ argN `r , argN `x ]) ty
+        <|> error
+      unify goal `refl
+
+    error = do
+      `x ← quoteTC x
+      `y ← quoteTC y
+      typeError
+        [ "trivialᵉ failed: the values\n  "
+        , termErr `x
+        , "\nand\n  "
+        , termErr `y
+        , "\nare not extensionally equal by refl."
+        ]
+
+{-
+trivialᵉ serves to replace proofs like
+
+  Nat-path λ x → funext λ y → Nat-path λ z → Homomorphism-path λ a → refl
+
+since this is
+
+  ext λ x y z a → refl
+
+and that argument is precisely reflexivity for the computed identity
+system which 'ext' is using. By the way, this example is totally made
+up.
+-}
 
 opaque
   trivialᵉ
-    : ∀ {ℓ ℓr} {A : Type ℓ}
-    → {@(tactic extensional A) r : Extensional A ℓr}
-    → {x y : A}
+    : ∀ {ℓ ℓr} {A : Type ℓ} {x y : A}
+    → ⦃ r : Extensional A ℓr ⦄
     → {@(tactic trivial-worker r x y) p : Pathᵉ r x y}
     → x ≡ y
-  trivialᵉ {r = r} {p = p} = r .idsᵉ .to-path p
+  trivialᵉ ⦃ r ⦄ {p = p} = r .idsᵉ .to-path p
 
 Pathᵉ-is-hlevel
   : ∀ {ℓ ℓr} {A : Type ℓ} n (sa : Extensional A ℓr)
@@ -167,20 +278,12 @@ Pathᵉ-is-hlevel
 Pathᵉ-is-hlevel n sa hl =
   is-hlevel≃ _ (identity-system-gives-path (sa .idsᵉ)) (Path-is-hlevel' _ hl _ _)
 
-injection→extensional
-  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
-  → is-set B
-  → (f : A → B)
-  → (∀ {x y} → f x ≡ f y → x ≡ y)
-  → Extensional B ℓr
-  → Extensional A ℓr
-injection→extensional b-set f inj ext .Pathᵉ x y = Pathᵉ ext (f x) (f y)
-injection→extensional b-set f inj ext .reflᵉ x = reflᵉ ext (f x)
-injection→extensional b-set f inj ext .idsᵉ =
-  set-identity-system
-    (λ x y → Pathᵉ-is-hlevel 1 ext b-set)
-    (λ p → inj (ext .idsᵉ .to-path p))
-
+{-
+Convenient wrapper to define an Extensional instance if we're given
+an injection 'f : A → B' into a set. It would be possible to take an
+embedding into an arbitrary type, but that hasn't come up yet. The
+relation this equips A with is "equal under f".
+-}
 injection→extensional!
   : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
   → {@(tactic hlevel-tactic-worker) sb : is-set B}
@@ -188,33 +291,9 @@ injection→extensional!
   → (∀ {x y} → f x ≡ f y → x ≡ y)
   → Extensional B ℓr
   → Extensional A ℓr
-injection→extensional! {sb = sb} {f} = injection→extensional sb f
-
-private
-  record Test : Type where
-    no-eta-equality
-    field
-      foo     : Nat
-      useless : is-equiv {A = Nat} id
-
-  open Test
-
-  t1 t2 : Test
-  t1 .foo = 2
-  t1 .useless = id-equiv
-
-  t2 .foo = 2
-  t2 .useless = id-equiv
-
-  Extensional-Test : Extensional Test lzero
-  Extensional-Test = injection→extensional! {sb = Nat-is-set} p Extensional-default where
-    p : ∀ {x y} → x .foo ≡ y .foo → x ≡ y
-    p r i .foo = r i
-    p {x} {y} _ i .useless = is-equiv-is-prop id (x .useless) (y .useless) i
-
-  instance
-    _ : Extensionality Test
-    _ = record { lemma = quote Extensional-Test }
-
-  _ : t1 ≡ t2
-  _ = trivialᵉ
+injection→extensional! {sb = b-set} {f} inj ext .Pathᵉ x y = Pathᵉ ext (f x) (f y)
+injection→extensional! {sb = b-set} {f} inj ext .reflᵉ x = reflᵉ ext (f x)
+injection→extensional! {sb = b-set} {f} inj ext .idsᵉ =
+  set-identity-system
+    (λ x y → Pathᵉ-is-hlevel 1 ext b-set)
+    (λ p → inj (ext .idsᵉ .to-path p))

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -226,6 +226,11 @@ univalence-identity-system .to-path-over p =
 
 <!--
 ```agda
+Path-identity-system
+  : ∀ {ℓ} {A : Type ℓ} → is-identity-system (Path A) (λ _ → refl)
+Path-identity-system .to-path p = p
+Path-identity-system .to-path-over p i j = p (i ∧ j)
+
 is-identity-system-is-prop
   : ∀ {ℓ ℓ'} {A : Type ℓ} {R : A → A → Type ℓ'} {r : ∀ a → R a a}
   → is-prop (is-identity-system R r)

--- a/src/1Lab/Prelude.agda
+++ b/src/1Lab/Prelude.agda
@@ -44,3 +44,4 @@ open import 1Lab.Reflection.Regularity public
 open import 1Lab.Resizing public
 
 open import 1Lab.Underlying public
+open import 1Lab.Extensionality public

--- a/src/1Lab/Reflection/Regularity.agda
+++ b/src/1Lab/Reflection/Regularity.agda
@@ -140,8 +140,8 @@ private
     `x ← quoteTC x
     `y ← quoteTC y
     `p ← quoteTC p
-    just (_ , l , r) ← unapply-path =<< inferType goal
-      where _ → typeError []
+    just (_ , l , r) ← unapply-path =<< wait-for-type =<< inferType goal
+      where _ → typeError [ "goal type is not path type: " , termErr goal ]
     l ← normalise =<< wait-for-type l
     r ← normalise =<< wait-for-type r
     reg ← to-regularity-path pre l

--- a/src/1Lab/Reflection/Subst.agda
+++ b/src/1Lab/Reflection/Subst.agda
@@ -111,3 +111,14 @@ subst-tm ρ (agda-sort s) with s
 … | propLit n = pure (agda-sort (propLit n))
 … | inf n     = pure (agda-sort (inf n))
 … | unknown   = pure unknown
+
+raiseTC : Nat → Term → TC Term
+raiseTC n tm with raise n tm
+... | just x = pure x
+... | nothing = typeError [ "Failed to raise term " , termErr tm ]
+
+applyTC : Term → Arg Term → TC Term
+applyTC f x with apply-tm f x
+applyTC f x         | just r  = pure r
+applyTC f (arg _ x) | nothing =
+  typeError [ "Failed to apply function " , termErr f , " to argument " , termErr x ]

--- a/src/1Lab/Underlying.agda
+++ b/src/1Lab/Underlying.agda
@@ -85,13 +85,8 @@ record
     -- The underlying function (infix).
     _#_ : ∀ {A B} → F A B → ⌞ A ⌟ → ⌞ B ⌟
 
-    -- -- _#_ must be an injection. Really this should ask for an
-    -- -- embedding, but the most common use-cases have F valued in sets.
-    -- ext : ∀ {A B} {f g : F A B} → (∀ x → f # x ≡ g # x) → f ≡ g
-
 open Funlike ⦃ ... ⦄ using (_#_) public
 {-# DISPLAY Funlike._#_ p f x = f # x #-}
--- {-# DISPLAY Funlike.ext p q = ext q #-}
 
 -- Sections of the _#_ operator tend to be badly-behaved since they
 -- introduce an argument x : ⌞ ?0 ⌟ whose Underlying instance meta

--- a/src/1Lab/Underlying.agda
+++ b/src/1Lab/Underlying.agda
@@ -85,13 +85,13 @@ record
     -- The underlying function (infix).
     _#_ : ∀ {A B} → F A B → ⌞ A ⌟ → ⌞ B ⌟
 
-    -- _#_ must be an injection. Really this should ask for an
-    -- embedding, but the most common use-cases have F valued in sets.
-    ext : ∀ {A B} {f g : F A B} → (∀ x → f # x ≡ g # x) → f ≡ g
+    -- -- _#_ must be an injection. Really this should ask for an
+    -- -- embedding, but the most common use-cases have F valued in sets.
+    -- ext : ∀ {A B} {f g : F A B} → (∀ x → f # x ≡ g # x) → f ≡ g
 
-open Funlike ⦃ ... ⦄ using ( _#_ ; ext ) public
+open Funlike ⦃ ... ⦄ using (_#_) public
 {-# DISPLAY Funlike._#_ p f x = f # x #-}
-{-# DISPLAY Funlike.ext p q = ext q #-}
+-- {-# DISPLAY Funlike.ext p q = ext q #-}
 
 -- Sections of the _#_ operator tend to be badly-behaved since they
 -- introduce an argument x : ⌞ ?0 ⌟ whose Underlying instance meta
@@ -117,5 +117,4 @@ instance
     → Funlike {lsuc ℓ} {lsuc ℓ'} {ℓ ⊔ ℓ'} {Type ℓ} {Type ℓ'} λ x y → x → y
   Funlike-Fun = record
     { _#_ = _$_
-    ; ext = funext
     }

--- a/src/Algebra/Group/Ab.lagda.md
+++ b/src/Algebra/Group/Ab.lagda.md
@@ -171,8 +171,8 @@ Ab↪Grp : ∀ {ℓ} → Functor (Ab ℓ) (Groups ℓ)
 Ab↪Grp .F₀ (X , A) = X , Abelian→Group-on A
 Ab↪Grp .F₁ f .hom = f .hom
 Ab↪Grp .F₁ f .preserves = f .preserves
-Ab↪Grp .F-id = trivialᵉ
-Ab↪Grp .F-∘ f g = trivialᵉ
+Ab↪Grp .F-id = trivial!
+Ab↪Grp .F-∘ f g = trivial!
 ```
 -->
 

--- a/src/Algebra/Group/Ab.lagda.md
+++ b/src/Algebra/Group/Ab.lagda.md
@@ -171,8 +171,8 @@ Ab↪Grp : ∀ {ℓ} → Functor (Ab ℓ) (Groups ℓ)
 Ab↪Grp .F₀ (X , A) = X , Abelian→Group-on A
 Ab↪Grp .F₁ f .hom = f .hom
 Ab↪Grp .F₁ f .preserves = f .preserves
-Ab↪Grp .F-id = total-hom-path _ refl refl
-Ab↪Grp .F-∘ f g = total-hom-path _ refl refl
+Ab↪Grp .F-id = trivialᵉ
+Ab↪Grp .F-∘ f g = trivialᵉ
 ```
 -->
 

--- a/src/Algebra/Group/Ab/Abelianisation.lagda.md
+++ b/src/Algebra/Group/Ab/Abelianisation.lagda.md
@@ -222,6 +222,6 @@ make-free-abelian {ℓ} = go where
         f # (a G.⋆ (c G.⋆ b))       ∎
   go .universal f .preserves .is-group-hom.pres-⋆ =
     Coeq-elim-prop₂ (λ _ _ → hlevel!) λ _ _ → f .preserves .is-group-hom.pres-⋆ _ _
-  go .commutes f = Homomorphism-path (λ _ → refl)
-  go .unique p = Homomorphism-path (Coeq-elim-prop (λ _ → hlevel!) (λ x → p #ₚ x))
+  go .commutes f = trivialᵉ
+  go .unique p = ext (Coeq-elim-prop (λ _ → hlevel!) (λ x → p #ₚ x))
 ```

--- a/src/Algebra/Group/Ab/Abelianisation.lagda.md
+++ b/src/Algebra/Group/Ab/Abelianisation.lagda.md
@@ -221,6 +221,6 @@ make-free-abelian {ℓ} = go where
         f # (a G.⋆ (c G.⋆ b))       ∎
   go .universal f .preserves .is-group-hom.pres-⋆ =
     Coeq-elim-prop₂ (λ _ _ → hlevel!) λ _ _ → f .preserves .is-group-hom.pres-⋆ _ _
-  go .commutes f = trivialᵉ
+  go .commutes f = trivial!
   go .unique p = ext (Coeq-elim-prop (λ _ → hlevel!) (λ x → p #ₚ x))
 ```

--- a/src/Algebra/Group/Ab/Abelianisation.lagda.md
+++ b/src/Algebra/Group/Ab/Abelianisation.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS --show-implicit #-}
 open import Algebra.Group.Cat.Base
 open import Algebra.Group.Ab
 open import Algebra.Group

--- a/src/Algebra/Group/Ab/Hom.lagda.md
+++ b/src/Algebra/Group/Ab/Hom.lagda.md
@@ -101,6 +101,6 @@ Ab-hom-functor .F₀ (A , B) = Ab[ A , B ]
 Ab-hom-functor .F₁ (f , g) .hom h = g Ab.∘ h Ab.∘ f
 Ab-hom-functor .F₁ (f , g) .preserves .pres-⋆ x y = ext λ z →
   g .preserves .pres-⋆ _ _
-Ab-hom-functor .F-id    = trivialᵉ
-Ab-hom-functor .F-∘ f g = trivialᵉ
+Ab-hom-functor .F-id    = trivial!
+Ab-hom-functor .F-∘ f g = trivial!
 ```

--- a/src/Algebra/Group/Ab/Hom.lagda.md
+++ b/src/Algebra/Group/Ab/Hom.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS -vtactic.extensionality:10 #-}
 open import Algebra.Group.Ab
 open import Algebra.Group
 

--- a/src/Algebra/Group/Ab/Hom.lagda.md
+++ b/src/Algebra/Group/Ab/Hom.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS -vtactic.extensionality:10 #-}
 open import Algebra.Group.Ab
 open import Algebra.Group
 
@@ -78,10 +79,10 @@ Abelian-group-on-hom A B = to-abelian-group-on make-ab-on-hom module Hom-ab wher
 
 <!--
 ```agda
-  make-ab-on-hom .idl x       = Homomorphism-path λ x → B.idl
-  make-ab-on-hom .assoc x y z = Homomorphism-path λ _ → B.associative
-  make-ab-on-hom .invl x      = Homomorphism-path λ x → B.inversel
-  make-ab-on-hom .comm x y    = Homomorphism-path λ x → B.commutes
+  make-ab-on-hom .idl x       = ext λ x → B.idl
+  make-ab-on-hom .assoc x y z = ext λ _ → B.associative
+  make-ab-on-hom .invl x      = ext λ x → B.inversel
+  make-ab-on-hom .comm x y    = ext λ x → B.commutes
 
 open Functor
 
@@ -99,8 +100,8 @@ $\Ab\op \times \Ab \to \Ab$.
 Ab-hom-functor : ∀ {ℓ} → Functor (Ab ℓ ^op ×ᶜ Ab ℓ) (Ab ℓ)
 Ab-hom-functor .F₀ (A , B) = Ab[ A , B ]
 Ab-hom-functor .F₁ (f , g) .hom h = g Ab.∘ h Ab.∘ f
-Ab-hom-functor .F₁ (f , g) .preserves .pres-⋆ x y = Homomorphism-path λ z →
+Ab-hom-functor .F₁ (f , g) .preserves .pres-⋆ x y = ext λ z →
   g .preserves .pres-⋆ _ _
-Ab-hom-functor .F-id    = Homomorphism-path λ _ → Homomorphism-path λ x → refl
-Ab-hom-functor .F-∘ f g = Homomorphism-path λ _ → Homomorphism-path λ x → refl
+Ab-hom-functor .F-id    = trivialᵉ
+Ab-hom-functor .F-∘ f g = trivialᵉ
 ```

--- a/src/Algebra/Group/Ab/Sum.lagda.md
+++ b/src/Algebra/Group/Ab/Sum.lagda.md
@@ -83,8 +83,7 @@ limits][rapl]).
   Direct-sum-is-product .⟨_,_⟩ f g .preserves .pres-⋆ x y =
     Σ-pathp (f .preserves .pres-⋆ x y) (g .preserves .pres-⋆ x y)
 
-  Direct-sum-is-product .π₁∘factor = Homomorphism-path λ _ → refl
-  Direct-sum-is-product .π₂∘factor = Homomorphism-path λ _ → refl
-  Direct-sum-is-product .unique other p q = Homomorphism-path λ x →
-    Σ-pathp (p #ₚ x) (q #ₚ x)
+  Direct-sum-is-product .π₁∘factor = trivialᵉ
+  Direct-sum-is-product .π₂∘factor = trivialᵉ
+  Direct-sum-is-product .unique other p q = ext λ x → p #ₚ x , q #ₚ x
 ```

--- a/src/Algebra/Group/Ab/Sum.lagda.md
+++ b/src/Algebra/Group/Ab/Sum.lagda.md
@@ -83,7 +83,7 @@ limits][rapl]).
   Direct-sum-is-product .⟨_,_⟩ f g .preserves .pres-⋆ x y =
     Σ-pathp (f .preserves .pres-⋆ x y) (g .preserves .pres-⋆ x y)
 
-  Direct-sum-is-product .π₁∘factor = trivialᵉ
-  Direct-sum-is-product .π₂∘factor = trivialᵉ
+  Direct-sum-is-product .π₁∘factor = trivial!
+  Direct-sum-is-product .π₂∘factor = trivial!
   Direct-sum-is-product .unique other p q = ext λ x → p #ₚ x , q #ₚ x
 ```

--- a/src/Algebra/Group/Ab/Tensor.lagda.md
+++ b/src/Algebra/Group/Ab/Tensor.lagda.md
@@ -116,7 +116,7 @@ homomorphisms $A \to [B,C]$.
     morp .is-iso.inv uc .Bilinear.map x y = uc # x # y
     morp .is-iso.inv uc .Bilinear.pres-*l x y z = ap (_# _) (uc .preserves .is-group-hom.pres-⋆ _ _)
     morp .is-iso.inv uc .Bilinear.pres-*r x y z = (uc # _) .preserves .is-group-hom.pres-⋆ _ _
-    morp .is-iso.rinv uc = Homomorphism-path λ x → Homomorphism-path λ y → refl
+    morp .is-iso.rinv uc = trivialᵉ
     morp .is-iso.linv uc = Bilinear-path λ x y → refl
 ```
 
@@ -345,5 +345,5 @@ Tensor⊣Hom A = hom-iso→adjoints to to-eqv nat where
     (curry-bilinear-is-equiv _ _ _)
 
   nat : hom-iso-natural {L = Bifunctor.Left Ab-tensor-functor A} {R = Bifunctor.Right Ab-hom-functor A} to
-  nat f g h = Homomorphism-path λ x → Homomorphism-path λ y → refl
+  nat f g h = trivialᵉ
 ```

--- a/src/Algebra/Group/Ab/Tensor.lagda.md
+++ b/src/Algebra/Group/Ab/Tensor.lagda.md
@@ -116,7 +116,7 @@ homomorphisms $A \to [B,C]$.
     morp .is-iso.inv uc .Bilinear.map x y = uc # x # y
     morp .is-iso.inv uc .Bilinear.pres-*l x y z = ap (_# _) (uc .preserves .is-group-hom.pres-⋆ _ _)
     morp .is-iso.inv uc .Bilinear.pres-*r x y z = (uc # _) .preserves .is-group-hom.pres-⋆ _ _
-    morp .is-iso.rinv uc = trivialᵉ
+    morp .is-iso.rinv uc = trivial!
     morp .is-iso.linv uc = Bilinear-path λ x y → refl
 ```
 
@@ -345,5 +345,5 @@ Tensor⊣Hom A = hom-iso→adjoints to to-eqv nat where
     (curry-bilinear-is-equiv _ _ _)
 
   nat : hom-iso-natural {L = Bifunctor.Left Ab-tensor-functor A} {R = Bifunctor.Right Ab-hom-functor A} to
-  nat f g h = trivialᵉ
+  nat f g h = trivial!
 ```

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -75,7 +75,7 @@ Zero-group-is-initial (_ , G) .paths x =
 Zero-group-is-terminal : is-terminal Zero-group
 Zero-group-is-terminal _ .centre =
   total-hom (λ _ → lift tt) record { pres-⋆ = λ _ _ _ → lift tt }
-Zero-group-is-terminal _ .paths x = trivialᵉ
+Zero-group-is-terminal _ .paths x = trivial!
 
 Zero-group-is-zero : is-zero Zero-group
 Zero-group-is-zero = record

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -70,12 +70,12 @@ Zero-group-is-initial (_ , G) .centre = total-hom (λ x → G.unit) gh where
     G.unit            ≡˘⟨ G.idl ⟩
     G.unit G.⋆ G.unit ∎
 Zero-group-is-initial (_ , G) .paths x =
-  Homomorphism-path λ _ → sym (is-group-hom.pres-id (x .preserves))
+  ext λ _ → sym (is-group-hom.pres-id (x .preserves))
 
 Zero-group-is-terminal : is-terminal Zero-group
 Zero-group-is-terminal _ .centre =
   total-hom (λ _ → lift tt) record { pres-⋆ = λ _ _ _ → lift tt }
-Zero-group-is-terminal _ .paths x = Homomorphism-path λ _ → refl
+Zero-group-is-terminal _ .paths x = trivialᵉ
 
 Zero-group-is-zero : is-zero Zero-group
 Zero-group-is-zero = record

--- a/src/Algebra/Group/Concrete.lagda.md
+++ b/src/Algebra/Group/Concrete.lagda.md
@@ -227,8 +227,8 @@ functorial:
   (sym ptf ·· ap f x ∙ ap f y ·· ptf)                     ≡˘⟨ ··-chain ⟩
   (sym ptf ·· ap f x ·· ptf) ∙ (sym ptf ·· ap f y ·· ptf) ∎
 
-Π₁ .F-id = Homomorphism-path λ _ → sym (··-filler _ _ _)
-Π₁ .F-∘ (f , ptf) (g , ptg) = Homomorphism-path λ x →
+Π₁ .F-id = ext λ _ → sym (··-filler _ _ _)
+Π₁ .F-∘ (f , ptf) (g , ptg) = ext λ x →
   (sym (ap f ptg ∙ ptf) ·· ap (f ⊙ g) x ·· (ap f ptg ∙ ptf))         ≡˘⟨ ··-stack ⟩
   (sym ptf ·· ⌜ ap f (sym ptg) ·· ap (f ⊙ g) x ·· ap f ptg ⌝ ·· ptf) ≡˘⟨ ap¡ (ap-·· f _ _ _) ⟩
   (sym ptf ·· ap f (sym ptg ·· ap g x ·· ptg) ·· ptf)                ∎
@@ -342,7 +342,7 @@ right inverse to $\Pi_1$:
     f # ω ∙ p refl         ∎
 
   rinv : Π₁ .F₁ g ≡ f
-  rinv = Homomorphism-path λ ω → sym (··-unique' (symP (f≡apg ω)))
+  rinv = ext λ ω → sym (··-unique' (symP (f≡apg ω)))
 ```
 
 We are most of the way there. In order to get a proper equivalence, we must check that

--- a/src/Algebra/Group/Free.lagda.md
+++ b/src/Algebra/Group/Free.lagda.md
@@ -191,7 +191,7 @@ make-free-group .Ml.unit _ = inc
 make-free-group .Ml.universal f = fold-free-group f
 make-free-group .Ml.commutes f = refl
 make-free-group .Ml.unique {y = y} {g = g} p =
-  Homomorphism-path $ Free-elim-prop _ (λ _ → hlevel!)
+  ext $ Free-elim-prop _ (λ _ → hlevel!)
     (p $ₚ_)
     (λ a b p q → ap₂ y._⋆_ p q ∙ sym (g .preserves .is-group-hom.pres-⋆ _ _))
     (λ a p → ap y.inverse p ∙ sym (is-group-hom.pres-inv (g .preserves)))

--- a/src/Algebra/Group/Subgroup.lagda.md
+++ b/src/Algebra/Group/Subgroup.lagda.md
@@ -580,8 +580,8 @@ predicate $\rm{inc}(x) = \rm{inc}(0)$ recovers the subgroup $H$; And
     from .hom (x , p) = x , quot (subst (_∈ H) (sym idr ∙ ap (_ ⋆_) (sym inv-unit)) p)
     from .preserves .is-group-hom.pres-⋆ _ _ = Σ-prop-path (λ _ → squash _ _) refl
 
-    il = Homomorphism-path λ x → Σ-prop-path (λ _ → H _ .is-tr) refl
-    ir = Homomorphism-path λ x → Σ-prop-path (λ _ → squash _ _) refl
+    il = ext λ x → Σ-prop-path (λ _ → H _ .is-tr) refl
+    ir = ext λ x → Σ-prop-path (λ _ → squash _ _) refl
 ```
 
 To show that these are equal as subgroups of $G$, we must show that the

--- a/src/Algebra/Magma.lagda.md
+++ b/src/Algebra/Magma.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS --show-implicit #-}
 open import 1Lab.Prelude
 ```
 -->

--- a/src/Algebra/Monoid/Category.lagda.md
+++ b/src/Algebra/Monoid/Category.lagda.md
@@ -263,10 +263,10 @@ properties of the underlying map.
 
 ```agda
     from∘to : is-right-inverse from comparison.₁
-    from∘to x = trivialᵉ
+    from∘to x = trivial!
 
     to∘from : is-left-inverse from comparison.₁
-    to∘from x = trivialᵉ
+    to∘from x = trivial!
 ```
 
 Showing that the functor is essentially surjective is significantly more

--- a/src/Algebra/Monoid/Category.lagda.md
+++ b/src/Algebra/Monoid/Category.lagda.md
@@ -145,8 +145,8 @@ concatenation, identity and composition by induction on the list.
 
 ```agda
 Free .F₁ f = total-hom (map f) record { pres-id = refl ; pres-⋆  = map-++ f }
-Free .F-id = Homomorphism-path map-id
-Free .F-∘ f g = Homomorphism-path map-∘ where
+Free .F-id = ext map-id
+Free .F-∘ f g = ext map-∘ where
   map-∘ : ∀ xs → map (λ x → f (g x)) xs ≡ map f (map g xs)
   map-∘ [] = refl
   map-∘ (x ∷ xs) = ap (f (g x) ∷_) (map-∘ xs)
@@ -209,9 +209,9 @@ Free⊣Forget .unit .η _ x = x ∷ []
 Free⊣Forget .unit .is-natural x y f = refl
 Free⊣Forget .counit .η M = total-hom (fold _) record { pres-id = refl ; pres-⋆ = fold-++ }
 Free⊣Forget .counit .is-natural x y th =
-  Homomorphism-path $ fold-natural (th .hom) (th .preserves)
+  ext $ fold-natural (th .hom) (th .preserves)
 Free⊣Forget .zig {A = A} =
-  Homomorphism-path $ fold-pure {X = A}
+  ext $ fold-pure {X = A}
 Free⊣Forget .zag {B = B} i x = B .snd .idr {x = x} i
 ```
 
@@ -263,10 +263,10 @@ properties of the underlying map.
 
 ```agda
     from∘to : is-right-inverse from comparison.₁
-    from∘to x = Algebra-hom-path _ refl
+    from∘to x = trivialᵉ
 
     to∘from : is-left-inverse from comparison.₁
-    to∘from x = Homomorphism-path λ _ → refl
+    to∘from x = trivialᵉ
 ```
 
 Showing that the functor is essentially surjective is significantly more

--- a/src/Algebra/Ring/Module/Action.lagda.md
+++ b/src/Algebra/Ring/Module/Action.lagda.md
@@ -109,6 +109,6 @@ and ring morphisms $R \to [G,G]$ into the [endomorphism ring] of $G$.
     : (G : Abelian-group ℓ)
     → Ring-action (G .snd) ≃ Rings.Hom R (Endo Ab-ab-category G)
   Action≃Hom G = Iso→Equiv $ Action→Hom G , iso (Hom→Action G)
-    (λ x → Homomorphism-path λ _ → refl)
+    (λ x → trivialᵉ)
     (λ x → refl)
 ```

--- a/src/Algebra/Ring/Module/Action.lagda.md
+++ b/src/Algebra/Ring/Module/Action.lagda.md
@@ -109,6 +109,6 @@ and ring morphisms $R \to [G,G]$ into the [endomorphism ring] of $G$.
     : (G : Abelian-group ℓ)
     → Ring-action (G .snd) ≃ Rings.Hom R (Endo Ab-ab-category G)
   Action≃Hom G = Iso→Equiv $ Action→Hom G , iso (Hom→Action G)
-    (λ x → trivialᵉ)
+    (λ x → trivial!)
     (λ x → refl)
 ```

--- a/src/Algebra/Ring/Module/Category.lagda.md
+++ b/src/Algebra/Ring/Module/Category.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS -vtactic.extensionality:10 --show-implicit #-}
 open import Algebra.Ring.Module.Notation
 open import Algebra.Ring.Module.Action
 open import Algebra.Ring.Commutative

--- a/src/Algebra/Ring/Module/Category.lagda.md
+++ b/src/Algebra/Ring/Module/Category.lagda.md
@@ -180,7 +180,7 @@ R-Mod-ab-category .Abelian-group-on-hom A B = to-abelian-group-on grp where
   grp .invl f      = Homomorphism-path λ x → +-invl
   grp .comm f g    = Homomorphism-path λ x → +-comm _ _
 
-R-Mod-ab-category .∘-linear-l f g h = trivialᵉ
+R-Mod-ab-category .∘-linear-l f g h = trivial!
 R-Mod-ab-category .∘-linear-r {B = B} {C} f g h = Homomorphism-path λ x → sym (is-linear-map.pres-+ (f .preserves) _ _)
 ```
 -->
@@ -263,8 +263,8 @@ path-mangling, but it's nothing _too_ bad:
   prod .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
   prod .has-is-product .⟨_,_⟩ f g .preserves .linear r m s =
     Σ-pathp (f .preserves .linear _ _ _) (g .preserves .linear _ _ _)
-  prod .has-is-product .π₁∘factor = trivialᵉ
-  prod .has-is-product .π₂∘factor = trivialᵉ
+  prod .has-is-product .π₁∘factor = trivial!
+  prod .has-is-product .π₂∘factor = trivial!
   prod .has-is-product .unique other p q = ext λ x → p #ₚ x , q #ₚ x
 ```
 

--- a/src/Algebra/Ring/Module/Category.lagda.md
+++ b/src/Algebra/Ring/Module/Category.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS -vtactic.extensionality:10 --show-implicit #-}
 open import Algebra.Ring.Module.Notation
 open import Algebra.Ring.Module.Action
 open import Algebra.Ring.Commutative
@@ -12,6 +13,7 @@ open import Algebra.Ring
 open import Cat.Displayed.Univalence.Thin
 open import Cat.Abelian.Instances.Ab
 open import Cat.Diagram.Terminal
+open import Cat.Diagram.Product
 open import Cat.Abelian.Base
 open import Cat.Prelude hiding (_+_ ; _*_)
 ```
@@ -24,8 +26,8 @@ module Algebra.Ring.Module.Category {ℓ} (R : Ring ℓ) where
 <!--
 ```agda
 private module R = Ring-on (R .snd)
-open Ab-category hiding (_+_ ; Terminal)
-open is-additive hiding (_+_ ; Terminal)
+open Ab-category hiding (_+_ ; Terminal ; Product ; is-product)
+open is-additive hiding (_+_ ; Terminal ; Product ; is-product)
 open make-abelian-group
 open Total-hom
 
@@ -179,7 +181,7 @@ R-Mod-ab-category .Abelian-group-on-hom A B = to-abelian-group-on grp where
   grp .invl f      = Homomorphism-path λ x → +-invl
   grp .comm f g    = Homomorphism-path λ x → +-comm _ _
 
-R-Mod-ab-category .∘-linear-l f g h = Homomorphism-path λ x → refl
+R-Mod-ab-category .∘-linear-l f g h = trivialᵉ
 R-Mod-ab-category .∘-linear-r {B = B} {C} f g h = Homomorphism-path λ x → sym (is-linear-map.pres-+ (f .preserves) _ _)
 ```
 -->
@@ -197,7 +199,7 @@ The zero object is simple, because the unit type is so well-behaved^[and
 constantly the unit, including the paths, which are _all_ reflexivity.
 
 ```agda
-R-Mod-is-additive : is-additive (R-Mod R _)
+R-Mod-is-additive : ∀ {ℓ} → is-additive (R-Mod R ℓ)
 R-Mod-is-additive .has-ab = R-Mod-ab-category
 R-Mod-is-additive .has-terminal = term where
   act : Ring-action R _
@@ -250,10 +252,10 @@ Proving that this cone is actually universal involves a bit of
 path-mangling, but it's nothing _too_ bad:
 
 ```agda
-  open Ab-category.Product
-  open Ab-category.is-product
+  open Product
+  open is-product
 
-  prod : Ab-category.Product R-Mod-ab-category M N
+  prod : Product (R-Mod _ _) M N
   prod .apex = M⊕ᵣN
   prod .π₁ .hom = fst
   prod .π₁ .preserves .linear r s t = refl
@@ -262,10 +264,9 @@ path-mangling, but it's nothing _too_ bad:
   prod .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
   prod .has-is-product .⟨_,_⟩ f g .preserves .linear r m s =
     Σ-pathp (f .preserves .linear _ _ _) (g .preserves .linear _ _ _)
-  prod .has-is-product .π₁∘factor = Homomorphism-path λ _ → refl
-  prod .has-is-product .π₂∘factor = Homomorphism-path λ _ → refl
-  prod .has-is-product .unique other p q = Homomorphism-path {ℓ = lzero} λ x →
-    Σ-pathp (ap hom p $ₚ x) (ap hom q $ₚ x)
+  prod .has-is-product .π₁∘factor = trivialᵉ
+  prod .has-is-product .π₂∘factor = trivialᵉ
+  prod .has-is-product .unique other p q = ext λ x → p #ₚ x , q #ₚ x
 ```
 
 <!-- TODO [Amy 2022-09-15]

--- a/src/Algebra/Ring/Module/Vec.lagda.md
+++ b/src/Algebra/Ring/Module/Vec.lagda.md
@@ -117,7 +117,7 @@ Fin-vec-is-product {n} .has-is-ip .tuple {Y} f = assemble where
   assemble : R-Mod.Hom Y (Fin-vec-module n)
   assemble .hom yob ix = f ix # yob
   assemble .preserves .linear r m n = funext λ i → f i .preserves .linear _ _ _
-Fin-vec-is-product .has-is-ip .commute = trivialᵉ
+Fin-vec-is-product .has-is-ip .commute = trivial!
 Fin-vec-is-product .has-is-ip .unique {h = h} f ps =
   ext λ i ix → ap hom (ps ix) $ₚ i
 ```

--- a/src/Algebra/Ring/Module/Vec.lagda.md
+++ b/src/Algebra/Ring/Module/Vec.lagda.md
@@ -117,7 +117,7 @@ Fin-vec-is-product {n} .has-is-ip .tuple {Y} f = assemble where
   assemble : R-Mod.Hom Y (Fin-vec-module n)
   assemble .hom yob ix = f ix # yob
   assemble .preserves .linear r m n = funext λ i → f i .preserves .linear _ _ _
-Fin-vec-is-product .has-is-ip .commute = Homomorphism-path λ _ → refl
+Fin-vec-is-product .has-is-ip .commute = trivialᵉ
 Fin-vec-is-product .has-is-ip .unique {h = h} f ps =
-  Homomorphism-path λ i → funext λ ix → ap hom (ps ix) $ₚ i
+  ext λ i ix → ap hom (ps ix) $ₚ i
 ```

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -448,7 +448,7 @@ $\cA$, thus assemble into an isomorphism in the slice.
     mono→kernel : cut f m.≅ cut (Ker.kernel (Coker.coeq f))
     mono→kernel = m.make-iso f→kercoker kercoker→f f→kc→f kc→f→kc where
       f→kc→f : f→kercoker m.∘ kercoker→f ≡ m.id
-      f→kc→f = /-Hom-path $
+      f→kc→f = ext $
         (decompose f .fst ∘ Coker.coeq _) ∘ Coker.universal _ _ ∘ _  ≡⟨ cancel-inner lemma ⟩
         decompose f .fst ∘ _                                         ≡⟨ coker-ker≃ker-coker f .is-invertible.invl ⟩
         id                                                           ∎
@@ -460,8 +460,8 @@ $\cA$, thus assemble into an isomorphism in the slice.
             (eliml refl)
 
       kc→f→kc : kercoker→f m.∘ f→kercoker ≡ m.id
-      kc→f→kc = /-Hom-path $
+      kc→f→kc = ext $
         (Coker.universal _ _ ∘ _) ∘ decompose f .fst ∘ Coker.coeq _ ≡⟨ cancel-inner (coker-ker≃ker-coker f .is-invertible.invr) ⟩
         Coker.universal _ _ ∘ Coker.coeq _                          ≡⟨ Coker.factors _ ⟩
-        id                                                           ∎
+        id                                                          ∎
 ```

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -171,7 +171,7 @@ module _ where
   open Ab-category
   Ab-ab-category : ∀ {ℓ} → Ab-category (Ab ℓ)
   Ab-ab-category .Abelian-group-on-hom A B = Ab.Abelian-group-on-hom A B
-  Ab-ab-category .∘-linear-l f g h = Homomorphism-path (λ _ → refl)
+  Ab-ab-category .∘-linear-l f g h = trivialᵉ
   Ab-ab-category .∘-linear-r f g h =
     Homomorphism-path (λ _ → sym (f .preserves .is-group-hom.pres-⋆ _ _))
 ```

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -171,7 +171,7 @@ module _ where
   open Ab-category
   Ab-ab-category : ∀ {ℓ} → Ab-category (Ab ℓ)
   Ab-ab-category .Abelian-group-on-hom A B = Ab.Abelian-group-on-hom A B
-  Ab-ab-category .∘-linear-l f g h = trivialᵉ
+  Ab-ab-category .∘-linear-l f g h = trivial!
   Ab-ab-category .∘-linear-r f g h =
     Homomorphism-path (λ _ → sym (f .preserves .is-group-hom.pres-⋆ _ _))
 ```

--- a/src/Cat/Abelian/Instances/Ab.lagda.md
+++ b/src/Cat/Abelian/Instances/Ab.lagda.md
@@ -48,7 +48,7 @@ Ab-is-additive .has-ab = Ab-ab-category
 Ab-is-additive .has-terminal .top = from-commutative-group (Zero-group {ℓ}) (λ x y → refl)
 Ab-is-additive .has-terminal .has⊤ x =
   contr (total-hom (λ _ → lift tt) (record { pres-⋆ = λ x y i → lift tt }))
-    λ x → trivialᵉ
+    λ x → trivial!
 
 Ab-is-additive .has-prods A B .Product.apex = A ⊕ B
 Ab-is-additive .has-prods A B .Product.π₁ = _

--- a/src/Cat/Abelian/Instances/Ab.lagda.md
+++ b/src/Cat/Abelian/Instances/Ab.lagda.md
@@ -48,7 +48,7 @@ Ab-is-additive .has-ab = Ab-ab-category
 Ab-is-additive .has-terminal .top = from-commutative-group (Zero-group {ℓ}) (λ x y → refl)
 Ab-is-additive .has-terminal .has⊤ x =
   contr (total-hom (λ _ → lift tt) (record { pres-⋆ = λ x y i → lift tt }))
-    λ x → Homomorphism-path λ _ → refl
+    λ x → trivialᵉ
 
 Ab-is-additive .has-prods A B .Product.apex = A ⊕ B
 Ab-is-additive .has-prods A B .Product.π₁ = _

--- a/src/Cat/Allegory/Base.lagda.md
+++ b/src/Cat/Allegory/Base.lagda.md
@@ -219,8 +219,8 @@ to show $R(x, y)$! Fortunately if we we set $\Id(x, a)$, then $R(x,
 y) \simeq R(a, y)$, and we're done.
 
 ```agda
-Rel ℓ .cat .idr {A} {B} R = funext λ x → funext λ y → Ω-ua
-  (□-rec! (λ { (a , b , w) → subst (λ e → ∣ R e y ∣)  (sym (out! b)) w }))
+Rel ℓ .cat .idr {A} {B} R = ext λ x y → Ω-ua
+  (□-rec! (λ { (a , b , w) → subst (λ e → ∣ R e y ∣) (sym (out! b)) w }))
   λ w → inc (x , inc refl , w)
 ```
 
@@ -251,11 +251,11 @@ automatic proof search: that speaks to how contentful it is.</summary>
 
 ```agda
 Rel ℓ .cat .Hom-set x y = hlevel 2
-Rel ℓ .cat .idl R = funext λ x → funext λ y → Ω-ua
+Rel ℓ .cat .idl R = ext λ x y → Ω-ua
   (□-rec! (λ { (a , b , w) → subst (λ e → ∣ R x e ∣) (out! w) b }))
   λ w → inc (y , w , inc refl)
 
-Rel ℓ .cat .assoc T S R = funext λ x → funext λ y → Ω-ua
+Rel ℓ .cat .assoc T S R = ext λ x y → Ω-ua
   (□-rec! λ { (a , b , w) → □-rec! (λ { (c , d , x) →
     inc (c , d , inc (a , x , w)) }) b })
   (□-rec! λ { (a , b , w) → □-rec! (λ { (c , d , x) →
@@ -264,13 +264,13 @@ Rel ℓ .cat .assoc T S R = funext λ x → funext λ y → Ω-ua
 Rel ℓ .≤-thin = hlevel!
 Rel ℓ .≤-refl x y w = w
 Rel ℓ .≤-trans x y p q z = y p q (x p q z)
-Rel ℓ .≤-antisym p q = funext λ x → funext λ y → Ω-ua (p x y) (q x y)
+Rel ℓ .≤-antisym p q = ext λ x y → Ω-ua (p x y) (q x y)
 
 Rel ℓ ._◆_ f g a b = □-map (λ { (x , y , w) → x , g a x y , f x b w })
 
 -- This is nice:
 Rel ℓ .dual R = refl
-Rel ℓ .dual-∘ = funext λ x → funext λ y → Ω-ua
+Rel ℓ .dual-∘ = ext λ x y → Ω-ua
   (□-map λ { (a , b , c) → a , c , b })
   (□-map λ { (a , b , c) → a , c , b })
 Rel ℓ .dual-≤ f≤g x y w = f≤g y x w

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -1,8 +1,10 @@
 <!--
 ```agda
+open import 1Lab.Path.IdentitySystem
 open import 1Lab.Reflection.Record
 open import 1Lab.HLevel.Retracts
 open import 1Lab.HLevel.Universe
+open import 1Lab.Extensionality
 open import 1Lab.Rewrite
 open import 1Lab.HLevel
 open import 1Lab.Equiv
@@ -575,3 +577,35 @@ is a proposition:
 
   infixl 45 _ηₚ_
 ```
+
+<!--
+```agda
+open Precategory
+open _=>_
+
+Extensional-natural-transformation
+  : ∀ {o ℓ o' ℓ' ℓr} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
+  → {F G : Functor C D}
+  → {@(tactic extensionalᶠ {A = Precategory.Ob C → Type _}
+        (λ x → D .Hom (F .Functor.F₀ x) (G .Functor.F₀ x)))
+      sa : ∀ x → Extensional (D .Hom (F .Functor.F₀ x) (G .Functor.F₀ x)) ℓr}
+  → Extensional (F => G) (o ⊔ ℓr)
+Extensional-natural-transformation {sa = sa} .Pathᵉ f g = ∀ i → Pathᵉ (sa i) (f .η i) (g .η i)
+Extensional-natural-transformation {sa = sa} .reflᵉ x i = reflᵉ (sa i) (x .η i)
+Extensional-natural-transformation {sa = sa} .idsᵉ .to-path x = Nat-path λ i →
+  sa _ .idsᵉ .to-path (x i)
+Extensional-natural-transformation {D = D} {sa = sa} .idsᵉ .to-path-over h =
+  is-prop→pathp
+    (λ i → Π-is-hlevel 1
+      (λ _ → is-hlevel≃ 1 (identity-system-gives-path (sa _ .idsᵉ)) (D .Hom-set _ _ _ _)))
+    _ _
+
+instance
+  extensionality-natural-transformation
+    : ∀ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
+        {F G : Functor C D}
+    → Extensionality (F => G)
+  extensionality-natural-transformation = record
+    { lemma = quote Extensional-natural-transformation }
+```
+-->

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -583,6 +583,22 @@ is a proposition:
 open Precategory
 open _=>_
 
+{-
+Set-up for using natural transformations with the extensionality tactic;
+See the docs in 1Lab.Extensionality for a more detailed explanation of
+how it works.
+
+This function is the actual worker which computes the preferred
+identity system for natural transformations. Its type asks for
+
+   ∀ x → Extensional (D.Hom (F # x) (G # x))
+
+instead of the more generic ∀ x y → Extensional (D.Hom x y) so that
+any specific *instances* for D.Hom involving the object parts of F and G
+have a chance to fire. E.g. if G is the product functor on Sets then
+(x → y) will only match the funext instance but (x → G # y) will
+match funext *and* product extensionality.
+-}
 Extensional-natural-transformation
   : ∀ {o ℓ o' ℓ' ℓr} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
   → {F G : Functor C D}
@@ -599,6 +615,10 @@ Extensional-natural-transformation {D = D} {sa = sa} .idsᵉ .to-path-over h =
     (λ i → Π-is-hlevel 1
       (λ _ → is-hlevel≃ 1 (identity-system-gives-path (sa _ .idsᵉ)) (D .Hom-set _ _ _ _)))
     _ _
+
+-- Actually define the loop-breaker instance which tells the
+-- extensionality tactic what lemma to use for a type of natural
+-- transformations.
 
 instance
   extensionality-natural-transformation

--- a/src/Cat/CartesianClosed/Instances/PSh.agda
+++ b/src/Cat/CartesianClosed/Instances/PSh.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS -vtc.decl:5 #-}
 open import Cat.Instances.Functor.Limits
 open import Cat.Instances.Sets.Complete
 open import Cat.Diagram.Everything
@@ -10,6 +11,7 @@ open import Cat.Prelude
 
 open import Data.Sum
 
+import Cat.Functor.Bifunctor as Bifunctor
 import Cat.Reasoning
 
 module Cat.CartesianClosed.Instances.PSh where
@@ -195,9 +197,9 @@ module _ {κ} {C : Precategory κ κ} where
         F .F₁ f nt .η i (g , x) = nt .η i (f C.∘ g , x)
         F .F₁ f nt .is-natural x y g = funext λ o →
           ap (nt .η y) (Σ-pathp (C.assoc _ _ _) refl) ∙ happly (nt .is-natural _ _ _) _
-        F .F-id = funext λ f → Nat-path $ λ i → funext $ λ (g , x) →
+        F .F-id = ext λ f i (g , x) →
           ap (f .η i) (Σ-pathp (C.idl _) refl)
-        F .F-∘ f g = funext λ h → Nat-path $ λ i → funext $ λ (j , x) →
+        F .F-∘ f g = ext λ h i (j , x) →
           ap (h .η i) (Σ-pathp (sym (C.assoc _ _ _)) refl)
 
       func : Functor (PSh κ C) (PSh κ C)
@@ -209,7 +211,7 @@ module _ {κ} {C : Precategory κ κ} where
       func .F-id = trivialᵉ
       func .F-∘ f g = trivialᵉ
 
-      adj : _ ⊣ func
+      adj : Bifunctor.Left ×-functor A ⊣ func
       adj .unit .η x .η i a =
         NT (λ j (h , b) → x .F₁ h a , b) λ _ _ _ →
           funext λ _ → Σ-pathp (happly (x .F-∘ _ _) _) refl
@@ -221,9 +223,8 @@ module _ {κ} {C : Precategory κ κ} where
         ap (h .fst .η _) (Σ-pathp C.id-comm refl) ∙ happly (h .fst .is-natural _ _ _) _
       adj .counit .is-natural x y f = Nat-path λ x → refl
       adj .zig {A} = ext λ x _ → happly (F-id A) _ , refl
-      adj .zag {A} = Nat-path λ f → funext λ x → Nat-path λ g → funext λ y →
-        ap (x .η _) (Σ-pathp (C.idr _) refl)
+      adj .zag {A} = ext λ _ x i (f , g) j → x .η i (C.idr f j , g)
 
-    cc : Cartesian-closed _ (PSh-products {C = C}) (PSh-terminal {C = C})
+    cc : Cartesian-closed (PSh κ C) (PSh-products {C = C}) (PSh-terminal {C = C})
     cc = product-adjoint→cartesian-closed (PSh κ C)
       (PSh-products {C = C}) (PSh-terminal {C = C}) func adj

--- a/src/Cat/CartesianClosed/Instances/PSh.agda
+++ b/src/Cat/CartesianClosed/Instances/PSh.agda
@@ -82,8 +82,8 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     pb .has-is-pb .universal path .η idx arg = _ , _ , (path ηₚ idx $ₚ arg)
     pb .has-is-pb .universal {p₁' = p₁'} {p₂'} path .is-natural x y f =
       funext λ x → pb-path (happly (p₁' .is-natural _ _ _) _) (happly (p₂' .is-natural _ _ _) _)
-    pb .has-is-pb .p₁∘universal = trivialᵉ
-    pb .has-is-pb .p₂∘universal = trivialᵉ
+    pb .has-is-pb .p₁∘universal = trivial!
+    pb .has-is-pb .p₂∘universal = trivial!
     pb .has-is-pb .unique p q = Nat-path λ _ → funext λ _ →
       pb-path (p ηₚ _ $ₚ _) (q ηₚ _ $ₚ _)
 
@@ -104,8 +104,8 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     prod .has-is-product .⟨_,_⟩ f g =
       NT (λ i x → f .η i x , g .η i x) λ x y h i a →
         f .is-natural x y h i a , g .is-natural x y h i a
-    prod .has-is-product .π₁∘factor = trivialᵉ
-    prod .has-is-product .π₂∘factor = trivialᵉ
+    prod .has-is-product .π₁∘factor = trivial!
+    prod .has-is-product .π₂∘factor = trivial!
     prod .has-is-product .unique h p q = Nat-path (λ i j y → p j .η i y , q j .η i y)
 
   {-# TERMINATING #-}
@@ -135,8 +135,8 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     coprod .has-is-coproduct .is-coproduct.[_,_] f g .is-natural x y h = funext λ where
       (inl x) → f .is-natural _ _ _ $ₚ _
       (inr x) → g .is-natural _ _ _ $ₚ _
-    coprod .has-is-coproduct .in₀∘factor = trivialᵉ
-    coprod .has-is-coproduct .in₁∘factor = trivialᵉ
+    coprod .has-is-coproduct .in₀∘factor = trivial!
+    coprod .has-is-coproduct .in₁∘factor = trivial!
     coprod .has-is-coproduct .unique other p q = ext λ where
       a (inl x) → p ηₚ a $ₚ x
       a (inr x) → q ηₚ a $ₚ x
@@ -207,9 +207,9 @@ module _ {κ} {C : Precategory κ κ} where
       func .F₁ f .η i g .η j (h , x) = f .η _ (g .η _ (h , x))
       func .F₁ f .η i g .is-natural x y h = funext λ x →
         ap (f .η _) (happly (g .is-natural _ _ _) _) ∙ happly (f .is-natural _ _ _) _
-      func .F₁ nt .is-natural x y f = trivialᵉ
-      func .F-id = trivialᵉ
-      func .F-∘ f g = trivialᵉ
+      func .F₁ nt .is-natural x y f = trivial!
+      func .F-id = trivial!
+      func .F-∘ f g = trivial!
 
       adj : Bifunctor.Left ×-functor A ⊣ func
       adj .unit .η x .η i a =

--- a/src/Cat/CartesianClosed/Instances/PSh.agda
+++ b/src/Cat/CartesianClosed/Instances/PSh.agda
@@ -76,12 +76,12 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     pb .p₁ .is-natural _ _ _ = refl
     pb .p₂ .η x (a , b , _) = b
     pb .p₂ .is-natural _ _ _ = refl
-    pb .has-is-pb .square = Nat-path λ _ → funext λ (_ , _ , p) → p
+    pb .has-is-pb .square = ext λ _ (_ , _ , p) → p
     pb .has-is-pb .universal path .η idx arg = _ , _ , (path ηₚ idx $ₚ arg)
     pb .has-is-pb .universal {p₁' = p₁'} {p₂'} path .is-natural x y f =
       funext λ x → pb-path (happly (p₁' .is-natural _ _ _) _) (happly (p₂' .is-natural _ _ _) _)
-    pb .has-is-pb .p₁∘universal = Nat-path λ _ → refl
-    pb .has-is-pb .p₂∘universal = Nat-path λ _ → refl
+    pb .has-is-pb .p₁∘universal = trivialᵉ
+    pb .has-is-pb .p₂∘universal = trivialᵉ
     pb .has-is-pb .unique p q = Nat-path λ _ → funext λ _ →
       pb-path (p ηₚ _ $ₚ _) (q ηₚ _ $ₚ _)
 
@@ -102,8 +102,8 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     prod .has-is-product .⟨_,_⟩ f g =
       NT (λ i x → f .η i x , g .η i x) λ x y h i a →
         f .is-natural x y h i a , g .is-natural x y h i a
-    prod .has-is-product .π₁∘factor = Nat-path λ x → refl
-    prod .has-is-product .π₂∘factor = Nat-path λ x → refl
+    prod .has-is-product .π₁∘factor = trivialᵉ
+    prod .has-is-product .π₂∘factor = trivialᵉ
     prod .has-is-product .unique h p q = Nat-path (λ i j y → p j .η i y , q j .η i y)
 
   {-# TERMINATING #-}
@@ -133,11 +133,11 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     coprod .has-is-coproduct .is-coproduct.[_,_] f g .is-natural x y h = funext λ where
       (inl x) → f .is-natural _ _ _ $ₚ _
       (inr x) → g .is-natural _ _ _ $ₚ _
-    coprod .has-is-coproduct .in₀∘factor = Nat-path λ _ → refl
-    coprod .has-is-coproduct .in₁∘factor = Nat-path λ _ → refl
-    coprod .has-is-coproduct .unique other p q = Nat-path λ a → funext λ where
-      (inl x) → p ηₚ a $ₚ x
-      (inr x) → q ηₚ a $ₚ x
+    coprod .has-is-coproduct .in₀∘factor = trivialᵉ
+    coprod .has-is-coproduct .in₁∘factor = trivialᵉ
+    coprod .has-is-coproduct .unique other p q = ext λ where
+      a (inl x) → p ηₚ a $ₚ x
+      a (inr x) → q ηₚ a $ₚ x
 
   PSh-coequaliser
     : ∀ {X Y} (f g : PSh.Hom X Y)
@@ -205,9 +205,9 @@ module _ {κ} {C : Precategory κ κ} where
       func .F₁ f .η i g .η j (h , x) = f .η _ (g .η _ (h , x))
       func .F₁ f .η i g .is-natural x y h = funext λ x →
         ap (f .η _) (happly (g .is-natural _ _ _) _) ∙ happly (f .is-natural _ _ _) _
-      func .F₁ nt .is-natural x y f = funext λ h → Nat-path λ _ → refl
-      func .F-id = Nat-path λ x → funext λ _ → Nat-path λ _ → funext λ _ → refl
-      func .F-∘ f g = Nat-path λ x → funext λ _ → Nat-path λ _ → funext λ _ → refl
+      func .F₁ nt .is-natural x y f = trivialᵉ
+      func .F-id = trivialᵉ
+      func .F-∘ f g = trivialᵉ
 
       adj : _ ⊣ func
       adj .unit .η x .η i a =
@@ -215,13 +215,12 @@ module _ {κ} {C : Precategory κ κ} where
           funext λ _ → Σ-pathp (happly (x .F-∘ _ _) _) refl
       adj .unit .η x .is-natural _ _ _ = funext λ _ → Nat-path λ _ → funext λ _ →
         Σ-pathp (sym (happly (x .F-∘ _ _) _)) refl
-      adj .unit .is-natural x y f = Nat-path λ _ → funext λ _ → Nat-path λ _ → funext λ _ →
-        Σ-pathp (sym (happly (f .is-natural _ _ _) _)) refl
+      adj .unit .is-natural x y f = ext λ _ _ _ _ → sym (f .is-natural _ _ _ $ₚ _) , refl
       adj .counit .η _ .η _ x = x .fst .η _ (C.id , x .snd)
       adj .counit .η _ .is-natural x y f = funext λ h →
         ap (h .fst .η _) (Σ-pathp C.id-comm refl) ∙ happly (h .fst .is-natural _ _ _) _
       adj .counit .is-natural x y f = Nat-path λ x → refl
-      adj .zig {A} = Nat-path λ x → funext λ _ → Σ-pathp (happly (F-id A) _) refl
+      adj .zig {A} = ext λ x _ → happly (F-id A) _ , refl
       adj .zag {A} = Nat-path λ f → funext λ x → Nat-path λ g → funext λ y →
         ap (x .η _) (Σ-pathp (C.idr _) refl)
 

--- a/src/Cat/CartesianClosed/Locally.lagda.md
+++ b/src/Cat/CartesianClosed/Locally.lagda.md
@@ -187,9 +187,9 @@ isomorphic.
     Slice-product-functor .eta x .commutes = idr _ ∙ pullbacks _ _ .square
     Slice-product-functor .inv x .map      = id
     Slice-product-functor .inv x .commutes = idr _ ∙ sym (pullbacks _ _ .square)
-    Slice-product-functor .eta∘inv x     = /-Hom-path $ idl _
-    Slice-product-functor .inv∘eta x     = /-Hom-path $ idl _
-    Slice-product-functor .natural x y f = /-Hom-path $ id-comm ∙ ap (id ∘_) (pullbacks _ _ .unique
+    Slice-product-functor .eta∘inv x     = ext $ idl _
+    Slice-product-functor .inv∘eta x     = ext $ idl _
+    Slice-product-functor .natural x y f = ext $ id-comm ∙ ap (id ∘_) (pullbacks _ _ .unique
       (pullbacks _ _ .p₁∘universal) (pullbacks _ _ .p₂∘universal ∙ idl _))
 ```
 
@@ -278,9 +278,9 @@ equivalence $(\cC/B)/f \cong \cC/A$.
     rem₂ .eta x .commutes = idr _
     rem₂ .inv x .map      = id
     rem₂ .inv x .commutes = idr _
-    rem₂ .eta∘inv x = /-Hom-path (idr _)
-    rem₂ .inv∘eta x = /-Hom-path (idr _)
-    rem₂ .natural x y f = /-Hom-path $
+    rem₂ .eta∘inv x = ext (idr _)
+    rem₂ .inv∘eta x = ext (idr _)
+    rem₂ .natural x y f = ext $
          idr _
       ·· ap (pullbacks _ _ .universal) prop!
       ·· sym (idl _)

--- a/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
+++ b/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
@@ -205,11 +205,11 @@ is-effective-mono→image {f = f} mon = im where
     hom : ↓Hom _ _ itself other
     hom .α = tt
     hom .β = other .map
-    hom .sq = /-Hom-path refl
+    hom .sq = trivialᵉ
 
     unique : ∀ x → hom ≡ x
     unique x = ↓Hom-path _ _ refl
-      (/-Hom-path (intror refl ∙ ap map (x .sq) ∙ elimr refl))
+      (ext (intror refl ∙ ap map (x .sq) ∙ elimr refl))
 ```
 
 Hence the characterisation of regular monomorphisms given in the

--- a/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
+++ b/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
@@ -205,7 +205,7 @@ is-effective-mono→image {f = f} mon = im where
     hom : ↓Hom _ _ itself other
     hom .α = tt
     hom .β = other .map
-    hom .sq = trivialᵉ
+    hom .sq = trivial!
 
     unique : ∀ x → hom ≡ x
     unique x = ↓Hom-path _ _ refl

--- a/src/Cat/Diagram/Exponential.lagda.md
+++ b/src/Cat/Diagram/Exponential.lagda.md
@@ -454,7 +454,7 @@ $\Delta_B \dashv \Pi_B$ we've been chasing.
         Σ (Hom X (-^B .F₀ (f .domain))) (λ h → ƛ (f .map ∘ ev) ∘ h ≡ ƛ π₂ ∘ !)
           ≃⟨ Σ-ap (Equiv.inverse (ƛ , lambda-is-equiv _)) (coh₁ f) ⟩
         Σ (Hom (X ⊗₀ B) (f .domain)) (λ h → f .map ∘ h ≡ π₂)
-          ≃⟨ Iso→Equiv ((λ x → record { commutes = x .snd }) , iso (λ x → _ , x .commutes) (λ _ → /-Hom-path refl) (λ _ → refl)) ⟩
+          ≃⟨ Iso→Equiv ((λ x → record { commutes = x .snd }) , iso (λ x → _ , x .commutes) (λ _ → trivialᵉ) (λ _ → trivialᵉ)) ⟩
         Slice C B .Precategory.Hom (b.₀ X) f
           ≃∎
 
@@ -463,7 +463,7 @@ $\Delta_B \dashv \Pi_B$ we've been chasing.
       rem₁-β f h = refl
 
     nat : hom-iso-inv-natural {L = constant-family fp} {R = exponentiable→product pb} (rem₁ _ .fst)
-    nat g h x = /-Hom-path $
+    nat g h x = ext $
      rem₁ _ .fst (Π.₁ g ∘ x ∘ h) .map                           ≡⟨ rem₁-β _ _ ⟩
      app (pb _ _ .p₁ ∘ Π.₁ g ∘ x ∘ h)                           ≡⟨ ap app (pulll (pb _ _ .p₁∘universal ∙ ƛ-∘ {f = g .map} {g = pb _ _ .p₁} (has-is-exp _))) ⟩
      app (ƛ (g .map ∘ ev ∘ pb _ _ .p₁ ⊗₁ id) ∘ x ∘ h)           ≡⟨ ap₂ _∘_ refl (ap₂ _⊗₁_ refl (sym (idl id)) ∙ ×-functor .F-∘ _ _) ∙ pulll refl ⟩

--- a/src/Cat/Diagram/Exponential.lagda.md
+++ b/src/Cat/Diagram/Exponential.lagda.md
@@ -454,7 +454,7 @@ $\Delta_B \dashv \Pi_B$ we've been chasing.
         Σ (Hom X (-^B .F₀ (f .domain))) (λ h → ƛ (f .map ∘ ev) ∘ h ≡ ƛ π₂ ∘ !)
           ≃⟨ Σ-ap (Equiv.inverse (ƛ , lambda-is-equiv _)) (coh₁ f) ⟩
         Σ (Hom (X ⊗₀ B) (f .domain)) (λ h → f .map ∘ h ≡ π₂)
-          ≃⟨ Iso→Equiv ((λ x → record { commutes = x .snd }) , iso (λ x → _ , x .commutes) (λ _ → trivialᵉ) (λ _ → trivialᵉ)) ⟩
+          ≃⟨ Iso→Equiv ((λ x → record { commutes = x .snd }) , iso (λ x → _ , x .commutes) (λ _ → trivial!) (λ _ → trivial!)) ⟩
         Slice C B .Precategory.Hom (b.₀ X) f
           ≃∎
 

--- a/src/Cat/Diagram/Monad.lagda.md
+++ b/src/Cat/Diagram/Monad.lagda.md
@@ -203,10 +203,10 @@ module _ {o ℓ} {C : Precategory o ℓ} {M : Monad C} where
 
   Extensional-Algebra-Hom
     : ∀ {ℓr} {a b} {A : Algebra-on C M a} {B : Algebra-on C M b}
-    → {@(tactic extensionalᶠ C.Hom) sa : ∀ x y → Extensional (C.Hom x y) ℓr}
+    → ⦃ sa : Extensional (C.Hom a b) ℓr ⦄
     → Extensional (Algebra-hom C M (a , A) (b , B)) ℓr
-  Extensional-Algebra-Hom {sa = sa} = injection→extensional!
-    (Algebra-hom-path C) (sa _ _)
+  Extensional-Algebra-Hom ⦃ sa ⦄ = injection→extensional!
+    (Algebra-hom-path C) sa
 
   instance
     extensionality-algebra-hom

--- a/src/Cat/Diagram/Monad.lagda.md
+++ b/src/Cat/Diagram/Monad.lagda.md
@@ -4,16 +4,23 @@ open import Cat.Functor.Properties
 open import Cat.Functor.Adjoint
 open import Cat.Prelude
 
+import Cat.Reasoning
+
 open Functor
 open _=>_
 ```
 -->
 
 ```agda
-module Cat.Diagram.Monad {o h : _} (C : Precategory o h) where
-
-import Cat.Reasoning C as C
+module Cat.Diagram.Monad where
 ```
+
+<!--
+```
+module _ {o h : _} (C : Precategory o h) where
+  private module C = Cat.Reasoning C
+```
+-->
 
 # Monads
 
@@ -28,23 +35,23 @@ ident=mult} $(M \circ M) \To M$.
 [monoid]: Algebra.Monoid.html
 
 ```agda
-record Monad : Type (o ⊔ h) where
-  no-eta-equality
-  field
-    M    : Functor C C
-    unit : Id => M
-    mult : (M F∘ M) => M
+  record Monad : Type (o ⊔ h) where
+    no-eta-equality
+    field
+      M    : Functor C C
+      unit : Id => M
+      mult : (M F∘ M) => M
 ```
 
 <!--
 ```agda
-  module unit = _=>_ unit
-  module mult = _=>_ mult
+    module unit = _=>_ unit
+    module mult = _=>_ mult
 
-  M₀ = F₀ M
-  M₁ = F₁ M
-  M-id = F-id M
-  M-∘ = F-∘ M
+    M₀ = F₀ M
+    M₁ = F₁ M
+    M-id = F-id M
+    M-∘ = F-∘ M
 ```
 -->
 
@@ -52,10 +59,10 @@ Furthermore, these natural transformations must satisfy identity and
 associativity laws exactly analogous to those of a monoid.
 
 ```agda
-  field
-    left-ident  : ∀ {x} → mult.η x C.∘ M₁ (unit.η x) ≡ C.id
-    right-ident : ∀ {x} → mult.η x C.∘ unit.η (M₀ x) ≡ C.id
-    mult-assoc  : ∀ {x} → mult.η x C.∘ M₁ (mult.η x) ≡ mult.η x C.∘ mult.η (M₀ x)
+    field
+      left-ident  : ∀ {x} → mult.η x C.∘ M₁ (unit.η x) ≡ C.id
+      right-ident : ∀ {x} → mult.η x C.∘ unit.η (M₀ x) ≡ C.id
+      mult-assoc  : ∀ {x} → mult.η x C.∘ M₁ (mult.η x) ≡ mult.η x C.∘ mult.η (M₀ x)
 ```
 
 # Algebras over a monad
@@ -71,12 +78,12 @@ value. Formally, an algebra for $M$ is given by a choice of object $A$
 and a morphism $\nu : M(A) \to A$.
 
 ```agda
-record Algebra-on (M : Monad) (ob : C.Ob) : Type (o ⊔ h) where
-  no-eta-equality
-  open Monad M
+  record Algebra-on (M : Monad) (ob : C.Ob) : Type (o ⊔ h) where
+    no-eta-equality
+    open Monad M
 
-  field
-    ν : C.Hom (M₀ ob) ob
+    field
+      ν : C.Hom (M₀ ob) ob
 ```
 
 This morphism must satisfy equations categorifying those which define a
@@ -86,28 +93,28 @@ effects, and `v-mult`{.Agda} says that, given two layers $M(M(A))$, it
 doesn't matter whether you first join then evaluate, or evaluate twice.
 
 ```agda
-    ν-unit : ν C.∘ unit.η ob ≡ C.id
-    ν-mult : ν C.∘ M₁ ν ≡ ν C.∘ mult.η ob
+      ν-unit : ν C.∘ unit.η ob ≡ C.id
+      ν-mult : ν C.∘ M₁ ν ≡ ν C.∘ mult.η ob
 
-Algebra : Monad → Type (o ⊔ h)
-Algebra M = Σ _ (Algebra-on M)
+  Algebra : Monad → Type (o ⊔ h)
+  Algebra M = Σ _ (Algebra-on M)
 ```
 
 <!--
 ```agda
-Algebra-on-pathp
-  : ∀ {M} {X Y} (p : X ≡ Y) {A : Algebra-on M X} {B : Algebra-on M Y}
-  → PathP (λ i → C.Hom (Monad.M₀ M (p i)) (p i)) (A .Algebra-on.ν) (B .Algebra-on.ν)
-  → PathP (λ i → Algebra-on M (p i)) A B
-Algebra-on-pathp over mults i .Algebra-on.ν = mults i
-Algebra-on-pathp {M} over {A} {B} mults i .Algebra-on.ν-unit =
-  is-prop→pathp (λ i → C.Hom-set _ _ (mults i C.∘ M.unit.η _) (C.id {x = over i}))
-    (A .Algebra-on.ν-unit) (B .Algebra-on.ν-unit) i
-  where module M = Monad M
-Algebra-on-pathp {M} over {A} {B} mults i .Algebra-on.ν-mult =
-  is-prop→pathp (λ i → C.Hom-set _ _ (mults i C.∘ M.M₁ (mults i)) (mults i C.∘ M.mult.η _))
-    (A .Algebra-on.ν-mult) (B .Algebra-on.ν-mult) i
-  where module M = Monad M
+  Algebra-on-pathp
+    : ∀ {M} {X Y} (p : X ≡ Y) {A : Algebra-on M X} {B : Algebra-on M Y}
+    → PathP (λ i → C.Hom (Monad.M₀ M (p i)) (p i)) (A .Algebra-on.ν) (B .Algebra-on.ν)
+    → PathP (λ i → Algebra-on M (p i)) A B
+  Algebra-on-pathp over mults i .Algebra-on.ν = mults i
+  Algebra-on-pathp {M} over {A} {B} mults i .Algebra-on.ν-unit =
+    is-prop→pathp (λ i → C.Hom-set _ _ (mults i C.∘ M.unit.η _) (C.id {x = over i}))
+      (A .Algebra-on.ν-unit) (B .Algebra-on.ν-unit) i
+    where module M = Monad M
+  Algebra-on-pathp {M} over {A} {B} mults i .Algebra-on.ν-mult =
+    is-prop→pathp (λ i → C.Hom-set _ _ (mults i C.∘ M.M₁ (mults i)) (mults i C.∘ M.mult.η _))
+      (A .Algebra-on.ν-mult) (B .Algebra-on.ν-mult) i
+    where module M = Monad M
 ```
 -->
 
@@ -121,19 +128,19 @@ homomorphism`{.Agda ident=Algebra-hom} is a map of the underlying
 objects which "commutes with the algebras".
 
 ```agda
-record Algebra-hom (M : Monad) (X Y : Algebra M) : Type (o ⊔ h) where
-  no-eta-equality
-  private
-    module X = Algebra-on (X .snd)
-    module Y = Algebra-on (Y .snd)
+  record Algebra-hom (M : Monad) (X Y : Algebra M) : Type (o ⊔ h) where
+    no-eta-equality
+    private
+      module X = Algebra-on (X .snd)
+      module Y = Algebra-on (Y .snd)
 
-  open Monad M
+    open Monad M
 
-  field
-    morphism : C.Hom (X .fst) (Y .fst)
-    commutes : morphism C.∘ X.ν ≡ Y.ν C.∘ M₁ morphism
+    field
+      morphism : C.Hom (X .fst) (Y .fst)
+      commutes : morphism C.∘ X.ν ≡ Y.ν C.∘ M₁ morphism
 
-open Algebra-hom
+  open Algebra-hom
 ```
 
 We can be more specific about "commuting with the algebras" by drawing a
@@ -158,33 +165,58 @@ ident=C.Hom-set}), equality of algebra homomorphisms only depends on an
 equality of their underlying morphisms.
 
 ```agda
-Algebra-hom-path
-  : {M : Monad} {X Y : Algebra M} {F G : Algebra-hom M X Y}
-  → morphism F ≡ morphism G
-  → F ≡ G
-Algebra-hom-path x i .morphism = x i
-Algebra-hom-path {M = M} {X} {Y} {F} {G} x i .commutes =
-  is-prop→pathp (λ i → C.Hom-set _ _ (x i C.∘ X .snd .Algebra-on.ν)
-                                     (Y .snd .Algebra-on.ν C.∘ Monad.M₁ M (x i)))
-    (F .commutes) (G .commutes) i
+  Algebra-hom-path
+    : {M : Monad} {X Y : Algebra M} {F G : Algebra-hom M X Y}
+    → morphism F ≡ morphism G
+    → F ≡ G
+  Algebra-hom-path x i .morphism = x i
+  Algebra-hom-path {M = M} {X} {Y} {F} {G} x i .commutes =
+    is-prop→pathp (λ i → C.Hom-set _ _ (x i C.∘ X .snd .Algebra-on.ν)
+                                      (Y .snd .Algebra-on.ν C.∘ Monad.M₁ M (x i)))
+      (F .commutes) (G .commutes) i
 ```
 
 <!--
 ```agda
-private unquoteDecl eqv = declare-record-iso eqv (quote Algebra-hom)
-Algebra-hom-pathp
-  : {M : Monad} {W X Y Z : Algebra M}
-    {F : Algebra-hom M W X}
-    {G : Algebra-hom M Y Z}
-    (p : W ≡ Y)
-    (q : X ≡ Z)
-  → PathP _ (morphism F) (morphism G)
-  → PathP (λ i → Algebra-hom M (p i) (q i)) F G
-Algebra-hom-pathp p q r i .morphism = r i
-Algebra-hom-pathp {M = M} {W} {X} {Y} {Z} {F} {G} p q r i .commutes =
-  is-prop→pathp (λ i → C.Hom-set _ _ (r i C.∘ p i .snd .Algebra-on.ν)
-                                     (q i .snd .Algebra-on.ν C.∘ Monad.M₁ M (r i)))
-    (F .commutes) (G .commutes) i
+  Algebra-hom-pathp
+    : {M : Monad} {W X Y Z : Algebra M}
+      {F : Algebra-hom M W X}
+      {G : Algebra-hom M Y Z}
+      (p : W ≡ Y)
+      (q : X ≡ Z)
+    → PathP _ (morphism F) (morphism G)
+    → PathP (λ i → Algebra-hom M (p i) (q i)) F G
+  Algebra-hom-pathp p q r i .morphism = r i
+  Algebra-hom-pathp {M = M} {W} {X} {Y} {Z} {F} {G} p q r i .commutes =
+    is-prop→pathp (λ i → C.Hom-set _ _ (r i C.∘ p i .snd .Algebra-on.ν)
+                                      (q i .snd .Algebra-on.ν C.∘ Monad.M₁ M (r i)))
+      (F .commutes) (G .commutes) i
+```
+-->
+
+<!--
+```agda
+open Algebra-hom public
+
+module _ {o ℓ} {C : Precategory o ℓ} {M : Monad C} where
+  private module C = Cat.Reasoning C
+
+  Extensional-Algebra-Hom
+    : ∀ {ℓr} {a b} {A : Algebra-on C M a} {B : Algebra-on C M b}
+    → {@(tactic extensionalᶠ C.Hom) sa : ∀ x y → Extensional (C.Hom x y) ℓr}
+    → Extensional (Algebra-hom C M (a , A) (b , B)) ℓr
+  Extensional-Algebra-Hom {sa = sa} = injection→extensional!
+    (Algebra-hom-path C) (sa _ _)
+
+  instance
+    extensionality-algebra-hom
+      : ∀ {a b} {A : Algebra-on C M a} {B : Algebra-on C M b}
+      → Extensionality (Algebra-hom C M (a , A) (b , B))
+    extensionality-algebra-hom = record { lemma = quote Extensional-Algebra-Hom }
+
+module _ {o ℓ} (C : Precategory o ℓ) where
+  private module C = Cat.Reasoning C
+  private unquoteDecl eqv = declare-record-iso eqv (quote Algebra-hom)
 ```
 -->
 
@@ -194,35 +226,35 @@ algebra homomorphism, they assemble into a category: The
 **Eilenberg-Moore** category of $M$.
 
 ```agda
-module _ (M : Monad) where
-  private
-    module M = Monad M
-  open M hiding (M)
-  open Precategory
-  open Algebra-on
+  module _ (M : Monad C) where
+    private
+      module M = Monad M
+    open M hiding (M)
+    open Precategory
+    open Algebra-on
 
-  Eilenberg-Moore : Precategory _ _
-  Eilenberg-Moore .Ob = Algebra M
-  Eilenberg-Moore .Hom X Y = Algebra-hom M X Y
+    Eilenberg-Moore : Precategory _ _
+    Eilenberg-Moore .Ob = Algebra C M
+    Eilenberg-Moore .Hom X Y = Algebra-hom C M X Y
 ```
 
 Defining the identity and composition maps is mostly an exercise in
 categorical yoga:
 
 ```agda
-  Eilenberg-Moore .id {o , x} .morphism = C.id
-  Eilenberg-Moore .id {o , x} .commutes =
-    C.id C.∘ ν x     ≡⟨ C.id-comm-sym ⟩
-    ν x C.∘ C.id     ≡⟨ ap (C._∘_ _) (sym M-id) ⟩
-    ν x C.∘ M₁ C.id  ∎
+    Eilenberg-Moore .id {o , x} .morphism = C.id
+    Eilenberg-Moore .id {o , x} .commutes =
+      C.id C.∘ ν x     ≡⟨ C.id-comm-sym ⟩
+      ν x C.∘ C.id     ≡⟨ ap (C._∘_ _) (sym M-id) ⟩
+      ν x C.∘ M₁ C.id  ∎
 
-  Eilenberg-Moore ._∘_ {_ , x} {_ , y} {_ , z} F G .morphism =
-    morphism F C.∘ morphism G
-  Eilenberg-Moore ._∘_ {_ , x} {_ , y} {_ , z} F G .commutes =
-    (morphism F C.∘ morphism G) C.∘ ν x            ≡⟨ C.extendr (commutes G) ⟩
-    ⌜ morphism F C.∘ ν y ⌝ C.∘ M₁ (morphism G)     ≡⟨ ap! (commutes F) ⟩
-    (ν z C.∘ M₁ (morphism F)) C.∘ M₁ (morphism G)  ≡⟨ C.pullr (sym (M-∘ _ _)) ⟩
-    ν z C.∘ M₁ (morphism F C.∘ morphism G)         ∎
+    Eilenberg-Moore ._∘_ {_ , x} {_ , y} {_ , z} F G .morphism =
+      morphism F C.∘ morphism G
+    Eilenberg-Moore ._∘_ {_ , x} {_ , y} {_ , z} F G .commutes =
+      (morphism F C.∘ morphism G) C.∘ ν x            ≡⟨ C.extendr (commutes G) ⟩
+      ⌜ morphism F C.∘ ν y ⌝ C.∘ M₁ (morphism G)     ≡⟨ ap! (commutes F) ⟩
+      (ν z C.∘ M₁ (morphism F)) C.∘ M₁ (morphism G)  ≡⟨ C.pullr (sym (M-∘ _ _)) ⟩
+      ν z C.∘ M₁ (morphism F C.∘ morphism G)         ∎
 ```
 
 <details>
@@ -233,11 +265,11 @@ the identity and associativity laws from its underlying category.
 </summary>
 
 ```agda
-  Eilenberg-Moore .idr f = Algebra-hom-path (C.idr (morphism f))
-  Eilenberg-Moore .idl f = Algebra-hom-path (C.idl (morphism f))
-  Eilenberg-Moore .assoc f g h = Algebra-hom-path (C.assoc _ _ _)
-  Eilenberg-Moore .Hom-set X Y = Iso→is-hlevel 2 eqv (hlevel 2)
-    where open C.HLevel-instance
+    Eilenberg-Moore .idr f = ext (C.idr _)
+    Eilenberg-Moore .idl f = ext (C.idl _)
+    Eilenberg-Moore .assoc f g h = ext (C.assoc _ _ _)
+    Eilenberg-Moore .Hom-set X Y = Iso→is-hlevel 2 eqv (hlevel 2)
+      where open C.HLevel-instance
 ```
 
 </details>
@@ -247,19 +279,19 @@ morphisms of the homomorphisms between them, we can define a functor
 from `Eilenberg-Moore`{.Agda} back to the underlying category:
 
 ```agda
-  Forget : Functor Eilenberg-Moore C
-  Forget .F₀ = fst
-  Forget .F₁ = Algebra-hom.morphism
-  Forget .F-id = refl
-  Forget .F-∘ f g = refl
+    Forget : Functor Eilenberg-Moore C
+    Forget .F₀ = fst
+    Forget .F₁ = Algebra-hom.morphism
+    Forget .F-id = refl
+    Forget .F-∘ f g = refl
 ```
 
 The lemma `Algebra-hom-path`{.Agda} says exactly that this functor is
 faithful.
 
 ```agda
-  Forget-is-faithful : is-faithful Forget
-  Forget-is-faithful = Algebra-hom-path
+    Forget-is-faithful : is-faithful Forget
+    Forget-is-faithful = ext
 ```
 
 ## Free Algebras
@@ -280,11 +312,11 @@ multiplication; The associativity and unit laws of the monad _itself_
 become those of the $M$-action.
 
 ```agda
-  Free : Functor C Eilenberg-Moore
-  Free .F₀ A .fst = M₀ A
-  Free .F₀ A .snd .ν = mult .η A
-  Free .F₀ A .snd .ν-mult = mult-assoc
-  Free .F₀ A .snd .ν-unit = right-ident
+    Free : Functor C Eilenberg-Moore
+    Free .F₀ A .fst = M₀ A
+    Free .F₀ A .snd .ν = mult .η A
+    Free .F₀ A .snd .ν-mult = mult-assoc
+    Free .F₀ A .snd .ν-unit = right-ident
 ```
 
 The construction of free $M$-algebras is furthermore functorial on the
@@ -306,10 +338,10 @@ algebraic action:
 ~~~
 
 ```agda
-  Free .F₁ f .morphism = M₁ f
-  Free .F₁ f .commutes = sym $ mult.is-natural _ _ _
-  Free .F-id = Algebra-hom-path M-id
-  Free .F-∘ f g = Algebra-hom-path (M-∘ f g)
+    Free .F₁ f .morphism = M₁ f
+    Free .F₁ f .commutes = sym $ mult.is-natural _ _ _
+    Free .F-id = ext M-id
+    Free .F-∘ f g = ext (M-∘ f g)
 ```
 
 This is a free construction in the precise sense of the word: it's the
@@ -321,16 +353,16 @@ $\cC^M$.
 [universal]: Cat.Functor.Adjoint.html#universal-morphisms
 
 ```agda
-  open _⊣_
+    open _⊣_
 
-  Free⊣Forget : Free ⊣ Forget
-  Free⊣Forget .unit = NT M.unit.η M.unit.is-natural
-  Free⊣Forget .counit .η x =
-    record { morphism = x .snd .ν
-           ; commutes = sym (x .snd .ν-mult)
-           }
-  Free⊣Forget .counit .is-natural x y f =
-    Algebra-hom-path (sym (commutes f))
-  Free⊣Forget .zig = Algebra-hom-path left-ident
-  Free⊣Forget .zag {x} = x .snd .ν-unit
+    Free⊣Forget : Free ⊣ Forget
+    Free⊣Forget .unit = NT M.unit.η M.unit.is-natural
+    Free⊣Forget .counit .η x =
+      record { morphism = x .snd .ν
+             ; commutes = sym (x .snd .ν-mult)
+             }
+    Free⊣Forget .counit .is-natural x y f =
+      ext (sym (commutes f))
+    Free⊣Forget .zig = ext left-ident
+    Free⊣Forget .zag {x} = x .snd .ν-unit
 ```

--- a/src/Cat/Diagram/Monad/Limits.lagda.md
+++ b/src/Cat/Diagram/Monad/Limits.lagda.md
@@ -124,7 +124,7 @@ functor $U$ reflects limits: We already had an algebra structure
   Forget-reflects-limits : reflects-limit (Forget C M) F
   Forget-reflects-limits {K} {eps} lim = to-is-limitp
     (make-algebra-limit lim (K .F₀ tt .snd) (λ j → eps .η j .commutes))
-    trivialᵉ
+    trivial!
 ```
 
 Having shown that $U$ reflects the property of _being a limit_, we now

--- a/src/Cat/Diagram/Monad/Limits.lagda.md
+++ b/src/Cat/Diagram/Monad/Limits.lagda.md
@@ -100,13 +100,13 @@ $\cC$ later.
     em-lim : make-is-limit F _
     em-lim .ψ j .morphism = lim.ψ j
     em-lim .ψ j .commutes = comm j
-    em-lim .commutes f    = Algebra-hom-path C (lim.commutes f)
+    em-lim .commutes f    = ext (lim.commutes f)
     em-lim .universal eta p .morphism =
       lim.universal (λ j → eta j .morphism) (λ f i → p f i .morphism)
     em-lim .factors eta p =
-      Algebra-hom-path C (lim.factors _ _)
+      ext (lim.factors _ _)
     em-lim .unique eta p other q =
-      Algebra-hom-path C (lim.unique _ _ _ λ j i → q j i .morphism)
+      ext (lim.unique _ _ _ λ j i → q j i .morphism)
     em-lim .universal eta p .commutes = lim.unique₂ _
       (λ f → C.pulll (F.F₁ f .commutes)
            ∙ C.pullr (sym (M.M-∘ _ _) ∙ ap M.M₁ (ap morphism (p f))))
@@ -124,7 +124,7 @@ functor $U$ reflects limits: We already had an algebra structure
   Forget-reflects-limits : reflects-limit (Forget C M) F
   Forget-reflects-limits {K} {eps} lim = to-is-limitp
     (make-algebra-limit lim (K .F₀ tt .snd) (λ j → eps .η j .commutes))
-    (Algebra-hom-path C refl)
+    trivialᵉ
 ```
 
 Having shown that $U$ reflects the property of _being a limit_, we now

--- a/src/Cat/Displayed/Instances/Slice.lagda.md
+++ b/src/Cat/Displayed/Instances/Slice.lagda.md
@@ -158,7 +158,7 @@ Fibre→slice : ∀ {x} → Functor (Fibre Slices x) (Slice B x)
 Fibre→slice .F₀ x = x
 Fibre→slice .F₁ f ./-Hom.map = f .to
 Fibre→slice .F₁ f ./-Hom.commutes = sym (f .commute) ∙ eliml refl
-Fibre→slice .F-id = trivialᵉ
+Fibre→slice .F-id = trivial!
 Fibre→slice .F-∘ f g = ext (transport-refl _)
 
 Fibre→slice-is-ff : ∀ {x} → is-fully-faithful (Fibre→slice {x = x})

--- a/src/Cat/Displayed/Instances/Slice.lagda.md
+++ b/src/Cat/Displayed/Instances/Slice.lagda.md
@@ -158,15 +158,15 @@ Fibre→slice : ∀ {x} → Functor (Fibre Slices x) (Slice B x)
 Fibre→slice .F₀ x = x
 Fibre→slice .F₁ f ./-Hom.map = f .to
 Fibre→slice .F₁ f ./-Hom.commutes = sym (f .commute) ∙ eliml refl
-Fibre→slice .F-id = /-Hom-path refl
-Fibre→slice .F-∘ f g = /-Hom-path (transport-refl _)
+Fibre→slice .F-id = trivialᵉ
+Fibre→slice .F-∘ f g = ext (transport-refl _)
 
 Fibre→slice-is-ff : ∀ {x} → is-fully-faithful (Fibre→slice {x = x})
 Fibre→slice-is-ff {_} {x} {y} = is-iso→is-equiv isom where
   isom : is-iso (Fibre→slice .F₁)
   isom .is-iso.inv hom =
     slice-hom (hom ./-Hom.map) (eliml refl ∙ sym (hom ./-Hom.commutes))
-  isom .is-iso.rinv x = /-Hom-path refl
+  isom .is-iso.rinv x = ext refl
   isom .is-iso.linv x = Slice-pathp refl refl
 
 Fibre→slice-is-equiv : ∀ {x} → is-equivalence (Fibre→slice {x})

--- a/src/Cat/Displayed/Univalence/Thin.lagda.md
+++ b/src/Cat/Displayed/Univalence/Thin.lagda.md
@@ -128,11 +128,19 @@ module _ {ℓ o' ℓ'} {S : Type ℓ → Type o'} {spec : Thin-structure ℓ' S}
     module So = Precategory (Structured-objects spec)
     module Som = Cat.Morphism (Structured-objects spec)
 
+  Extensional-Hom
+    : ∀ {a b ℓr} {@(tactic extensional (⌞ a ⌟ → ⌞ b ⌟)) sa : Extensional (⌞ a ⌟ → ⌞ b ⌟) ℓr}
+    → Extensional (So.Hom a b) ℓr
+  Extensional-Hom {sa = sa} = injection→extensional!
+    (Structured-hom-path spec) sa
+
   instance
+    extensionality-hom : ∀ {a b} → Extensionality (So.Hom a b)
+    extensionality-hom = record { lemma = quote Extensional-Hom }
+
     Funlike-Hom : Funlike So.Hom
     Funlike-Hom = record
       { _#_ = Total-hom.hom
-      ; ext = λ p → Structured-hom-path spec (funext p)
       }
 
   Homomorphism-path
@@ -166,9 +174,7 @@ record is-equational {ℓ o' ℓ'} {S : Type ℓ → Type o'} (spec : Thin-struc
         (λ st pres → to-pathp (ap (λ e → subst S e (a .snd)) ua-id-equiv
                   ·· transport-refl _
                   ·· spec .id-hom-unique pres (invert-id-hom pres)))
-        (f .hom , eqv)
-        (b .snd)
-        (f .preserves)
+        (f .hom , eqv) (b .snd) (f .preserves)
 
 open is-equational public
 ```

--- a/src/Cat/Displayed/Univalence/Thin.lagda.md
+++ b/src/Cat/Displayed/Univalence/Thin.lagda.md
@@ -129,9 +129,9 @@ module _ {ℓ o' ℓ'} {S : Type ℓ → Type o'} {spec : Thin-structure ℓ' S}
     module Som = Cat.Morphism (Structured-objects spec)
 
   Extensional-Hom
-    : ∀ {a b ℓr} {@(tactic extensional (⌞ a ⌟ → ⌞ b ⌟)) sa : Extensional (⌞ a ⌟ → ⌞ b ⌟) ℓr}
+    : ∀ {a b ℓr} ⦃ sa : Extensional (⌞ a ⌟ → ⌞ b ⌟) ℓr ⦄
     → Extensional (So.Hom a b) ℓr
-  Extensional-Hom {sa = sa} = injection→extensional!
+  Extensional-Hom ⦃ sa ⦄ = injection→extensional!
     (Structured-hom-path spec) sa
 
   instance

--- a/src/Cat/Functor/Adjoint/Monadic.lagda.md
+++ b/src/Cat/Functor/Adjoint/Monadic.lagda.md
@@ -84,8 +84,8 @@ Comparison .F₁ x = hom where
     R.₁ (x D.∘ adj.counit.ε _)            ≡⟨ ap R.₁ (sym (adj.counit.is-natural _ _ _)) ⟩
     R.₁ (adj.counit.ε _ D.∘ L.₁ (R.₁ x))  ≡⟨ R.F-∘ _ _ ⟩
     R.₁ (adj.counit.ε _) C.∘ M₁ (R.₁ x)   ∎
-Comparison .F-id    = Algebra-hom-path _ R.F-id
-Comparison .F-∘ f g = Algebra-hom-path _ (R.F-∘ _ _)
+Comparison .F-id    = ext R.F-id
+Comparison .F-∘ f g = ext (R.F-∘ _ _)
 ```
 </details>
 

--- a/src/Cat/Functor/Base.lagda.md
+++ b/src/Cat/Functor/Base.lagda.md
@@ -77,9 +77,9 @@ Cat[ C , D ] .Pc.Hom-set F G = Nat-is-set
 Cat[ C , D ] .Pc.id  = idnt
 Cat[ C , D ] .Pc._∘_ = _∘nt_
 
-Cat[ C , D ] .Pc.idr f       = Nat-path λ x → Pc.idr D _
-Cat[ C , D ] .Pc.idl f       = Nat-path λ x → Pc.idl D _
-Cat[ C , D ] .Pc.assoc f g h = Nat-path λ x → Pc.assoc D _ _ _
+Cat[ C , D ] .Pc.idr f       = ext λ x → Pc.idr D _
+Cat[ C , D ] .Pc.idl f       = ext λ x → Pc.idl D _
+Cat[ C , D ] .Pc.assoc f g h = ext λ x → Pc.assoc D _ _ _
 ```
 
 We'll also need the following foundational tool, characterising paths

--- a/src/Cat/Functor/Dense.lagda.md
+++ b/src/Cat/Functor/Dense.lagda.md
@@ -77,8 +77,7 @@ the induced [nerve] functor is fully faithful.
         λ f → sym (nt .is-natural _ _ _ $ₚ _) ∙ ap (nt .η _) (f .sq ∙ D.idl _)
 
     invr : ∀ {x y} (f : Nerve F .F₀ x => Nerve F .F₀ y) → Nerve F .F₁ (inv f) ≡ f
-    invr f = Nat-path λ x → funext λ i →
-      is-dense.factors _ {j = ↓obj i} _ _
+    invr f = ext λ x i → is-dense.factors _ {j = ↓obj i} _ _
 
     invl : ∀ {x y} (f : D.Hom x y) → inv (Nerve F .F₁ f) ≡ f
     invl f = sym $ is-dense.unique _ _ _ f (λ _ → refl)
@@ -95,5 +94,5 @@ enough to tell morphisms (and so objects) in the ambient category apart.
     → f ≡ g
   dense→separating dense h =
     fully-faithful→faithful {F = Nerve F} (is-dense→nerve-is-ff dense) $
-      Nat-path λ x → funext λ g → h g
+      ext λ x g → h g
 ```

--- a/src/Cat/Functor/Hom.lagda.md
+++ b/src/Cat/Functor/Hom.lagda.md
@@ -135,7 +135,7 @@ embedding functor is [[fully faithful]].
 
   isom : is-iso よ₁
   isom .inv nt = nt .η _ id
-  isom .rinv nt = Nat-path λ c → funext λ g →
+  isom .rinv nt = ext λ c g →
     happly (sym (nt .is-natural _ _ _)) _ ∙ ap (nt .η c) (idl g)
   isom .linv _ = idr _
 ```
@@ -157,8 +157,8 @@ though we define it anyways for posterity.
 よcov : Functor (C ^op) Cat[ C , Sets h ]
 よcov .F₀ = Hom-from
 よcov .F₁ = よcov₁
-よcov .F-id = Nat-path λ _ → funext λ g → idr g
-よcov .F-∘ f g = Nat-path λ _ → funext λ h → (assoc h g f)
+よcov .F-id = ext λ _ g → idr g
+よcov .F-∘ f g = ext λ _ h → (assoc h g f)
 ```
 
 As expected, the covariant yoneda embedding is also fully faithful.
@@ -170,7 +170,7 @@ As expected, the covariant yoneda embedding is also fully faithful.
 
   isom : is-iso よcov₁
   isom .inv nt = nt .η _ id
-  isom .rinv nt = Nat-path λ c → funext λ g →
+  isom .rinv nt = ext λ c g →
     sym (nt .is-natural _ _ _) $ₚ _ ∙ ap (nt .η c) (idr g)
   isom .linv _ = idl _
 ```

--- a/src/Cat/Functor/Hom/Coyoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Coyoneda.lagda.md
@@ -76,8 +76,7 @@ $px : P(X)$. Then, to construct the injection map, we can just use the
     colim .ψ x .η y f = P.F₁ f (x .section)
     colim .ψ x .is-natural y z f =
       funext (λ g → happly (P.F-∘ f g) (x .section))
-    colim .commutes {x = x} {y = y} f =
-      Nat-path λ z → funext λ g →
+    colim .commutes {x = x} {y = y} f = ext λ z g →
       P.F₁ (f .hom ∘ g) (y .section)      ≡⟨ happly (P.F-∘ g (f .hom)) (y .section) ⟩
       P.F₁ g (P.F₁ (f .hom) (y .section)) ≡⟨ ap (P.F₁ g) (f .commute) ⟩
       P.F₁ g (x .section)                 ∎
@@ -111,7 +110,7 @@ of $K$. The tricky bit of the proof here is that we need to use
 `induce`{.Agda} to regard `f` as a morphism in the category of elements.
 
 ```agda
-    colim .factors {o} eps comm = Nat-path λ x → funext λ f →
+    colim .factors {o} eps comm = ext λ x f →
       eps (elem x (P.F₁ f (o .section))) .η x id ≡˘⟨ (λ i → comm (induce f (o .section)) i .η x id) ⟩
       eps o .η x (f ∘ id)                        ≡⟨ ap (eps o .η x) (idr f) ⟩
       eps o .η x f ∎
@@ -121,7 +120,7 @@ Finally, uniqueness: This just follows by the commuting conditions on
 `α`.
 
 ```agda
-    colim .unique eps comm α p = Nat-path λ x → funext λ px →
+    colim .unique eps comm α p = ext λ x px →
        α .η x px               ≡˘⟨ ap (α .η x) (happly P.F-id px) ⟩
        α .η x (P.F₁ id px)     ≡⟨ happly (p _ ηₚ x) id ⟩
        eps (elem x px) .η x id ∎
@@ -235,7 +234,7 @@ private module _ where private
     → f ≡ g
   よ-cancelr sep =
     fully-faithful→faithful {F = よ} よ-is-fully-faithful $
-      Representables-generate-presheaf λ h → Nat-path λ x → funext λ a →
+      Representables-generate-presheaf λ h → ext λ x a →
         sep (h .η x a)
 ```
 

--- a/src/Cat/Functor/Kan/Global.lagda.md
+++ b/src/Cat/Functor/Kan/Global.lagda.md
@@ -58,9 +58,9 @@ module _ (has-lan : (G : Functor C D) → Lan p G) where
   Lan-functor .F₀ G = has-lan G .Ext
   Lan-functor .F₁ {x} {y} θ =
     has-lan x .σ (has-lan y .eta ∘nt θ)
-  Lan-functor .F-id {x} = has-lan x .σ-uniq (Nat-path λ _ → D.id-comm)
+  Lan-functor .F-id {x} = has-lan x .σ-uniq (ext λ _ → D.id-comm)
   Lan-functor .F-∘ {x} {y} {z} f g =
-    has-lan x .σ-uniq $ Nat-path λ a → sym $
+    has-lan x .σ-uniq $ ext λ a → sym $
         D.pullr   (has-lan x .σ-comm ηₚ a)
       ∙ D.extendl (has-lan y .σ-comm ηₚ a)
 ```
@@ -88,7 +88,7 @@ adjoint to the [precomposition] functor $- \circ p$.
     eqv {x} {y} .linv θ = has-lan _ .σ-uniq refl
 
     natural : hom-iso-natural {L = Lan-functor} {precompose p} f
-    natural {b = b} g h x = Nat-path λ a →
+    natural {b = b} g h x = ext λ a →
       D.pullr (D.pullr (has-lan _ .σ-comm ηₚ a))
       ∙ ap₂ D._∘_ refl (D.pushr refl)
 ```
@@ -109,7 +109,7 @@ adjoint-precompose→Lan F adj G = extn where
 
   extn : is-lan p G _ _
   extn .σ α = R-adjunct adj α
-  extn .σ-comm {M = M} {α = α} = Nat-path λ a →
+  extn .σ-comm {M = M} {α = α} = ext λ a →
       D.pullr   (sym (adj.unit .is-natural _ _ _) ηₚ a)
     ∙ D.cancell (adj.zag ηₚ a)
   extn .σ-uniq x = Equiv.injective (_ , L-adjunct-is-equiv adj)

--- a/src/Cat/Functor/Kan/Nerve.lagda.md
+++ b/src/Cat/Functor/Kan/Nerve.lagda.md
@@ -142,33 +142,30 @@ computations using naturality. It's not very enlightening.
 </summary>
 
 ```agda
-    Nerve-is-lan .σ {M = M} α .η d .is-natural x y f =
-      funext λ g →
-        M.₁ (g D.∘ F.₁ f) .η y (α .η y .η y C.id)          ≡⟨ M.F-∘ g (F .F₁ f) ηₚ _ $ₚ _ ⟩
-        M.₁ g .η y (M .F₁ (F.₁ f) .η y (α .η y .η y C.id)) ≡˘⟨ ap (M.F₁ g .η y) (α .is-natural _ _ _ ηₚ _ $ₚ _) ⟩
-        M.₁ g .η y (α .η x .η y ⌜ f C.∘ C.id ⌝)            ≡⟨ ap! C.id-comm ⟩
-        M.₁ g .η y (α .η x .η y (C.id C.∘ f))              ≡⟨ ap (M.₁ g .η y) (α .η _ .is-natural _ _ _ $ₚ _) ⟩
-        M.₁ g .η y (M.₀ (F.₀ x) .F₁ f (α .η x .η x C.id))  ≡⟨ M.₁ g .is-natural _ _ _ $ₚ _ ⟩
-        M.₀ d .F₁ f (M.₁ g .η x (α .η x .η x C.id))        ∎
+    Nerve-is-lan .σ {M = M} α .η d .is-natural x y f = funext λ g →
+      M.₁ (g D.∘ F.₁ f) .η y (α .η y .η y C.id)          ≡⟨ M.F-∘ g (F .F₁ f) ηₚ _ $ₚ _ ⟩
+      M.₁ g .η y (M .F₁ (F.₁ f) .η y (α .η y .η y C.id)) ≡˘⟨ ap (M.F₁ g .η y) (α .is-natural _ _ _ ηₚ _ $ₚ _) ⟩
+      M.₁ g .η y (α .η x .η y ⌜ f C.∘ C.id ⌝)            ≡⟨ ap! C.id-comm ⟩
+      M.₁ g .η y (α .η x .η y (C.id C.∘ f))              ≡⟨ ap (M.₁ g .η y) (α .η _ .is-natural _ _ _ $ₚ _) ⟩
+      M.₁ g .η y (M.₀ (F.₀ x) .F₁ f (α .η x .η x C.id))  ≡⟨ M.₁ g .is-natural _ _ _ $ₚ _ ⟩
+      M.₀ d .F₁ f (M.₁ g .η x (α .η x .η x C.id))        ∎
       where module M = Functor M
 
-    Nerve-is-lan .σ {M = M} α .is-natural x y f =
-      Nat-path λ z → funext λ g → M .F-∘ f g ηₚ _ $ₚ _
+    Nerve-is-lan .σ {M = M} α .is-natural x y f = ext λ z g →
+      M .F-∘ f g ηₚ _ $ₚ _
 
-    Nerve-is-lan .σ-comm {M = M} {α = α} =
-      Nat-path λ x → Nat-path λ y → funext λ f →
-        M.₁ (F.₁ f) .η y (α .η y .η y C.id) ≡˘⟨ α .is-natural _ _ _ ηₚ _ $ₚ _ ⟩
-        α .η x .η y (f C.∘ C.id)            ≡⟨ ap (α .η x .η y) (C.idr _) ⟩
-        α .η x .η y f                       ∎
+    Nerve-is-lan .σ-comm {M = M} {α = α} = ext λ x y f →
+      M.₁ (F.₁ f) .η y (α .η y .η y C.id) ≡˘⟨ α .is-natural _ _ _ ηₚ _ $ₚ _ ⟩
+      α .η x .η y (f C.∘ C.id)            ≡⟨ ap (α .η x .η y) (C.idr _) ⟩
+      α .η x .η y f                       ∎
       where module M = Functor M
 
-    Nerve-is-lan .σ-uniq {M = M} {α = α} {σ' = σ'} p =
-      Nat-path λ x → Nat-path λ y → funext λ f →
-        M.₁ f .η y (α .η y .η y C.id)          ≡⟨ ap (M.₁ f .η y) (p ηₚ _ ηₚ _ $ₚ _) ⟩
-        M.₁ f .η y (σ' .η _ .η y ⌜ F.₁ C.id ⌝) ≡⟨ ap! F.F-id ⟩
-        M.₁ f .η y (σ' .η _ .η y D.id)         ≡˘⟨ σ' .is-natural _ _ _ ηₚ _ $ₚ _ ⟩
-        σ' .η x .η y (f D.∘ D.id)              ≡⟨ ap (σ' .η x .η y) (D.idr _) ⟩
-        σ' .η x .η y f                         ∎
+    Nerve-is-lan .σ-uniq {M = M} {α = α} {σ' = σ'} p = ext λ x y f →
+      M.₁ f .η y (α .η y .η y C.id)          ≡⟨ ap (M.₁ f .η y) (p ηₚ _ ηₚ _ $ₚ _) ⟩
+      M.₁ f .η y (σ' .η _ .η y ⌜ F.₁ C.id ⌝) ≡⟨ ap! F.F-id ⟩
+      M.₁ f .η y (σ' .η _ .η y D.id)         ≡˘⟨ σ' .is-natural _ _ _ ηₚ _ $ₚ _ ⟩
+      σ' .η x .η y (f D.∘ D.id)              ≡⟨ ap (σ' .η x .η y) (D.idr _) ⟩
+      σ' .η x .η y f                         ∎
       where module M = Functor M
 ```
 </summary>

--- a/src/Cat/Functor/Kan/Pointwise.lagda.md
+++ b/src/Cat/Functor/Kan/Pointwise.lagda.md
@@ -508,7 +508,7 @@ the usual Yoneda-like argument.
         pointwise-↓cocone d α .η c' C'.id
       inv .is-natural x y f = funext λ α →
         pointwise.σ-uniq y {σ' = pointwise-↓cocone x α ∘nt (_=>_.op (よ₁ D f) ◂ L)}
-          (Nat-path λ c → funext λ g → D.pushr (sym (pointwise.σ-comm x ηₚ _ $ₚ _))) ηₚ c' $ₚ C'.id
+          (ext λ c g → D.pushr (sym (pointwise.σ-comm x ηₚ _ $ₚ _))) ηₚ c' $ₚ C'.id
 ```
 
 <details>
@@ -519,7 +519,7 @@ _pointwise_, and remember that we're working with a Kan extension.
 
 ```agda
       invl : Hom-into-inj (↓cocone c') ∘nt inv ≡ idnt
-      invl = Nat-path λ d → funext λ α → Nat-path λ p↓c' →
+      invl = ext λ d α p↓c' →
         pointwise-↓cocone d α .η _ C'.id D.∘ L .Functor.F₁ (p↓c' .map) D.∘ eta .η _ ≡⟨ D.pulll (pointwise.σ d (represent-↓cocone d α) .is-natural _ _ _ $ₚ _) ⟩
         pointwise-↓cocone d α .η _ ⌜ C'.id C'.∘ p↓c' .map ⌝ D.∘ eta .η _            ≡⟨ ap! (C'.idl _) ⟩
         pointwise-↓cocone d α .η _ (p↓c' .map) D.∘ eta .η (x p↓c')                  ≡⟨ pointwise.σ-comm d ηₚ _ $ₚ p↓c' .map ⟩
@@ -536,7 +536,7 @@ _pointwise_, and remember that we're working with a Kan extension.
       invr : inv ∘nt Hom-into-inj (↓cocone c') ≡ idnt
       invr = Nat-path λ d → funext λ α →
         pointwise.σ-uniq d {σ' = vaguely-yoneda α}
-          (Nat-path λ c → funext λ f → D.assoc _ _ _) ηₚ c' $ₚ C'.id
+          (ext λ c f → D.assoc _ _ _) ηₚ c' $ₚ C'.id
         ∙ D.elimr (L .F-id)
 ```
 </details>

--- a/src/Cat/Functor/Monadic/Beck.lagda.md
+++ b/src/Cat/Functor/Monadic/Beck.lagda.md
@@ -171,16 +171,15 @@ from the algebra laws.
     (e' .morphism C.∘ T.mult .η A) C.∘ T.M₁ (unit.η A)    ≡⟨ C.pushl (e' .commutes) ⟩
     F .snd .ν C.∘ T.M₁ (e' .morphism) C.∘ T.M₁ (unit.η A) ≡˘⟨ C.refl⟩∘⟨ T.M-∘ _ _ ⟩
     F .snd .ν C.∘ T.M₁ (e' .morphism C.∘ unit.η A)        ∎
-  algebra-is-coequaliser .factors {F = F} {e'} {p} = Algebra-hom-path C $
+  algebra-is-coequaliser .factors {F = F} {e'} {p} = ext $
     (e' .morphism C.∘ unit.η _) C.∘ A.ν          ≡⟨ C.extendr (unit.is-natural _ _ _) ⟩
     (e' .morphism C.∘ T.M₁ A.ν) C.∘ unit.η  _    ≡˘⟨ ap morphism p C.⟩∘⟨refl ⟩
     (e' .morphism C.∘ T.mult .η _) C.∘ unit.η  _ ≡⟨ C.cancelr T.right-ident ⟩
     e' .morphism                                 ∎
-  algebra-is-coequaliser .unique {F = F} {e'} {p} {colim} q =
-    Algebra-hom-path C $ sym $
-      e' .morphism C.∘ unit.η A              ≡⟨ ap morphism (sym q) C.⟩∘⟨refl ⟩
-      (colim .morphism C.∘ A.ν) C.∘ unit.η A ≡⟨ C.cancelr A.ν-unit ⟩
-      colim .morphism                        ∎
+  algebra-is-coequaliser .unique {F = F} {e'} {p} {colim} q = ext $ sym $
+    e' .morphism C.∘ unit.η A              ≡⟨ ap morphism (sym q) C.⟩∘⟨refl ⟩
+    (colim .morphism C.∘ A.ν) C.∘ unit.η A ≡⟨ C.cancelr A.ν-unit ⟩
+    colim .morphism                        ∎
 ```
 
 # Presented algebras
@@ -268,7 +267,7 @@ readers.
     ∙ C.elimr (F⊣G .zag)
     ∙ G.intror (F⊣G .zig)
     ∙ G.weave (D.pulll (sym (F⊣G .counit.is-natural _ _ _)) ∙ D.pullr (sym (F.F-∘ _ _)))
-  Comparison⁻¹⊣Comparison .unit .is-natural x y f = Algebra-hom-path C $
+  Comparison⁻¹⊣Comparison .unit .is-natural x y f = ext $
     (G.₁ (has-coeq y .coeq) C.∘ T.unit.η _) C.∘ f .morphism                    ≡⟨ C.pullr (T.unit.is-natural _ _ _) ⟩
     G.₁ (has-coeq y .coeq) C.∘ T.M₁ (f .morphism) C.∘ T.unit .η (x .fst)       ≡⟨ C.pulll (sym (G.F-∘ _ _)) ⟩
     G.₁ (has-coeq y .coeq D.∘ F.₁ (f .morphism)) C.∘ T.unit .η (x .fst)        ≡⟨ ap G.₁ (sym (has-coeq _ .factors)) C.⟩∘⟨refl ⟩
@@ -290,7 +289,7 @@ readers.
       ∙ D.pulll (F⊣G .counit.is-natural _ _ _)
       ∙ D.cancelr (F⊣G .zig))
       (D.idl _)
-  Comparison⁻¹⊣Comparison .zag = Algebra-hom-path C $
+  Comparison⁻¹⊣Comparison .zag = ext $
     G.pulll (has-coeq _ .factors) ∙ F⊣G .zag
 ```
 

--- a/src/Cat/Functor/Monadic/Crude.lagda.md
+++ b/src/Cat/Functor/Monadic/Crude.lagda.md
@@ -137,7 +137,7 @@ module _
   -- by "prcoeq".
   prcoeq→unit-is-iso : ∀ {o} → C^T.is-invertible (adj.unit.η o)
   prcoeq→unit-is-iso {o} = C^T.make-invertible inverse
-    (Algebra-hom-path C η⁻¹η) (Algebra-hom-path C ηη⁻¹) where
+    (ext η⁻¹η) (ext ηη⁻¹) where
 ```
 
 The first thing we note is that Beck's coequaliser is reflexive: The

--- a/src/Cat/Functor/Properties.lagda.md
+++ b/src/Cat/Functor/Properties.lagda.md
@@ -63,7 +63,7 @@ module _ {C : Precategory o h} {D : Precategory o₁ h₁} where
     → is-prop (Σ[ g ∈ x C.≅ y ] (F-map-iso F g ≡ f))
   faithful→iso-fibre-prop F faithful f (g , p) (g' , q) =
     Σ-prop-path (λ _ → D.≅-is-set _ _) $
-    C.≅-pathp refl refl (faithful (ap D.to (p ∙ sym q)))
+    ext (faithful (ap D.to (p ∙ sym q)))
 ```
 -->
 
@@ -214,8 +214,8 @@ module _ {C : Precategory o h} {D : Precategory o₁ h₁} where
   is-ff→F-map-iso-is-equiv {F = F} ff = is-iso→is-equiv isom where
     isom : is-iso _
     isom .is-iso.inv    = is-ff→essentially-injective {F = F} ff
-    isom .is-iso.rinv x = D.≅-pathp refl refl (equiv→counit ff _)
-    isom .is-iso.linv x = C.≅-pathp refl refl (equiv→unit ff _)
+    isom .is-iso.rinv x = ext (equiv→counit ff _)
+    isom .is-iso.linv x = ext (equiv→unit ff _)
 ```
 -->
 
@@ -298,7 +298,7 @@ essentially injective.
   ff→pseudomonic {F} ff .faithful = fully-faithful→faithful {F = F} ff
   ff→pseudomonic {F} ff .isos-full f =
     inc (is-ff→essentially-injective {F = F} ff f ,
-         D.≅-pathp refl refl (equiv→counit ff (D.to f)))
+         ext (equiv→counit ff (D.to f)))
 ```
 
 ## Equivalence on Objects Functors

--- a/src/Cat/Functor/Pullback.lagda.md
+++ b/src/Cat/Functor/Pullback.lagda.md
@@ -97,11 +97,11 @@ diagram below is a cone over $K' \to X \ot Y$.
 functorial, but the details are not particularly enlightening.</summary>
 
 ```agda
-  Base-change .F-id {x} = /-Hom-path (sym (xpb.unique id-comm (idr _)))
+  Base-change .F-id {x} = ext (sym (xpb.unique id-comm (idr _)))
     where module xpb = Pullback (pullbacks (x .map) f)
 
   Base-change .F-∘ {x} {y} {z} am bm =
-    /-Hom-path (sym (zpb.unique
+    ext (sym (zpb.unique
       (pulll zpb.p₁∘universal ∙ pullr ypb.p₁∘universal ∙ assoc _ _ _)
       (pulll zpb.p₂∘universal ∙ ypb.p₂∘universal)))
     where
@@ -127,8 +127,8 @@ module _ {X Y : Ob} (f : Hom Y X) where
   Σf : Functor (Slice C Y) (Slice C X)
   Σf .F₀ o = cut (f ∘ o .map)
   Σf .F₁ dh = record { map = dh .map ; commutes = pullr (dh .commutes) }
-  Σf .F-id = /-Hom-path refl
-  Σf .F-∘ f g = /-Hom-path refl
+  Σf .F-id = trivialᵉ
+  Σf .F-∘ f g = trivialᵉ
 
   open _⊣_
   open _=>_
@@ -146,14 +146,14 @@ module _ {X Y : Ob} (f : Hom Y X) where
 
   func = Σf f
   Σ-ff : ∀ {x y} → is-equiv (func .F₁ {x} {y})
-  Σ-ff = is-iso→is-equiv (iso ∘inv (λ x → /-Hom-path refl) λ x →  /-Hom-path refl) where
+  Σ-ff = is-iso→is-equiv (iso ∘inv (λ x → trivialᵉ) λ x → trivialᵉ) where
     ∘inv : /-Hom _ _ → /-Hom _ _
     ∘inv o .map = o .map
     ∘inv o .commutes = invertible→monic isom _ _ (assoc _ _ _ ∙ o .commutes)
 
   Σ-seso : is-split-eso func
   Σ-seso y = cut (isom.inv ∘ y .map)
-           , Sl.make-iso into from' (/-Hom-path (eliml refl)) (/-Hom-path (eliml refl))
+           , Sl.make-iso into from' (ext (eliml refl)) (ext (eliml refl))
     where
     into : /-Hom _ _
     into .map = id
@@ -184,7 +184,7 @@ module _ (pullbacks : ∀ {X Y Z} f g → Pullback C {X} {Y} {Z} f g) {X Y : Ob}
     dh .map = pb.universal {p₁' = id} {p₂' = obj .map} (idr _)
     dh .commutes = pb.p₂∘universal
   Σf⊣f* .unit .is-natural x y g =
-    /-Hom-path (pb.unique₂
+    ext (pb.unique₂
       {p = (f ∘ y .map) ∘ id ∘ g .map ≡⟨ cat! C ⟩ f ∘ y .map ∘ g .map ∎}
       (pulll pb.p₁∘universal)
       (pulll pb.p₂∘universal)
@@ -199,13 +199,13 @@ module _ (pullbacks : ∀ {X Y Z} f g → Pullback C {X} {Y} {Z} f g) {X Y : Ob}
     dh : /-Hom _ _
     dh .map = pb.p₁
     dh .commutes = pb.square
-  Σf⊣f* .counit .is-natural x y g = /-Hom-path pb.p₁∘universal
+  Σf⊣f* .counit .is-natural x y g = ext pb.p₁∘universal
     where module pb = Pullback (pullbacks (y .map) f)
 
-  Σf⊣f* .zig {A} = /-Hom-path pb.p₁∘universal
+  Σf⊣f* .zig {A} = ext pb.p₁∘universal
     where module pb = Pullback (pullbacks (f ∘ A .map) f)
 
-  Σf⊣f* .zag {B} = /-Hom-path
+  Σf⊣f* .zag {B} = ext
     (sym (pb.unique₂ {p = pb.square}
       (idr _) (idr _)
       (pulll pb.p₁∘universal ∙ pullr pb'.p₁∘universal ∙ idr _)

--- a/src/Cat/Functor/Pullback.lagda.md
+++ b/src/Cat/Functor/Pullback.lagda.md
@@ -127,8 +127,8 @@ module _ {X Y : Ob} (f : Hom Y X) where
   Σf : Functor (Slice C Y) (Slice C X)
   Σf .F₀ o = cut (f ∘ o .map)
   Σf .F₁ dh = record { map = dh .map ; commutes = pullr (dh .commutes) }
-  Σf .F-id = trivialᵉ
-  Σf .F-∘ f g = trivialᵉ
+  Σf .F-id = trivial!
+  Σf .F-∘ f g = trivial!
 
   open _⊣_
   open _=>_
@@ -146,7 +146,7 @@ module _ {X Y : Ob} (f : Hom Y X) where
 
   func = Σf f
   Σ-ff : ∀ {x y} → is-equiv (func .F₁ {x} {y})
-  Σ-ff = is-iso→is-equiv (iso ∘inv (λ x → trivialᵉ) λ x → trivialᵉ) where
+  Σ-ff = is-iso→is-equiv (iso ∘inv (λ x → trivial!) λ x → trivial!) where
     ∘inv : /-Hom _ _ → /-Hom _ _
     ∘inv o .map = o .map
     ∘inv o .commutes = invertible→monic isom _ _ (assoc _ _ _ ∙ o .commutes)

--- a/src/Cat/Functor/Slice.lagda.md
+++ b/src/Cat/Functor/Slice.lagda.md
@@ -45,8 +45,8 @@ Sliced F X .F₁ sh = sh' where
   sh' : /-Hom _ _
   sh' .map = F .F₁ (sh .map)
   sh' .commutes = sym (F .F-∘ _ _) ∙ ap (F .F₁) (sh .commutes)
-Sliced F X .F-id = /-Hom-path (F .F-id)
-Sliced F X .F-∘ f g = /-Hom-path (F .F-∘ _ _)
+Sliced F X .F-id = ext (F .F-id)
+Sliced F X .F-∘ f g = ext (F .F-∘ _ _)
 ```
 
 # Faithful, fully faithful
@@ -71,7 +71,7 @@ the sliced functors are also [[fully faithful]].
 
 ```agda
   Sliced-faithful : is-faithful F → is-faithful (Sliced F X)
-  Sliced-faithful faith p = /-Hom-path (faith (ap map p))
+  Sliced-faithful faith p = ext (faith (ap map p))
 
   Sliced-ff : is-fully-faithful F → is-fully-faithful (Sliced F X)
   Sliced-ff eqv = is-iso→is-equiv isom where
@@ -81,8 +81,8 @@ the sliced functors are also [[fully faithful]].
       ; commutes = ap fst $ is-contr→is-prop (eqv .is-eqv _)
         (_ , F .F-∘ _ _ ∙ ap₂ D._∘_ refl (equiv→counit eqv _) ∙ sh .commutes) (_ , refl)
       }
-    isom .is-iso.rinv x = /-Hom-path (equiv→counit eqv _)
-    isom .is-iso.linv x = /-Hom-path (equiv→unit eqv _)
+    isom .is-iso.rinv x = ext (equiv→counit eqv _)
+    isom .is-iso.linv x = ext (equiv→unit eqv _)
 ```
 
 # Left exactness
@@ -149,13 +149,15 @@ Sliced-adjoints {C = C} {D} {L} {R} adj {X} = adj' where
   module D = Cat.Reasoning D
 
   adj' : (Σf (adj .counit .η _) F∘ Sliced L (R .F₀ X)) ⊣ Sliced R X
-  adj' .unit .η x .map = adj.unit.η _
-  adj' .unit .is-natural x y f = /-Hom-path (adj.unit.is-natural _ _ _)
-  adj' .counit .η x .map = adj.counit.ε _
-  adj' .counit .η x .commutes = sym (adj.counit.is-natural _ _ _)
-  adj' .counit .is-natural x y f = /-Hom-path (adj.counit.is-natural _ _ _)
-  adj' .zig = /-Hom-path adj.zig
-  adj' .zag = /-Hom-path adj.zag
+  adj' .unit .η x .map         = adj.unit.η _
+  adj' .unit .is-natural x y f = ext (adj.unit.is-natural _ _ _)
+
+  adj' .counit .η x .map         = adj.counit.ε _
+  adj' .counit .η x .commutes    = sym (adj.counit.is-natural _ _ _)
+  adj' .counit .is-natural x y f = ext (adj.counit.is-natural _ _ _)
+
+  adj' .zig = ext adj.zig
+  adj' .zag = ext adj.zag
 ```
 
 80% of the adjunction transfers as-is (I didn't quite count, but the

--- a/src/Cat/Functor/Subcategory.lagda.md
+++ b/src/Cat/Functor/Subcategory.lagda.md
@@ -200,7 +200,7 @@ with $F$ and $C$.
     is-iso→is-equiv $ iso
     (λ f → sub-hom (D.to y-es D.∘ F₁ f D.∘ D.from x-es) (f , refl))
     (λ _ → refl)
-    (λ f → ext {A = Subcat-hom Faithful-subcat _ _} (f .witness .snd))
+    (λ f → ext (f .witness .snd))
 
   Faithful-subcat-domain-is-split-eso : is-split-eso Faithful-subcat-domain
   Faithful-subcat-domain-is-split-eso x =

--- a/src/Cat/Functor/Subcategory.lagda.md
+++ b/src/Cat/Functor/Subcategory.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS -vtactic.extensionality:10 #-}
 open import Cat.Functor.Properties
 open import Cat.Univalent
 open import Cat.Prelude
@@ -87,9 +86,10 @@ module _ {o o' ℓ ℓ'} {C : Precategory o ℓ} {subcat : Subcat C o' ℓ'} whe
 
   Extensional-subcat-hom
     : ∀ {ℓr} {x y : Σ[ ob ∈ Ob ] (is-ob ob)}
-    → {@(tactic extensionalᶠ Hom) sa : ∀ x y → Extensional (Hom x y) ℓr}
+    → ⦃ sa : Extensional (Hom (x .fst) (y .fst)) ℓr ⦄
     → Extensional (Subcat-hom subcat x y) ℓr
-  Extensional-subcat-hom {sa = sa} = injection→extensional! (Subcat-hom-pathp refl refl) (sa _ _)
+  Extensional-subcat-hom ⦃ sa ⦄ = injection→extensional!
+    (Subcat-hom-pathp refl refl) sa
 
   instance
     extensionality-subcat-hom

--- a/src/Cat/Functor/Subcategory.lagda.md
+++ b/src/Cat/Functor/Subcategory.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS -vtactic.extensionality:10 #-}
 open import Cat.Functor.Properties
 open import Cat.Univalent
 open import Cat.Prelude
@@ -84,20 +85,22 @@ module _ {o o' ℓ ℓ'} {C : Precategory o ℓ} {subcat : Subcat C o' ℓ'} whe
   Subcat-hom-pathp {f = f} {g = g} p q r i .witness =
     is-prop→pathp (λ i → is-hom-prop (r i) (p i .snd) (q i .snd)) (f .witness) (g .witness) i
 
-  Subcat-hom-path
-    : {x y : Σ[ ob ∈ Ob ] (is-ob ob)}
-    → {f g : Subcat-hom subcat x y}
-    → f .hom ≡ g .hom
-    → f ≡ g
-  Subcat-hom-path p = Subcat-hom-pathp refl refl p
+  Extensional-subcat-hom
+    : ∀ {ℓr} {x y : Σ[ ob ∈ Ob ] (is-ob ob)}
+    → {@(tactic extensionalᶠ Hom) sa : ∀ x y → Extensional (Hom x y) ℓr}
+    → Extensional (Subcat-hom subcat x y) ℓr
+  Extensional-subcat-hom {sa = sa} = injection→extensional! (Subcat-hom-pathp refl refl) (sa _ _)
 
   instance
+    extensionality-subcat-hom
+      : ∀ {x y : Σ[ ob ∈ Ob ] (is-ob ob)} → Extensionality (Subcat-hom subcat x y)
+    extensionality-subcat-hom = record { lemma = quote Extensional-subcat-hom }
+
     Funlike-Subcat-hom : ⦃ _ : Funlike Hom ⦄ → Funlike (Subcat-hom subcat)
     Funlike-Subcat-hom ⦃ i ⦄ = record
       { au = Underlying-Σ ⦃ i .Funlike.au ⦄
       ; bu = Underlying-Σ ⦃ i .Funlike.bu ⦄
       ; _#_ = λ f x → apply (f .hom) x
-      ; ext = λ x → Subcat-hom-path (ext x)
       }
 
   Subcat-hom-is-set
@@ -129,9 +132,9 @@ module _ {o o' ℓ ℓ'} {C : Precategory o ℓ} (subcat : Subcat C o' ℓ') whe
   Subcategory .Precategory.id .witness = is-hom-id _
   Subcategory .Precategory._∘_ f g .hom = f .hom ∘ g .hom
   Subcategory .Precategory._∘_ f g .witness = is-hom-∘ (f .witness) (g .witness)
-  Subcategory .Precategory.idr f = Subcat-hom-path (idr (f .hom))
-  Subcategory .Precategory.idl f = Subcat-hom-path (idl (f .hom))
-  Subcategory .Precategory.assoc f g h = Subcat-hom-path (assoc (f .hom) (g .hom) (h .hom))
+  Subcategory .Precategory.idr f = ext (idr _)
+  Subcategory .Precategory.idl f = ext (idl _)
+  Subcategory .Precategory.assoc f g h = ext (assoc _ _ _)
 ```
 
 ## From pseudomonic functors
@@ -197,7 +200,7 @@ with $F$ and $C$.
     is-iso→is-equiv $ iso
     (λ f → sub-hom (D.to y-es D.∘ F₁ f D.∘ D.from x-es) (f , refl))
     (λ _ → refl)
-    (λ f → Subcat-hom-path (f .witness .snd))
+    (λ f → ext {A = Subcat-hom Faithful-subcat _ _} (f .witness .snd))
 
   Faithful-subcat-domain-is-split-eso : is-split-eso Faithful-subcat-domain
   Faithful-subcat-domain-is-split-eso x =
@@ -223,7 +226,7 @@ module _ {o o' ℓ ℓ'} {C : Precategory o ℓ} {subcat : Subcat C o' ℓ'} whe
   Forget-subcat .Functor.F-∘ _ _ = refl
 
   is-faithful-Forget-subcat : is-faithful Forget-subcat
-  is-faithful-Forget-subcat = Subcat-hom-path
+  is-faithful-Forget-subcat = ext
 ```
 
 Furthermore, if the subcategory contains all of the isomorphisms of $\cC$, then
@@ -241,8 +244,8 @@ the forgetful functor is pseudomonic.
       Sub.make-iso
         (sub-hom (f .to) (invert (iso→invertible f)))
         (sub-hom (f .from) (invert (iso→invertible (f Iso⁻¹))))
-        (Subcat-hom-path (f .invl))
-        (Subcat-hom-path (f .invr))
+        (ext (f .invl))
+        (ext (f .invr))
       , ≅-path refl
 ```
 

--- a/src/Cat/Functor/WideSubcategory.lagda.md
+++ b/src/Cat/Functor/WideSubcategory.lagda.md
@@ -74,10 +74,10 @@ Wide-hom-path {sub = sub} {f = f} {g = g} p i .witness =
 
 Extensional-wide-hom
   : ∀ {ℓ ℓr} {sub : Wide-subcat ℓ} {x y : C.Ob}
-  → {@(tactic extensionalᶠ C.Hom) sa : ∀ x y → Extensional (C.Hom x y) ℓr}
+  → ⦃ sa : Extensional (C.Hom x y) ℓr ⦄
   → Extensional (Wide-hom sub x y) ℓr
-Extensional-wide-hom {sub = sub} {sa = sa} = injection→extensional!
-  Wide-hom-path (sa _ _)
+Extensional-wide-hom ⦃ sa ⦄ = injection→extensional!
+  Wide-hom-path sa
 
 instance
   extensionality-wide-hom

--- a/src/Cat/Functor/WideSubcategory.lagda.md
+++ b/src/Cat/Functor/WideSubcategory.lagda.md
@@ -72,6 +72,18 @@ Wide-hom-path {f = f} {g = g} p i .hom = p i
 Wide-hom-path {sub = sub} {f = f} {g = g} p i .witness =
   is-prop→pathp (λ i → sub .P-prop (p i)) (f .witness) (g .witness) i
 
+Extensional-wide-hom
+  : ∀ {ℓ ℓr} {sub : Wide-subcat ℓ} {x y : C.Ob}
+  → {@(tactic extensionalᶠ C.Hom) sa : ∀ x y → Extensional (C.Hom x y) ℓr}
+  → Extensional (Wide-hom sub x y) ℓr
+Extensional-wide-hom {sub = sub} {sa = sa} = injection→extensional!
+  Wide-hom-path (sa _ _)
+
+instance
+  extensionality-wide-hom
+    : ∀ {ℓ} {sub : Wide-subcat ℓ} {x y : C.Ob} → Extensionality (Wide-hom sub x y)
+  extensionality-wide-hom = record { lemma = quote Extensional-wide-hom }
+
 Wide-hom-is-set
   : {sub : Wide-subcat ℓ}
   → {x y : C.Ob}
@@ -96,9 +108,9 @@ Wide sub .id .witness = sub .P-id
 Wide sub ._∘_ f g .hom     = f .hom C.∘ g .hom
 Wide sub ._∘_ f g .witness = sub .P-∘ (f .witness) (g .witness)
 
-Wide sub .idr _ = Wide-hom-path $ C.idr _
-Wide sub .idl _ = Wide-hom-path $ C.idl _
-Wide sub .assoc _ _ _ = Wide-hom-path $ C.assoc _ _ _
+Wide sub .idr _ = ext $ C.idr _
+Wide sub .idl _ = ext $ C.idl _
+Wide sub .assoc _ _ _ = ext $ C.assoc _ _ _
 ```
 
 ## From split essentially surjective inclusions
@@ -158,7 +170,7 @@ This canonical wide subcategory is equivalent to $\cD$.
   is-fully-faithful-Wide-subcat→domain = is-iso→is-equiv $ iso
     (λ f → wide (eso.to _ C.∘ F₁ f C.∘ eso.from _) (f , refl))
     (λ _ → refl)
-    (λ f → Wide-hom-path (f .witness .snd))
+    (λ f → ext (f .witness .snd))
 
   is-eso-Wide-subcat→domain : is-split-eso Wide-subcat→Split-eso-domain
   is-eso-Wide-subcat→domain x =
@@ -204,8 +216,8 @@ module _ {sub : Wide-subcat ℓ} where
       Wide.make-iso
         (wide f.to (P-invert (C.iso→invertible f)))
         (wide f.from (P-invert (C.iso→invertible (f C.Iso⁻¹))))
-        (Wide-hom-path f.invl)
-        (Wide-hom-path f.invr) ,
+        (ext f.invl)
+        (ext f.invr) ,
       C.≅-pathp refl refl refl
     where module f = C._≅_ f
 

--- a/src/Cat/Instances/OFE/Coproduct.lagda.md
+++ b/src/Cat/Instances/OFE/Coproduct.lagda.md
@@ -190,8 +190,8 @@ unique: but it suffices to reason at the level of sets.
   mk .in₀ = in0
   mk .in₁ = in1
   mk .has-is-coproduct .is-coproduct.[_,_] {Q = Q} f g = disj f g
-  mk .has-is-coproduct .in₀∘factor = trivialᵉ
-  mk .has-is-coproduct .in₁∘factor = trivialᵉ
+  mk .has-is-coproduct .in₀∘factor = trivial!
+  mk .has-is-coproduct .in₁∘factor = trivial!
   mk .has-is-coproduct .unique other p q = Homomorphism-path λ where
     (inl x) → p #ₚ x
     (inr x) → q #ₚ x

--- a/src/Cat/Instances/OFE/Coproduct.lagda.md
+++ b/src/Cat/Instances/OFE/Coproduct.lagda.md
@@ -190,8 +190,8 @@ unique: but it suffices to reason at the level of sets.
   mk .in₀ = in0
   mk .in₁ = in1
   mk .has-is-coproduct .is-coproduct.[_,_] {Q = Q} f g = disj f g
-  mk .has-is-coproduct .in₀∘factor = Homomorphism-path λ x → refl
-  mk .has-is-coproduct .in₁∘factor = Homomorphism-path λ x → refl
+  mk .has-is-coproduct .in₀∘factor = trivialᵉ
+  mk .has-is-coproduct .in₁∘factor = trivialᵉ
   mk .has-is-coproduct .unique other p q = Homomorphism-path λ where
     (inl x) → p #ₚ x
     (inr x) → q #ₚ x

--- a/src/Cat/Instances/OFE/Product.lagda.md
+++ b/src/Cat/Instances/OFE/Product.lagda.md
@@ -83,8 +83,8 @@ OFE-Product A B .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
 OFE-Product A B .has-is-product .⟨_,_⟩ f g .preserves .pres-≈ p =
   f .preserves .pres-≈ p , g .preserves .pres-≈ p
 
-OFE-Product A B .has-is-product .π₁∘factor = trivialᵉ
-OFE-Product A B .has-is-product .π₂∘factor = trivialᵉ
+OFE-Product A B .has-is-product .π₁∘factor = trivial!
+OFE-Product A B .has-is-product .π₂∘factor = trivial!
 OFE-Product A B .has-is-product .unique o p q = ext λ x → p #ₚ x , q #ₚ x
 ```
 
@@ -181,7 +181,7 @@ OFE-Indexed-product F .π i .preserves .pres-≈ α =
 OFE-Indexed-product F .has-is-ip .tuple f .hom x i = f i # x
 OFE-Indexed-product F .has-is-ip .tuple f .preserves .pres-≈ wit =
   lift $ inc λ i → f i .preserves .pres-≈ wit
-OFE-Indexed-product F .has-is-ip .commute = trivialᵉ
+OFE-Indexed-product F .has-is-ip .commute = trivial!
 OFE-Indexed-product F .has-is-ip .unique f prf =
   ext λ x y → prf y #ₚ x
 ```

--- a/src/Cat/Instances/OFE/Product.lagda.md
+++ b/src/Cat/Instances/OFE/Product.lagda.md
@@ -83,10 +83,9 @@ OFE-Product A B .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
 OFE-Product A B .has-is-product .⟨_,_⟩ f g .preserves .pres-≈ p =
   f .preserves .pres-≈ p , g .preserves .pres-≈ p
 
-OFE-Product A B .has-is-product .π₁∘factor = Homomorphism-path λ x → refl
-OFE-Product A B .has-is-product .π₂∘factor = Homomorphism-path λ x → refl
-OFE-Product A B .has-is-product .unique o p q = Homomorphism-path λ x →
-  ap₂ _,_ (p #ₚ x) (q #ₚ x)
+OFE-Product A B .has-is-product .π₁∘factor = trivialᵉ
+OFE-Product A B .has-is-product .π₂∘factor = trivialᵉ
+OFE-Product A B .has-is-product .unique o p q = ext λ x → p #ₚ x , q #ₚ x
 ```
 
 <!--
@@ -182,7 +181,7 @@ OFE-Indexed-product F .π i .preserves .pres-≈ α =
 OFE-Indexed-product F .has-is-ip .tuple f .hom x i = f i # x
 OFE-Indexed-product F .has-is-ip .tuple f .preserves .pres-≈ wit =
   lift $ inc λ i → f i .preserves .pres-≈ wit
-OFE-Indexed-product F .has-is-ip .commute = Homomorphism-path λ x → refl
+OFE-Indexed-product F .has-is-ip .commute = trivialᵉ
 OFE-Indexed-product F .has-is-ip .unique f prf =
-  Homomorphism-path λ x → funext λ y → prf y #ₚ x
+  ext λ x y → prf y #ₚ x
 ```

--- a/src/Cat/Instances/Poly.lagda.md
+++ b/src/Cat/Instances/Poly.lagda.md
@@ -81,7 +81,7 @@ poly-map-path
                   ≡ g .preserves a b)
   → f ≡ g
 poly-map-path hom≡ pre≡ = total-hom-path _ hom≡
-  (to-pathp (funext λ a → funext λ b → Regularity.precise! (pre≡ a b)))
+  (to-pathp (ext λ a b → Regularity.precise! (pre≡ a b)))
 ```
 
 ## Polynomials as functors

--- a/src/Cat/Instances/Sets/CartesianClosed.lagda.md
+++ b/src/Cat/Instances/Sets/CartesianClosed.lagda.md
@@ -52,10 +52,10 @@ module _ {A B : Set ℓ} (func : ∣ A ∣ → ∣ B ∣) where
 
 <!--
 ```agda
-  Sets-Π .F-id = /-Hom-path
-    (funext λ x → Σ-pathp refl (funext λ x → Σ-pathp refl (A .is-tr _ _ _ _)))
-  Sets-Π .F-∘ f g = /-Hom-path
-    (funext λ x → Σ-pathp refl (funext λ x → Σ-pathp refl (A .is-tr _ _ _ _)))
+  Sets-Π .F-id = ext λ x → Σ-pathp refl
+    (funext λ x → Σ-pathp refl (A .is-tr _ _ _ _))
+  Sets-Π .F-∘ f g = ext λ x → Σ-pathp refl
+    (funext λ x → Σ-pathp refl (A .is-tr _ _ _ _))
 ```
 -->
 

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -528,8 +528,8 @@ fast:
   Total-space .F₁ nt .map (i , x) = i , nt .η _ x
   Total-space .F₁ nt .commutes    = refl
 
-  Total-space .F-id    = trivialᵉ
-  Total-space .F-∘ _ _ = trivialᵉ
+  Total-space .F-id    = trivial!
+  Total-space .F-∘ _ _ = trivial!
 ```
 
 Since the construction of the functor itself is straightforward, we turn

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -128,6 +128,15 @@ says that the map $h$ "respects reindexing", or less obliquely
              → x ≡ y
   /-Hom-path = /-Hom-pathp refl refl
 
+  Extensional-/-Hom
+    : ∀ {c a b ℓ} ⦃ sa : Extensional (C.Hom (/-Obj.domain a) (/-Obj.domain b)) ℓ ⦄
+    → Extensional (/-Hom {c = c} a b) ℓ
+  Extensional-/-Hom ⦃ sa ⦄ = injection→extensional! (/-Hom-pathp refl refl) sa
+
+  instance
+    extensionality-/-hom : ∀ {c a b} → Extensionality (/-Hom {c = c} a b)
+    extensionality-/-hom = record { lemma = quote Extensional-/-Hom }
+
   private unquoteDecl eqv = declare-record-iso eqv (quote /-Hom)
 
   abstract
@@ -188,9 +197,9 @@ commutativity for $g \circ f$).
       z .map C.∘ f.map C.∘ g.map ≡⟨ C.pulll f.commutes ⟩
       y .map C.∘ g.map           ≡⟨ g.commutes ⟩
       x .map                     ∎
-  precat .idr f = /-Hom-path (C.idr _)
-  precat .idl f = /-Hom-path (C.idl _)
-  precat .assoc f g h = /-Hom-path (C.assoc _ _ _)
+  precat .idr f = ext (C.idr _)
+  precat .idl f = ext (C.idl _)
+  precat .assoc f g h = ext (C.assoc _ _ _)
 ```
 
 ## Finite limits
@@ -210,7 +219,7 @@ module _ {o ℓ} {C : Precategory o ℓ} {c : Precategory.Ob C} where
   Slice-terminal-object' obj .centre .map = obj .map
   Slice-terminal-object' obj .centre .commutes = C.idl _
   Slice-terminal-object' obj .paths other =
-    /-Hom-path (sym (other .commutes) ∙ C.idl _)
+    ext (sym (other .commutes) ∙ C.idl _)
 
   Slice-terminal-object : Terminal (Slice C c)
   Slice-terminal-object .Terminal.top  = _
@@ -352,10 +361,10 @@ product in $\cC/c.$
 
 <!--
 ```agda
-    is-pullback→is-fibre-product .π₁∘factor = /-Hom-path pb.p₁∘universal
-    is-pullback→is-fibre-product .π₂∘factor = /-Hom-path pb.p₂∘universal
+    is-pullback→is-fibre-product .π₁∘factor = ext pb.p₁∘universal
+    is-pullback→is-fibre-product .π₂∘factor = ext pb.p₂∘universal
     is-pullback→is-fibre-product .unique other p q =
-      /-Hom-path (pb.unique (ap map p) (ap map q))
+      ext (pb.unique (ap map p) (ap map q))
 
   Pullback→Fibre-product
     : ∀ {f g : /-Obj c}
@@ -397,16 +406,16 @@ module _ {o ℓ} {C : Precategory o ℓ} {X : Precategory.Ob C}
     → is-pullback (Slice C X) {P} {A} {B} {c} p1 f p2 g
   pullback-above→pullback-below pb = pb' where
     pb' : is-pullback (Slice _ _) _ _ _ _
-    pb' .square = /-Hom-path (pb .square)
+    pb' .square           = ext (pb .square)
     pb' .universal p .map = pb .universal (ap map p)
     pb' .universal {P'} {p₁' = p₁'} p .commutes =
       (c .map ∘ pb .universal (ap map p))           ≡˘⟨ pulll (p1 .commutes) ⟩
       (P .map ∘ p1 .map ∘ pb .universal (ap map p)) ≡⟨ ap (_ ∘_) (pb .p₁∘universal) ⟩
       (P .map ∘ p₁' .map)                           ≡⟨ p₁' .commutes ⟩
       P' .map                                       ∎ {- * -}
-    pb' .p₁∘universal = /-Hom-path (pb .p₁∘universal)
-    pb' .p₂∘universal = /-Hom-path (pb .p₂∘universal)
-    pb' .unique p q   = /-Hom-path (pb .unique (ap map p) (ap map q))
+    pb' .p₁∘universal = ext (pb .p₁∘universal)
+    pb' .p₂∘universal = ext (pb .p₂∘universal)
+    pb' .unique p q   = ext (pb .unique (ap map p) (ap map q))
 
   pullback-below→pullback-above
     : is-pullback (Slice C X) {P} {A} {B} {c} p1 f p2 g
@@ -419,12 +428,12 @@ module _ {o ℓ} {C : Precategory o ℓ} {X : Precategory.Ob C}
       {p₂' = record { commutes = sym (pulll (g .commutes))
                               ·· sym (ap (_ ∘_) p)
                               ·· pulll (f .commutes) }}
-      (/-Hom-path p) .map
+      (ext p) .map
     pb' .p₁∘universal = ap map $ pb .p₁∘universal
     pb' .p₂∘universal = ap map $ pb .p₂∘universal
     pb' .unique p q   = ap map $ pb .unique
       {lim' = record { commutes = sym (pulll (p1 .commutes)) ∙ ap (_ ∘_) p }}
-      (/-Hom-path p) (/-Hom-path q)
+      (ext p) (ext q)
 ```
 
 It follows that any slice of a category with pullbacks is finitely
@@ -519,8 +528,8 @@ fast:
   Total-space .F₁ nt .map (i , x) = i , nt .η _ x
   Total-space .F₁ nt .commutes    = refl
 
-  Total-space .F-id    = /-Hom-path refl
-  Total-space .F-∘ _ _ = /-Hom-path refl
+  Total-space .F-id    = trivialᵉ
+  Total-space .F-∘ _ _ = trivialᵉ
 ```
 
 Since the construction of the functor itself is straightforward, we turn
@@ -558,11 +567,11 @@ dependent function is automatically a natural transformation.
 <!--
 ```agda
     linv : is-left-inverse (F₁ Total-space) from
-    linv x = /-Hom-path (funext (λ y → Σ-path (sym (happly (x .commutes) _))
+    linv x = ext λ y → Σ-path (sym (happly (x .commutes) _))
       ( sym (transport-∙ (ap (∣_∣ ⊙ G .F₀) (happly (x .commutes) y))
                     (sym (ap (∣_∣ ⊙ G .F₀) (happly (x .commutes) y))) _)
       ·· ap₂ transport (∙-invr (ap (∣_∣ ⊙ G .F₀) (happly (x .commutes) y))) refl
-      ·· transport-refl _)))
+      ·· transport-refl _)
 ```
 -->
 
@@ -655,8 +664,8 @@ module _ {o ℓ} {C : Precategory o ℓ} {B} (prod : has-products C) where
   constant-family .F₀ A = cut (π₂ {a = A})
   constant-family .F₁ f .map      = ⟨ f ∘ π₁ , π₂ ⟩
   constant-family .F₁ f .commutes = π₂∘⟨⟩
-  constant-family .F-id    = /-Hom-path (sym (⟨⟩-unique _ id-comm (idr _)))
-  constant-family .F-∘ f g = /-Hom-path $ sym $
+  constant-family .F-id    = ext (sym (⟨⟩-unique _ id-comm (idr _)))
+  constant-family .F-∘ f g = ext $ sym $
       ⟨⟩-unique _ (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₂∘⟨⟩)
 ```
 

--- a/src/Cat/Instances/Slice/Limit.lagda.md
+++ b/src/Cat/Instances/Slice/Limit.lagda.md
@@ -138,16 +138,14 @@ in $\cC$, then pass back to the slice category.
 
     lim : make-is-limit F apex
     lim .ψ = nadir
-    lim .commutes f =
-      /-Hom-path (lims.commutes (lift f))
+    lim .commutes f = ext (lims.commutes (lift f))
     lim .universal {x} eta p .map =
       lims.universal (Cone.ϕ eta p) (Cone.ϕ-commutes eta p)
     lim .universal eta p .commutes =
       lims.factors _ _
-    lim .factors eta p =
-      /-Hom-path (lims.factors _ _)
-    lim .unique eta p other q =
-      /-Hom-path $ lims.unique _ _ (other .map) (Cone.ϕ-factor eta p other q)
+    lim .factors eta p = ext (lims.factors _ _)
+    lim .unique eta p other q = ext $
+      lims.unique _ _ (other .map) (Cone.ϕ-factor eta p other q)
 ```
 
 In particular, if a category $\cC$ is complete, then so are its slices:

--- a/src/Cat/Instances/Slice/Presheaf.lagda.md
+++ b/src/Cat/Instances/Slice/Presheaf.lagda.md
@@ -157,7 +157,7 @@ without comment.
         (λ i → nt .η (elem (o .ob) (p i)) (z , (λ j → p (i ∧ j))) .fst)
 
     linv : is-left-inverse inv (F₁ slice→total)
-    linv sh = /-Hom-path (Nat-path (λ z → refl))
+    linv sh = trivialᵉ
 
   open is-precat-iso
   slice→total-is-iso : is-precat-iso slice→total

--- a/src/Cat/Instances/Slice/Presheaf.lagda.md
+++ b/src/Cat/Instances/Slice/Presheaf.lagda.md
@@ -148,12 +148,12 @@ without comment.
       ∙ ap fst (happly (nt .is-natural _ _
           (elem-hom f (happly (sym (x .map .is-natural _ _ _)) _))) _)
 
-    inv nt .commutes = Nat-path λ z → funext λ w →
+    inv nt .commutes = ext λ z w →
       nt .η (elem _ (x .map .η _ _)) (w , refl) .snd
 
     rinv : is-right-inverse inv (F₁ slice→total)
-    rinv nt = Nat-path λ o → funext λ where
-      (z , p) → Σ-prop-path (λ _ → P.₀ _ .is-tr _ _)
+    rinv nt = ext λ where
+      o (z , p) → Σ-prop-path (λ _ → P.₀ _ .is-tr _ _)
         (λ i → nt .η (elem (o .ob) (p i)) (z , (λ j → p (i ∧ j))) .fst)
 
     linv : is-left-inverse inv (F₁ slice→total)

--- a/src/Cat/Instances/Slice/Presheaf.lagda.md
+++ b/src/Cat/Instances/Slice/Presheaf.lagda.md
@@ -157,7 +157,7 @@ without comment.
         (λ i → nt .η (elem (o .ob) (p i)) (z , (λ j → p (i ∧ j))) .fst)
 
     linv : is-left-inverse inv (F₁ slice→total)
-    linv sh = trivialᵉ
+    linv sh = trivial!
 
   open is-precat-iso
   slice→total-is-iso : is-precat-iso slice→total

--- a/src/Cat/Instances/Slice/Twice.lagda.md
+++ b/src/Cat/Instances/Slice/Twice.lagda.md
@@ -57,10 +57,10 @@ Slice-twice f .F₀ g .map .commutes = refl
 
 Slice-twice f .F₁ h .map .map      = h .map
 Slice-twice f .F₁ h .map .commutes = pullr (h .commutes)
-Slice-twice f .F₁ h .commutes      = /-Hom-path (h .commutes)
+Slice-twice f .F₁ h .commutes      = ext (h .commutes)
 
-Slice-twice f .F-id    = /-Hom-path (/-Hom-path refl)
-Slice-twice f .F-∘ g h = /-Hom-path (/-Hom-path refl)
+Slice-twice f .F-id    = trivialᵉ
+Slice-twice f .F-∘ g h = trivialᵉ
 
 Twice-slice : (f : Hom a b) → Functor (Slice (Slice C b) (cut f)) (Slice C a)
 Twice-slice _ .F₀ x .domain = x .domain .domain
@@ -69,8 +69,8 @@ Twice-slice _ .F₀ x .map    = x .map .map
 Twice-slice _ .F₁ h .map      = h .map .map
 Twice-slice _ .F₁ h .commutes = ap map (h .commutes)
 
-Twice-slice _ .F-id = /-Hom-path refl
-Twice-slice _ .F-∘ _ _ = /-Hom-path refl
+Twice-slice _ .F-id = trivialᵉ
+Twice-slice _ .F-∘ _ _ = trivialᵉ
 ```
 
 We will also need the fact that these inverses are also adjoints.
@@ -81,13 +81,13 @@ Twice⊣Slice f = adj where
   adj : Twice-slice f ⊣ Slice-twice f
   adj .unit .η x .map .map      = id
   adj .unit .η x .map .commutes = idr _ ∙ x .map .commutes
-  adj .unit .η x .commutes      = /-Hom-path (idr _)
-  adj .unit .is-natural x y f   = /-Hom-path (/-Hom-path id-comm-sym)
+  adj .unit .η x .commutes      = ext (idr _)
+  adj .unit .is-natural x y f   = ext id-comm-sym
 
   adj .counit .η x .map         = id
   adj .counit .η x .commutes    = idr _
-  adj .counit .is-natural x y f = /-Hom-path id-comm-sym
+  adj .counit .is-natural x y f = ext id-comm-sym
 
-  adj .zig = /-Hom-path (idr _)
-  adj .zag = /-Hom-path (/-Hom-path (idr _))
+  adj .zig = ext (idr _)
+  adj .zag = ext (idr _)
 ```

--- a/src/Cat/Instances/Slice/Twice.lagda.md
+++ b/src/Cat/Instances/Slice/Twice.lagda.md
@@ -59,8 +59,8 @@ Slice-twice f .F₁ h .map .map      = h .map
 Slice-twice f .F₁ h .map .commutes = pullr (h .commutes)
 Slice-twice f .F₁ h .commutes      = ext (h .commutes)
 
-Slice-twice f .F-id    = trivialᵉ
-Slice-twice f .F-∘ g h = trivialᵉ
+Slice-twice f .F-id    = trivial!
+Slice-twice f .F-∘ g h = trivial!
 
 Twice-slice : (f : Hom a b) → Functor (Slice (Slice C b) (cut f)) (Slice C a)
 Twice-slice _ .F₀ x .domain = x .domain .domain
@@ -69,8 +69,8 @@ Twice-slice _ .F₀ x .map    = x .map .map
 Twice-slice _ .F₁ h .map      = h .map .map
 Twice-slice _ .F₁ h .commutes = ap map (h .commutes)
 
-Twice-slice _ .F-id = trivialᵉ
-Twice-slice _ .F-∘ _ _ = trivialᵉ
+Twice-slice _ .F-id = trivial!
+Twice-slice _ .F-∘ _ _ = trivial!
 ```
 
 We will also need the fact that these inverses are also adjoints.

--- a/src/Cat/Instances/StrictCat/Cohesive.lagda.md
+++ b/src/Cat/Instances/StrictCat/Cohesive.lagda.md
@@ -258,7 +258,7 @@ using our path helpers: `Nat-path`{.Agda}, `funext`{.Agda}, and
     f∘g = ext λ c x → Functor-path (λ x → refl) λ f → sym (F-id x)
 
     g∘f : g ∘nt f ≡ idnt
-    g∘f = trivialᵉ
+    g∘f = trivial!
 ```
 
 # Connected components

--- a/src/Cat/Instances/StrictCat/Cohesive.lagda.md
+++ b/src/Cat/Instances/StrictCat/Cohesive.lagda.md
@@ -255,10 +255,10 @@ using our path helpers: `Nat-path`{.Agda}, `funext`{.Agda}, and
     g .is-natural x y f = refl
 
     f∘g : f ∘nt g ≡ idnt
-    f∘g = Nat-path λ c → funext λ x → Functor-path (λ x → refl) λ f → sym (F-id x)
+    f∘g = ext λ c x → Functor-path (λ x → refl) λ f → sym (F-id x)
 
     g∘f : g ∘nt f ≡ idnt
-    g∘f = Nat-path λ _ i x → x
+    g∘f = trivialᵉ
 ```
 
 # Connected components

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -1,6 +1,6 @@
 <!--
 ```agda
-open import 1Lab.Prelude hiding (_∘_ ; id ; _↪_)
+open import 1Lab.Prelude hiding (_∘_ ; id ; _↪_ ; module Extensionality)
 
 open import Cat.Solver
 open import Cat.Base

--- a/src/Cat/Morphism/Extensionality.agda
+++ b/src/Cat/Morphism/Extensionality.agda
@@ -10,13 +10,13 @@ open Cat.Morphism C
 
 Extensional-≅
   : ∀ {ℓr} {a b}
-  → {@(tactic extensionalᶠ Hom) sa : ∀ x y → Extensional (Hom x y) ℓr}
+  → ⦃ sa : Extensional (Hom a b) ℓr ⦄
   → Extensional (a ≅ b) ℓr
-Extensional-≅ {sa = sa} .Pathᵉ a b = Pathᵉ (sa _ _) (a .to) (b .to)
-Extensional-≅ {sa = sa} .reflᵉ im = reflᵉ (sa _ _) (im .to)
-Extensional-≅ {sa = sa} .idsᵉ = set-identity-system
-  (λ x y → Pathᵉ-is-hlevel 1 (sa _ _) hlevel!)
-  (λ p → ≅-path (sa _ _ .idsᵉ .to-path p))
+Extensional-≅ ⦃ sa ⦄ .Pathᵉ a b = Pathᵉ sa (a .to) (b .to)
+Extensional-≅ ⦃ sa ⦄ .reflᵉ im = reflᵉ sa (im .to)
+Extensional-≅ ⦃ sa ⦄ .idsᵉ = set-identity-system
+  (λ x y → Pathᵉ-is-hlevel 1 sa hlevel!)
+  (λ p → ≅-path (sa .idsᵉ .to-path p))
 
 instance
   extensionality-≅ : ∀ {a b} → Extensionality (a ≅ b)

--- a/src/Cat/Morphism/Extensionality.agda
+++ b/src/Cat/Morphism/Extensionality.agda
@@ -1,0 +1,23 @@
+open import 1Lab.Prelude
+
+open import Cat.Base
+
+import Cat.Morphism
+
+module Cat.Morphism.Extensionality {o ℓ} {C : Precategory o ℓ} where
+
+open Cat.Morphism C
+
+Extensional-≅
+  : ∀ {ℓr} {a b}
+  → {@(tactic extensionalᶠ Hom) sa : ∀ x y → Extensional (Hom x y) ℓr}
+  → Extensional (a ≅ b) ℓr
+Extensional-≅ {sa = sa} .Pathᵉ a b = Pathᵉ (sa _ _) (a .to) (b .to)
+Extensional-≅ {sa = sa} .reflᵉ im = reflᵉ (sa _ _) (im .to)
+Extensional-≅ {sa = sa} .idsᵉ = set-identity-system
+  (λ x y → Pathᵉ-is-hlevel 1 (sa _ _) hlevel!)
+  (λ p → ≅-path (sa _ _ .idsᵉ .to-path p))
+
+instance
+  extensionality-≅ : ∀ {a b} → Extensionality (a ≅ b)
+  extensionality-≅ = record { lemma = quote Extensional-≅ }

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -308,10 +308,10 @@ in the relevant comma categories.
     dh .α = tt
     dh .β .map = the-lifting .centre .fst
     dh .β .commutes = the-lifting .centre .snd .snd
-    dh .sq = /-Hom-path (idr _ ∙ sym (the-lifting .centre .snd .fst))
+    dh .sq = ext (idr _ ∙ sym (the-lifting .centre .snd .fst))
 
     unique : ∀ om → dh ≡ om
-    unique om = ↓Hom-path _ _ refl $ /-Hom-path $ ap fst $ the-lifting .paths $
+    unique om = ↓Hom-path _ _ refl $ ext $ ap fst $ the-lifting .paths $
       om .β .map , sym (ap map (om .sq)) ∙ idr _ , om .β .commutes
 ```
 

--- a/src/Cat/Prelude.agda
+++ b/src/Cat/Prelude.agda
@@ -20,3 +20,5 @@ open import Cat.Univalent
         ; Hom-transport ; Hom-pathp-refll ; Hom-pathp-reflr
         ; module Univalent )
   public
+
+open import Cat.Morphism.Extensionality public

--- a/src/Cat/Regular/Slice.lagda.md
+++ b/src/Cat/Regular/Slice.lagda.md
@@ -73,7 +73,7 @@ private
     {c = cut (A .map ∘ a)}
     (record { commutes = refl })
     (record { commutes = pushl (sym (h .mor .commutes)) ·· ap₂ _∘_ refl (sym p) ·· pulll (h .mor .commutes) })
-    (/-Hom-path p)
+    (ext p)
 ```
 -->
 
@@ -104,13 +104,13 @@ invertible in $\cC$.
       mono : cut (B .map ∘ m .mor) C/y.↪ B
       mono = record
         { mor   = record { map = m .mor ; commutes = refl }
-        ; monic = λ g h p → /-Hom-path (m .monic _ _ (ap map p))
+        ; monic = λ g h p → ext (m .monic _ _ (ap map p))
         }
 
       inv : C/y.is-invertible (record { map = m .mor ; commutes = refl })
       inv = extreme mono
         (record { map = g ; commutes = pullr (sym p) ∙ h .commutes })
-        (/-Hom-path p)
+        (ext p)
     in make-invertible
       (inv .C/y.is-invertible.inv .map)
       (ap map (inv .C/y.is-invertible.invl))
@@ -138,8 +138,8 @@ calculate that the inverse to $m$ is still a map over $y$.
         ; commutes = invertible→epic inv _ _ $
           cancelr (inv .is-invertible.invr) ∙ sym (m .mor .commutes)
         })
-      (/-Hom-path (inv .is-invertible.invl))
-      (/-Hom-path (inv .is-invertible.invr))
+      (ext (inv .is-invertible.invl))
+      (ext (inv .is-invertible.invr))
     where extn = is-strong-epi→is-extremal-epi C cover
 ```
 
@@ -164,8 +164,8 @@ slice-is-regular .factor {a} {b} f = fact' where
   fact' .mediate∈E = do
     c ← f.mediate∈E
     pure (reflect-cover (fact' .mediate) c)
-  fact' .forget∈M = inc λ g h p → /-Hom-path $ out! f.forget∈M (g .map) (h .map) (ap map p)
-  fact' .factors = /-Hom-path f.factors
+  fact' .forget∈M = inc λ g h p → ext $ out! f.forget∈M (g .map) (h .map) (ap map p)
+  fact' .factors = ext f.factors
 
 slice-is-regular .stable {B = B} f g {p1} {p2} cover is-pb =
   reflect-cover p1 $ r.stable _ _

--- a/src/Cat/Regular/Slice.lagda.md
+++ b/src/Cat/Regular/Slice.lagda.md
@@ -140,8 +140,7 @@ calculate that the inverse to $m$ is still a map over $y$.
         })
       (/-Hom-path (inv .is-invertible.invl))
       (/-Hom-path (inv .is-invertible.invr))
-    where
-      extn = is-strong-epi→is-extremal-epi C cover
+    where extn = is-strong-epi→is-extremal-epi C cover
 ```
 
 Since the projection functor preserves and reflects strong epimorphisms,

--- a/src/Cat/Restriction/Instances/Allegory.lagda.md
+++ b/src/Cat/Restriction/Instances/Allegory.lagda.md
@@ -60,11 +60,11 @@ functional; it's only relevant in the converse direction of the 4th axiom!
   Partial-maps-restriction ._↓ f .hom = domain (f .hom)
   Partial-maps-restriction ._↓ f .witness = domain-functional (f .hom)
   Partial-maps-restriction .↓-dom f =
-    Wide-hom-path $ domain-absorb (f .hom)
+    ext $ domain-absorb (f .hom)
   Partial-maps-restriction .↓-comm f g =
-    Wide-hom-path $ domain-comm
+    ext $ domain-comm
   Partial-maps-restriction .↓-smashr f g =
-    Wide-hom-path $ domain-smashr (g .hom) (f .hom)
+    ext $ domain-smashr (g .hom) (f .hom)
   Partial-maps-restriction .↓-swap f g =
-    Wide-hom-path $ domain-swap (f .hom) (g .hom) (g .witness)
+    ext $ domain-swap (f .hom) (g .hom) (g .witness)
 ```

--- a/src/Data/Wellfounded/Properties.lagda.md
+++ b/src/Data/Wellfounded/Properties.lagda.md
@@ -28,7 +28,7 @@ private variable
 ```agda
 Acc-is-prop : ∀ x → is-prop (Acc R x)
 Acc-is-prop x (acc s) (acc t) =
-  ap acc (funext λ y → funext λ y<x → Acc-is-prop y (s y y<x) (t y y<x))
+  ap acc (ext λ y y<x → Acc-is-prop y (s y y<x) (t y y<x))
 
 Wf-is-prop : is-prop (Wf R)
 Wf-is-prop = Π-is-hlevel 1 Acc-is-prop

--- a/src/Order/Base.lagda.md
+++ b/src/Order/Base.lagda.md
@@ -119,7 +119,7 @@ Poset-on-path
   → {P Q : Poset-on ℓ A}
   → (∀ x y → Poset-on._≤_ P x y ≡ Poset-on._≤_ Q x y)
   → P ≡ Q
-Poset-on-path p = Poset-on-pathp refl (funext λ x → funext λ y → p x y)
+Poset-on-path p = Poset-on-pathp refl (ext p)
 ```
 -->
 

--- a/src/Order/DCPO.lagda.md
+++ b/src/Order/DCPO.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import Cat.Displayed.Univalence.Thin using (extensionality-hom)
 open import Cat.Functor.Subcategory
 open import Cat.Displayed.Total
 open import Cat.Prelude
@@ -337,15 +338,6 @@ module _ {o ℓ} {D E : DCPO o ℓ} where
     module E = DCPO E
   open is-directed-family
   open Total-hom
-
-  scott-path
-    : ∀ {f g : DCPOs.Hom D E}
-    → (∀ x → Scott.hom f x ≡ Scott.hom g x)
-    → f ≡ g
-  scott-path p =
-    Subcat-hom-path $
-    total-hom-path _ (funext p) $
-    is-prop→pathp (λ i → is-monotone-is-prop (λ x → p x i) D.poset-on E.poset-on) _ _
 ```
 -->
 

--- a/src/Order/DCPO/Free.lagda.md
+++ b/src/Order/DCPO/Free.lagda.md
@@ -67,8 +67,8 @@ Free-DCPO .F₁ f =
   const-inhabited-fam→is-lub (Disc _)
     (λ ix → ap f (disc-is-lub→const x-lub ix))
     (dir .elt)
-Free-DCPO .F-id = trivialᵉ
-Free-DCPO .F-∘ _ _ = trivialᵉ
+Free-DCPO .F-id = trivial!
+Free-DCPO .F-∘ _ _ = trivial!
 ```
 
 Furthermore, this functor is left adjoint to the forgetful functor
@@ -89,8 +89,8 @@ Free-DCPO⊣Forget-DCPO .counit .η D =
           y   ≤∎)
         (dir .elt)
    where open DCPO D
-Free-DCPO⊣Forget-DCPO .counit .is-natural x y f = trivialᵉ
-Free-DCPO⊣Forget-DCPO .zig = trivialᵉ
+Free-DCPO⊣Forget-DCPO .counit .is-natural x y f = trivial!
+Free-DCPO⊣Forget-DCPO .zig = trivial!
 Free-DCPO⊣Forget-DCPO .zag = refl
 ```
 

--- a/src/Order/DCPO/Free.lagda.md
+++ b/src/Order/DCPO/Free.lagda.md
@@ -1,5 +1,7 @@
 <!--
 ```agda
+open import Cat.Displayed.Univalence.Thin using (extensionality-hom)
+open import Cat.Functor.Subcategory using (extensionality-subcat-hom)
 open import Cat.Displayed.Total
 open import Cat.Functor.Adjoint
 open import Cat.Prelude
@@ -65,8 +67,8 @@ Free-DCPO .F₁ f =
   const-inhabited-fam→is-lub (Disc _)
     (λ ix → ap f (disc-is-lub→const x-lub ix))
     (dir .elt)
-Free-DCPO .F-id = scott-path (λ _ → refl)
-Free-DCPO .F-∘ _ _ = scott-path (λ _ → refl)
+Free-DCPO .F-id = trivialᵉ
+Free-DCPO .F-∘ _ _ = trivialᵉ
 ```
 
 Furthermore, this functor is left adjoint to the forgetful functor
@@ -87,9 +89,8 @@ Free-DCPO⊣Forget-DCPO .counit .η D =
           y   ≤∎)
         (dir .elt)
    where open DCPO D
-Free-DCPO⊣Forget-DCPO .counit .is-natural x y f =
-  scott-path (λ _ → refl)
-Free-DCPO⊣Forget-DCPO .zig = scott-path (λ _ → refl)
+Free-DCPO⊣Forget-DCPO .counit .is-natural x y f = trivialᵉ
+Free-DCPO⊣Forget-DCPO .zig = trivialᵉ
 Free-DCPO⊣Forget-DCPO .zag = refl
 ```
 
@@ -396,10 +397,8 @@ Free-Pointed-dcpo .F₁ {x = A} f =
     (λ _ _ → part-map-⊑)
     (λ _ _ → part-map-lub {A = A} f)
     (λ _ → part-map-never)
-Free-Pointed-dcpo .F-id =
-  strict-scott-path part-map-id
-Free-Pointed-dcpo .F-∘ f g =
-  strict-scott-path (part-map-∘ f g)
+Free-Pointed-dcpo .F-id = ext (part-map-id $_)
+Free-Pointed-dcpo .F-∘ f g = ext (part-map-∘ f g $_)
 ```
 
 Finally, we shall show that this functor is left-adjoint to the
@@ -525,9 +524,9 @@ Free-Pointed-dcpo⊣Forget-Pointed-dcpo .counit .η D =
     (λ s dir → part-counit-lub D s (dir .semidirected))
     (part-counit-never D)
 Free-Pointed-dcpo⊣Forget-Pointed-dcpo .counit .is-natural D E f =
-  strict-scott-path λ x → sym $ Strict-scott.pres-⋃-prop f _ _ _
+  ext λ x → sym $ Strict-scott.pres-⋃-prop f _ _ _
 Free-Pointed-dcpo⊣Forget-Pointed-dcpo .zig {A} =
-  strict-scott-path λ x →
+  ext λ x →
     part-ext
       (A?.⋃-prop-least _ _ x (λ p → always-⊒ (Lift.lower p) refl) .implies)
       (λ p → A?.⋃-prop-le _ _ (lift p) .implies tt)

--- a/src/Order/DCPO/Pointed.lagda.md
+++ b/src/Order/DCPO/Pointed.lagda.md
@@ -495,12 +495,6 @@ module _ {o ℓ} {D E : Pointed-dcpo o ℓ} where
     module E = Pointed-dcpo E
   open Total-hom
   open is-directed-family
-
-  strict-scott-path
-    : ∀ {f g : Pointed-DCPOs.Hom D E}
-    → (∀ x → Strict-scott.hom f x ≡ Strict-scott.hom g x)
-    → f ≡ g
-  strict-scott-path p = Subcat-hom-path (scott-path p)
 ```
 -->
 

--- a/src/Order/Frame/Free.lagda.md
+++ b/src/Order/Frame/Free.lagda.md
@@ -56,8 +56,8 @@ Frame↪SLat .F₁ f .hom = f .hom
 Frame↪SLat .F₁ f .preserves .Monoid-hom.pres-id = f .preserves .is-frame-hom.pres-⊤
 Frame↪SLat .F₁ f .preserves .Monoid-hom.pres-⋆ = f .preserves .is-frame-hom.pres-∩
 
-Frame↪SLat .F-id = trivialᵉ
-Frame↪SLat .F-∘ f g = trivialᵉ
+Frame↪SLat .F-id = trivial!
+Frame↪SLat .F-∘ f g = trivial!
 ```
 
 The question this module seeks to answer is: is there a way to freely

--- a/src/Order/Frame/Free.lagda.md
+++ b/src/Order/Frame/Free.lagda.md
@@ -56,8 +56,8 @@ Frame↪SLat .F₁ f .hom = f .hom
 Frame↪SLat .F₁ f .preserves .Monoid-hom.pres-id = f .preserves .is-frame-hom.pres-⊤
 Frame↪SLat .F₁ f .preserves .Monoid-hom.pres-⋆ = f .preserves .is-frame-hom.pres-∩
 
-Frame↪SLat .F-id = Homomorphism-path λ _ → refl
-Frame↪SLat .F-∘ f g = Homomorphism-path λ _ → refl
+Frame↪SLat .F-id = trivialᵉ
+Frame↪SLat .F-∘ f g = trivialᵉ
 ```
 
 The question this module seeks to answer is: is there a way to freely
@@ -162,7 +162,7 @@ performing this construction. Let's abbreviate it:
 ```
 
 The easy part is an appeal to the existing machinery for free
-cocompletions: Any monotone map $A \to B$ extneds to a _cocontinuous_
+cocompletions: Any monotone map $A \to B$ exteds to a _cocontinuous_
 map $DA \to B$, because $B$, being a frame, is cocomplete.
 
 ```agda

--- a/src/Order/Instances/Discrete.lagda.md
+++ b/src/Order/Instances/Discrete.lagda.md
@@ -38,8 +38,8 @@ This extends to a functor from $\Sets$ into the category of posets.
 DiscF : ∀ {ℓ} → Functor (Sets ℓ) (Posets ℓ ℓ)
 DiscF .Functor.F₀ = Disc
 DiscF .Functor.F₁ f = total-hom f (λ _ _ p → ap f p)
-DiscF .Functor.F-id = trivialᵉ
-DiscF .Functor.F-∘ f g = trivialᵉ
+DiscF .Functor.F-id = trivial!
+DiscF .Functor.F-∘ f g = trivial!
 ```
 
 Furthermore, this functor is a [[left adjoint]] to the forgetful functor
@@ -51,8 +51,8 @@ DiscF⊣Forget ._⊣_.unit ._=>_.η A x = x
 DiscF⊣Forget ._⊣_.unit ._=>_.is-natural _ _ _ = refl
 DiscF⊣Forget ._⊣_.counit ._=>_.η P =
   total-hom (λ x → x) (λ _ _ → Poset.path→≤ P)
-DiscF⊣Forget ._⊣_.counit ._=>_.is-natural P Q f = trivialᵉ
-DiscF⊣Forget ._⊣_.zig {A = A} = trivialᵉ
+DiscF⊣Forget ._⊣_.counit ._=>_.is-natural P Q f = trivial!
+DiscF⊣Forget ._⊣_.zig {A = A} = trivial!
 DiscF⊣Forget ._⊣_.zag = refl
 ```
 

--- a/src/Order/Instances/Discrete.lagda.md
+++ b/src/Order/Instances/Discrete.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import Cat.Displayed.Univalence.Thin
 open import Cat.Displayed.Total
 open import Cat.Functor.Adjoint
 open import Cat.Prelude
@@ -37,8 +38,8 @@ This extends to a functor from $\Sets$ into the category of posets.
 DiscF : ∀ {ℓ} → Functor (Sets ℓ) (Posets ℓ ℓ)
 DiscF .Functor.F₀ = Disc
 DiscF .Functor.F₁ f = total-hom f (λ _ _ p → ap f p)
-DiscF .Functor.F-id = total-hom-path _ refl refl
-DiscF .Functor.F-∘ f g = total-hom-path _ refl refl
+DiscF .Functor.F-id = trivialᵉ
+DiscF .Functor.F-∘ f g = trivialᵉ
 ```
 
 Furthermore, this functor is a [[left adjoint]] to the forgetful functor
@@ -50,13 +51,8 @@ DiscF⊣Forget ._⊣_.unit ._=>_.η A x = x
 DiscF⊣Forget ._⊣_.unit ._=>_.is-natural _ _ _ = refl
 DiscF⊣Forget ._⊣_.counit ._=>_.η P =
   total-hom (λ x → x) (λ _ _ → Poset.path→≤ P)
-DiscF⊣Forget ._⊣_.counit ._=>_.is-natural P Q f =
-  total-hom-path _ refl
-    (funext λ _ → funext λ _ → funext λ _ → Poset.≤-thin Q _ _)
-DiscF⊣Forget ._⊣_.zig {A = A} =
-  total-hom-path _ refl $
-  funext λ x → funext λ y → funext λ p →
-  J (λ y p → transport (λ i → p (~ i) ≡ y) refl ≡ p) (transport-refl _) p
+DiscF⊣Forget ._⊣_.counit ._=>_.is-natural P Q f = trivialᵉ
+DiscF⊣Forget ._⊣_.zig {A = A} = trivialᵉ
 DiscF⊣Forget ._⊣_.zag = refl
 ```
 

--- a/src/Order/Semilattice.lagda.md
+++ b/src/Order/Semilattice.lagda.md
@@ -65,6 +65,7 @@ record Semilattice-on {ℓ} (A : Type ℓ) : Type ℓ where
     _∩_ : A → A → A
     has-is-semilattice : is-semilattice top _∩_
   open is-semilattice has-is-semilattice public
+  infixr 25 _∩_
 ```
 
 <!--
@@ -240,8 +241,8 @@ semilattice homomorphism is a monotone map under the induced ordering.
 ```agda
 Meet-semi-lattice .F₁ f .hom = f .hom
 Meet-semi-lattice .F₁ f .preserves x y p = ap (f .hom) p ∙ f .preserves .Monoid-hom.pres-⋆ _ _
-Meet-semi-lattice .F-id    = trivialᵉ
-Meet-semi-lattice .F-∘ f g = trivialᵉ
+Meet-semi-lattice .F-id    = trivial!
+Meet-semi-lattice .F-∘ f g = trivial!
 ```
 
 ## The interface

--- a/src/Order/Semilattice.lagda.md
+++ b/src/Order/Semilattice.lagda.md
@@ -240,8 +240,8 @@ semilattice homomorphism is a monotone map under the induced ordering.
 ```agda
 Meet-semi-lattice .F₁ f .hom = f .hom
 Meet-semi-lattice .F₁ f .preserves x y p = ap (f .hom) p ∙ f .preserves .Monoid-hom.pres-⋆ _ _
-Meet-semi-lattice .F-id    = Homomorphism-path λ _ → refl
-Meet-semi-lattice .F-∘ f g = Homomorphism-path λ _ → refl
+Meet-semi-lattice .F-id    = trivialᵉ
+Meet-semi-lattice .F-∘ f g = trivialᵉ
 ```
 
 ## The interface


### PR DESCRIPTION
Implements a metaprogram `ext` which finds a "good" identity system for a given type, defaulting to `Path` at leaves. To implement default instances, the search is split between the `Extensional` class that actually carries the data and a loop-breaker `Extensionality` class that's used to match on the goal.

There's also a helper `trivialᵉ` for the most common case (surprisingly) where the values are extensionally equal, i.e. things like `funext λ x → Nat-path λ y → refl`.

Currently restricted to non-dependent types, so e.g. `Nat → B G →∙ B H` will stop at `∀ x → Path (B G →∙ B H) _ _` since nothing can match the `Σ`. Reductions are implemented for functions, pairs, natural transformations, and most kinds of morphism in concrete categories. `Homomorphism-path` can be consistently replaced by `ext`, and the search is robust enough to not need any new type annotations basically anywhere.