### PR TITLE
Update Path.lagda.md

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -747,7 +747,7 @@ contradiction, since any `I → Partial i1 T` extends to a path:
 A partial element in a context with $n$-variables gives us a way of
 mapping some subobject of the $n$-cube into a type. A natural question
 to ask, then, is: Given a partial element $e$ of $A$, can we extend that
-to a honest-to-god _element_ of $A$, which agrees with $e$ where it is
+to an honest-to-god _element_ of $A$, which agrees with $e$ where it is
 defined?
 
 Specifically, when this is the case, we say that $x : A$ _extends_ $e :


### PR DESCRIPTION
chore: Fix typo. NOAUTHOR

# Description

There is a typo that uses "a" where "an" should be used

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [X] All new code blocks have "agda" as their language.

If a commit affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message with `chore:`
or include the word `NOAUTHOR` anywhere.
