### PR TITLE
chore: misc fixes

### DIFF
--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -54,7 +54,7 @@ record
 open is-identity-system public
 ```
 
-As mentioned before, the data of an identity system gives is exactly
+As mentioned before, the data of an identity system gives us exactly
 what is required to prove J for the relation $R$. This is essentially
 the decomposition of J into _contractibility of singletons_, but with
 singletons replaced by $R$-singletons.

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -140,8 +140,9 @@
   note = {Commit: \texttt{33011eb}}
 }
 
-@techreport{HoTT,
-  author = {The Univalent Foundations Program},
-  institution = {Institute for Advanced Study},
-  title = {Homotopy type theory: Univalent foundations of mathematics},
-  year = {2013}}
+@Book{HoTT,
+  author =    {The {Univalent Foundations Program}},
+  title =     {Homotopy Type Theory: Univalent Foundations of Mathematics},
+  publisher = {\url{https://homotopytypetheory.org/book}},
+  address =   {Institute for Advanced Study},
+  year =      2013}

--- a/support/web/css/code.scss
+++ b/support/web/css/code.scss
@@ -49,6 +49,7 @@ div.sourceCode > pre {
 
 pre.Agda {
   box-shadow: none;
+  overflow-x: auto;
   overflow-y: clip;
 
   // The margin should be 1rem (the width of the padding for paragraphs
@@ -119,8 +120,6 @@ a[href].hover-highlight {
   a[href]:target {
     animation: highlight 2.5s;
   }
-
-  overflow-x: auto;
 
   // background-color: $code-bg;
   font-family: 'Julia Mono', 'Iosevka', 'Fantasque Sans Mono', 'Roboto Mono', monospace;


### PR DESCRIPTION
In this week's edition of "chore: misc fixes", we

- fix a typo;
- use the [suggested](https://homotopytypetheory.org/book/) BibTeX entry for the HoTT book, which includes the URL and formats the "author" field properly (currently it looks like "Program 2013", first name "The Univalent Foundations");
- move the `overflow-x: auto` from https://github.com/plt-amy/1lab/pull/269 from `.Agda` to `pre.Agda` to exempt the sidebar module name from it, because *for some reason* that causes it to collapse vertically, making it invisible or barely visible on most pages.