### PR TITLE
chore: don't preview forks

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,6 +15,8 @@ jobs:
   pr-preview:
     runs-on: ubuntu-latest
 
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     env:
       mailmap: ${{ secrets.MAILMAP }}
 


### PR DESCRIPTION
The workflow would fail anyway since it doesn't have permission to upload to the website.