### PR TITLE
Correct coend commutative diagram

### DIFF
--- a/src/Cat/Diagram/Coend.lagda.md
+++ b/src/Cat/Diagram/Coend.lagda.md
@@ -114,13 +114,13 @@ and contravariant in the other.
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-  w && {F(c',c')} \\
+  {F(c',c)} && {F(c',c')} \\
   \\
-  {F(c,c)} && {F(c',c)}
-  \arrow["{\psi_{c'}}", from=1-1, to=1-3]
-  \arrow["{F(\mathrm{id}_{c'},f)}", from=1-3, to=3-3]
-  \arrow["{F(f,\mathrm{id}_{c})}"', from=3-1, to=3-3]
-  \arrow["{\psi_c}"', from=1-1, to=3-1]
+  {F(c,c)} && w
+  \arrow["{F(\mathrm{id}_{c'},f)}", from=1-1, to=1-3]
+  \arrow["{\psi_{c'}}", from=1-3, to=3-3]
+  \arrow["{\psi_c}"', from=3-1, to=3-3]
+  \arrow["{F(f,\mathrm{id}_{c})}"', from=1-1, to=3-1]
 \end{tikzcd}\]
 ~~~
 


### PR DESCRIPTION
# Description

The original commutative diagram is for the end, and not the coend.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [X] All new code blocks have "agda" as their language.