### PR TITLE
chore: match NOAUTHOR at start of line

### DIFF
--- a/support/shake/app/Shake/Git.hs
+++ b/support/shake/app/Shake/Git.hs
@@ -47,7 +47,7 @@ doGitAuthors (GitAuthors path) = do
   Stdout authors <- gitCommand
     [ "shortlog", "-ns"
     -- Exclude chore commits (for example, trivial reformattings or treewide changes).
-    , "--invert-grep", "--grep=^chore:", "--grep=NOAUTHOR"
+    , "--invert-grep", "--grep=^chore:", "--grep=^NOAUTHOR"
     -- Include both authors and coauthors.
     , "--group=author", "--group=trailer:co-authored-by"
     , "HEAD", "--", path


### PR DESCRIPTION
Restores authorship for https://github.com/plt-amy/1lab/commit/9384879d9f78938cdae733ddc2843e465cf3fb66 which accidentally includes `NOAUTHOR` because of the PR template 🤦🤦🤦 while leaving https://github.com/plt-amy/1lab/commit/6527ec7471954b3921f470046d32af9960113e5a non-authoring.