### PR TITLE
Coherently constant maps into groupoids

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@ Before submitting a merge request, please check the items below:
 - [ ] The imports of new modules have been sorted with `support/sort-imports.hs`.
 - [ ] All new code blocks have "agda" as their language.
 
-If a commit affects many files without adding substantial content, and
+If your change affects many files without adding substantial content, and
 you don't want your name to appear on those pages (for example, treewide
-refactorings or reformattings), start the commit message with `chore:`
-or include the word `NOAUTHOR` anywhere.
+refactorings or reformattings), start the commit message and PR title with `chore:`.

--- a/src/1Lab/HIT/Truncation.lagda.md
+++ b/src/1Lab/HIT/Truncation.lagda.md
@@ -287,14 +287,15 @@ formulate in the language of type theory.
 However, when $B$ is an $n$-type, it is enough to ask for the first $n$
 levels of the tower. In the case of sets, we've [seen](#maps-into-sets)
 that the naïve notion of constancy is enough. We now deal with the case
-of groupoids, which requires an additional step: we ask for a function
+of [[groupoids]], which requires an additional step: we ask for a function
 $f : A \to B$ equipped with a witness of constancy $\rm{const}_{x,y} :
 f x \equiv f y$ *and* a coherence $\rm{coh}_{x,y,z} : \rm{const}_{x,y}
 \bullet \rm{const}_{y,z} \equiv \rm{const}_{x,z}$.
 
 This time, we cannot hope to show that the image of $f$ is a proposition:
 the image of a map $\top \to S^1$ is $S^1$. Instead, we use the following
-higher inductive type:
+higher inductive type, which can be thought of as the "codiscrete groupoid"
+on $A$:
 
 ```agda
 data ∥_∥³ {ℓ} (A : Type ℓ) : Type ℓ where
@@ -424,9 +425,9 @@ data ∥_∥⁴ {ℓ} (A : Type ℓ) : Type ℓ where
   inc : A → ∥ A ∥⁴
   iconst : ∀ a b → inc a ≡ inc b
   icoh : ∀ a b c → PathP (λ i → inc a ≡ iconst b c i) (iconst a b) (iconst a c)
-  icoh³ : ∀ a b c d → PathP (λ i → PathP (λ j → inc a ≡ icoh b c d i j)
-                                         (iconst a b) (icoh a c d i))
-                            (icoh a b c) (icoh a b d)
+  iassoc : ∀ a b c d → PathP (λ i → PathP (λ j → inc a ≡ icoh b c d i j)
+                                          (iconst a b) (icoh a c d i))
+                             (icoh a b c) (icoh a b d)
   squash : is-hlevel ∥ A ∥⁴ 4
 
 ∥-∥⁴-rec
@@ -439,12 +440,12 @@ data ∥_∥⁴ {ℓ} (A : Type ℓ) : Type ℓ where
                                     (fconst a b) (fcoh a c d i))
                        (fcoh a b c) (fcoh a b d))
   → ∥ A ∥⁴ → B
-∥-∥⁴-rec {A = A} {B} b4 f fconst fcoh fcoh³ = go where
+∥-∥⁴-rec {A = A} {B} b4 f fconst fcoh fassoc = go where
   go : ∥ A ∥⁴ → B
   go (inc x) = f x
   go (iconst a b i) = fconst a b i
   go (icoh a b c i j) = fcoh a b c i j
-  go (icoh³ a b c d i j k) = fcoh³ a b c d i j k
+  go (iassoc a b c d i j k) = fassoc a b c d i j k
   go (squash x y a b p q r s i j k l) = b4
     (go x) (go y)
     (λ i → go (a i)) (λ i → go (b i))

--- a/src/1Lab/HIT/Truncation.lagda.md
+++ b/src/1Lab/HIT/Truncation.lagda.md
@@ -7,6 +7,7 @@ definition: |
 ```agda
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Retracts
+open import 1Lab.Path.Reasoning
 open import 1Lab.Type.Sigma
 open import 1Lab.HLevel
 open import 1Lab.Equiv
@@ -190,7 +191,7 @@ from the HoTT book. For example, a type $X$ is said _merely equivalent_
 to $Y$ if the type $\| X \equiv Y \|$ is inhabited.
 :::
 
-## Maps into Sets
+## Maps into sets
 
 The elimination principle for $\| A \|$ says that we can only use the
 $A$ inside in a way that _doesn't matter_: the motive of elimination
@@ -198,11 +199,11 @@ must be a family of propositions, so our use of $A$ must not matter in a
 very strong sense. Often, it's useful to relax this requirement
 slightly: Can we map out of $\| A \|$ using a _constant_ function?
 
-The answer is yes! However, the witness of  constancy we use must be
-very coherent indeed. In particular, we need enough coherence on top of
-a family of paths $(x\ y : A) \to f x \equiv_B f y$ to ensure that the
-[[image]] of $f$ is a proposition; Then we can map from $\| A \| \to \im
-f \to B$.
+The answer is yes, provided we're mapping into a [[set]]! In that case,
+the [[image]] of $f$ is a proposition, so that we can map from
+$\| A \| \to \im f \to B$.
+In the [next section](#maps-into-groupoids), we'll see a more general
+method for mapping into types that aren't sets.
 
 From the discussion in [1Lab.Counterexamples.Sigma], we know the
 definition of image, or more properly of $(-1)$-image:
@@ -255,10 +256,10 @@ we crucially need to use the fact that $B$ is a set so that $a = b$ is a
 proposition.
 
 ```agda
-is-constant→image-is-prop bset f f-const (a , x) (b , y) =
+is-constant→image-is-prop bset f fconst (a , x) (b , y) =
   Σ-prop-path (λ _ → squash)
     (∥-∥-elim₂ (λ _ _ → bset _ _)
-      (λ { (f*a , p) (f*b , q) → sym p ·· f-const f*a f*b ·· q }) x y)
+      (λ { (f*a , p) (f*b , q) → sym p ·· fconst f*a f*b ·· q }) x y)
 ```
 
 Using the image factorisation, we can project from a propositional
@@ -266,14 +267,192 @@ truncation onto a set using a constant map.
 
 ```agda
 ∥-∥-rec-set : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+            → is-set B
             → (f : A → B)
             → (∀ x y → f x ≡ f y)
-            → is-set B
             → ∥ A ∥ → B
-∥-∥-rec-set {A = A} {B} f f-const bset x =
+∥-∥-rec-set {A = A} {B} bset f fconst x =
   ∥-∥-elim {P = λ _ → image f}
-    (λ _ → is-constant→image-is-prop bset f f-const) (f-image f) x .fst
+    (λ _ → is-constant→image-is-prop bset f fconst) (f-image f) x .fst
 ```
+
+## Maps into groupoids
+
+We can push this idea further: as discussed in [@Kraus:2015], in general,
+functions $\| A \| \to B$ are equivalent to **coherently constant**
+functions $A \to B$. This involves an infinite tower of conditions,
+each relating to the previous one, which isn't something we can easily
+formulate in the language of type theory.
+
+However, when $B$ is an $n$-type, it is enough to ask for the first $n$
+levels of the tower. In the case of sets, we've [seen](#maps-into-sets)
+that the naïve notion of constancy is enough. We now deal with the case
+of groupoids, which requires an additional step: we ask for a function
+$f : A \to B$ equipped with a witness of constancy $\rm{const}_{x,y} :
+f x \equiv f y$ *and* a coherence $\rm{coh}_{x,y,z} : \rm{const}_{x,y}
+\bullet \rm{const}_{y,z} \equiv \rm{const}_{x,z}$.
+
+This time, we cannot hope to show that the image of $f$ is a proposition:
+the image of a map $\top \to S^1$ is $S^1$. Instead, we use the following
+higher inductive type:
+
+```agda
+data ∥_∥³ {ℓ} (A : Type ℓ) : Type ℓ where
+  inc : A → ∥ A ∥³
+  iconst : ∀ a b → inc a ≡ inc b
+  icoh : ∀ a b c → PathP (λ i → inc a ≡ iconst b c i) (iconst a b) (iconst a c)
+  squash : is-groupoid ∥ A ∥³
+```
+
+The recursion principle for this type says exactly that any
+coherently constant function into a groupoid factors through $\| A \|^3$!
+
+```agda
+∥-∥³-rec
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → is-groupoid B
+  → (f : A → B)
+  → (fconst : ∀ x y → f x ≡ f y)
+  → (∀ x y z → fconst x y ∙ fconst y z ≡ fconst x z)
+  → ∥ A ∥³ → B
+∥-∥³-rec {A = A} {B} bgrpd f fconst fcoh = go where
+  go : ∥ A ∥³ → B
+  go (inc x) = f x
+  go (iconst a b i) = fconst a b i
+  go (icoh a b c i j) = ∙→square (sym (fcoh a b c)) i j
+  go (squash x y a b p q i j k) = bgrpd
+    (go x) (go y)
+    (λ i → go (a i)) (λ i → go (b i))
+    (λ i j → go (p i j)) (λ i j → go (q i j))
+    i j k
+```
+
+All that remains to show is that $\| A \|^3$ is a proposition^[in fact, it's
+even a *propositional truncation* of $A$, in that it satisfies the same
+universal property as $\| A \|$], which mainly requires writing more elimination
+principles.
+
+<!--
+```agda
+∥-∥³-elim-set
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : ∥ A ∥³ → Type ℓ'}
+  → (∀ a → is-set (P a))
+  → (f : (a : A) → P (inc a))
+  → (∀ a b → PathP (λ i → P (iconst a b i)) (f a) (f b))
+  → ∀ a → P a
+∥-∥³-elim-set {P = P} sets f fconst = go where
+  go : ∀ a → P a
+  go (inc x) = f x
+  go (iconst a b i) = fconst a b i
+  go (icoh a b c i j) = is-set→squarep (λ i j → sets (icoh a b c i j))
+    refl (λ i → go (iconst a b i)) (λ i → go (iconst a c i)) (λ i → go (iconst b c i))
+    i j
+  go (squash x y a b p q i j k) = is-hlevel→is-hlevel-dep 2 (λ _ → is-hlevel-suc 2 (sets _))
+    (go x) (go y)
+    (λ k → go (a k)) (λ k → go (b k))
+    (λ j k → go (p j k)) (λ j k → go (q j k))
+    (squash x y a b p q) i j k
+
+∥-∥³-elim-prop
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : ∥ A ∥³ → Type ℓ'}
+  → (∀ a → is-prop (P a))
+  → (f : (a : A) → P (inc a))
+  → ∀ a → P a
+∥-∥³-elim-prop props f = ∥-∥³-elim-set (λ _ → is-hlevel-suc 1 (props _)) f
+  (λ _ _ → is-prop→pathp (λ _ → props _) _ _)
+```
+-->
+
+```agda
+∥-∥³-is-prop : ∀ {ℓ} {A : Type ℓ} → is-prop ∥ A ∥³
+∥-∥³-is-prop = is-contr-if-inhabited→is-prop $
+  ∥-∥³-elim-prop (λ _ → hlevel 1)
+    (λ a → contr (inc a) (∥-∥³-elim-set (λ _ → squash _ _) (iconst a) (icoh a)))
+```
+
+Hence we get the desired recursion principle for the usual propositional
+truncation.
+
+```agda
+∥-∥-rec-groupoid
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → is-groupoid B
+  → (f : A → B)
+  → (fconst : ∀ x y → f x ≡ f y)
+  → (∀ x y z → fconst x y ∙ fconst y z ≡ fconst x z)
+  → ∥ A ∥ → B
+∥-∥-rec-groupoid bgrpd f fconst fcoh =
+  ∥-∥³-rec bgrpd f fconst fcoh ∘ ∥-∥-rec ∥-∥³-is-prop inc
+```
+
+<details>
+<summary>
+As we hinted at above, this method generalises (externally) to $n$-types;
+we sketch the details of the next level for the curious reader.
+</summary>
+
+The next coherence involves a tetrahedron all of whose faces are $\rm{coh}$,
+or, since we're doing cubical type theory, a "cubical tetrahedron":
+
+~~~{.quiver .tall-15}
+\[\begin{tikzcd}
+	a &&& a \\
+	& b & b \\
+	& c & d \\
+	a &&& a
+	\arrow[""{name=0, anchor=center, inner sep=0}, from=3-2, to=3-3]
+	\arrow[""{name=1, anchor=center, inner sep=0}, Rightarrow, no head, from=2-2, to=2-3]
+	\arrow[""{name=2, anchor=center, inner sep=0}, from=2-3, to=3-3]
+	\arrow[from=2-2, to=3-2]
+	\arrow[from=1-4, to=2-3]
+	\arrow[""{name=3, anchor=center, inner sep=0}, from=1-1, to=2-2]
+	\arrow[Rightarrow, no head, from=1-1, to=1-4]
+	\arrow[""{name=4, anchor=center, inner sep=0}, from=4-4, to=3-3]
+	\arrow[""{name=5, anchor=center, inner sep=0}, Rightarrow, no head, from=1-4, to=4-4]
+	\arrow[""{name=6, anchor=center, inner sep=0}, from=4-1, to=3-2]
+	\arrow[Rightarrow, no head, from=4-1, to=1-1]
+	\arrow[Rightarrow, no head, from=4-1, to=4-4]
+	\arrow["{\rm{coh}_{b,c,d}}"{description}, draw=none, from=0, to=1]
+	\arrow["{\rm{coh}_{a,b,d}}"{description}, draw=none, from=2, to=5]
+	\arrow["{\rm{coh}_{a,c,d}}"{description}, draw=none, from=6, to=4]
+	\arrow["{\rm{coh}_{a,b,c}}"{description}, draw=none, from=3, to=6]
+\end{tikzcd}\]
+~~~
+
+```agda
+data ∥_∥⁴ {ℓ} (A : Type ℓ) : Type ℓ where
+  inc : A → ∥ A ∥⁴
+  iconst : ∀ a b → inc a ≡ inc b
+  icoh : ∀ a b c → PathP (λ i → inc a ≡ iconst b c i) (iconst a b) (iconst a c)
+  icoh³ : ∀ a b c d → PathP (λ i → PathP (λ j → inc a ≡ icoh b c d i j)
+                                         (iconst a b) (icoh a c d i))
+                            (icoh a b c) (icoh a b d)
+  squash : is-hlevel ∥ A ∥⁴ 4
+
+∥-∥⁴-rec
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → is-hlevel B 4
+  → (f : A → B)
+  → (fconst : ∀ a b → f a ≡ f b)
+  → (fcoh : ∀ a b c → PathP (λ i → f a ≡ fconst b c i) (fconst a b) (fconst a c))
+  → (∀ a b c d → PathP (λ i → PathP (λ j → f a ≡ fcoh b c d i j)
+                                    (fconst a b) (fcoh a c d i))
+                       (fcoh a b c) (fcoh a b d))
+  → ∥ A ∥⁴ → B
+∥-∥⁴-rec {A = A} {B} b4 f fconst fcoh fcoh³ = go where
+  go : ∥ A ∥⁴ → B
+  go (inc x) = f x
+  go (iconst a b i) = fconst a b i
+  go (icoh a b c i j) = fcoh a b c i j
+  go (icoh³ a b c d i j k) = fcoh³ a b c d i j k
+  go (squash x y a b p q r s i j k l) = b4
+    (go x) (go y)
+    (λ i → go (a i)) (λ i → go (b i))
+    (λ i j → go (p i j)) (λ i j → go (q i j))
+    (λ i j k → go (r i j k)) (λ i j k → go (s i j k))
+    i j k l
+```
+</details>
 
 <!--
 ```agda

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -191,7 +191,7 @@ module
       k (i = i1) → p
 ```
 
-This is actually part of a logical equivalence: if the equality identity
+This is actually part of an equivalence: if the equality identity
 system on $B$ (thus any identity system) can be pulled back along $f$,
 then $f$ is an embedding.
 

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -173,7 +173,7 @@ $A$.
 ```agda
 module
   _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'}
-    {R : B → B → Type ℓ''} {r : ∀ a → R a a}
+    {R : B → B → Type ℓ''} {r : ∀ b → R b b}
     (ids : is-identity-system R r)
     (f : A ↪ B)
   where
@@ -189,6 +189,20 @@ module
       k (k = i0) → ids .to-path-over p (~ k)
       k (i = i0) → ids .to-path-over p (~ k ∨ i)
       k (i = i1) → p
+```
+
+This is actually part of a logical equivalence: if the equality identity
+system on $B$ (thus any identity system) can be pulled back along $f$,
+then $f$ is an embedding.
+
+```agda
+identity-system→embedding
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → (f : A → B)
+  → is-identity-system (λ x y → f x ≡ f y) (λ _ → refl)
+  → is-embedding f
+identity-system→embedding f ids = cancellable→embedding
+  (identity-system-gives-path ids)
 ```
 
 <!--

--- a/src/Algebra/Group/Subgroup.lagda.md
+++ b/src/Algebra/Group/Subgroup.lagda.md
@@ -266,7 +266,7 @@ elide the zero composite $e' \circ 0$.
           (p : e' Groups.∘ Zero.zero→ ∅ᴳ ≡ e' Groups.∘ Kerf.kernel)
       → ∀ {x : ⌞ B ⌟} → ∥ fibre (apply f) x ∥ → _
     elim {F = F} {e' = e'} p {x} =
-      ∥-∥-rec-set ((e' #_) ⊙ fst) const (F .snd .Group-on.has-is-set) where abstract
+      ∥-∥-rec-set (F .snd .Group-on.has-is-set) ((e' #_) ⊙ fst) const where abstract
       module e' = is-group-hom (e' .preserves)
       module F = Group-on (F .snd)
 ```

--- a/src/Data/Set/Surjection.lagda.md
+++ b/src/Data/Set/Surjection.lagda.md
@@ -59,9 +59,8 @@ elimination principle for $\| f^*x \| \to F$, since $F$ is a set.
 surjective→regular-epi c d f surj .has-is-coeq = coeqs where
   go : ∀ {F} (e' : ∣ c ∣ → ∣ F ∣) p (x : ∣ d ∣) → ∥ fibre f x ∥ → ∣ F ∣
   go e' p x =
-    ∥-∥-rec-set (λ x → e' (x .fst))
+    ∥-∥-rec-set hlevel! (λ x → e' (x .fst))
       (λ x y → p $ₚ (x .fst , y .fst , x .snd ∙ sym (y .snd)))
-      hlevel!
 ```
 
 After a small amount of computation to move the witnesses of

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -146,3 +146,14 @@
   publisher = {\url{https://homotopytypetheory.org/book}},
   address =   {Institute for Advanced Study},
   year =      2013}
+
+@article{Kraus:2015,
+  doi = {10.4230/LIPICS.TYPES.2014.111},
+  url = {http://drops.dagstuhl.de/opus/volltexte/2015/5494/},
+  author = {Kraus, Nicolai},
+  keywords = {Computer Science, 000 Computer science, knowledge, general works},
+  language = {en},
+  title = {The General Universal Property of the Propositional Truncation},
+  publisher = {Schloss Dagstuhl - Leibniz-Zentrum fuer Informatik GmbH, Wadern/Saarbruecken, Germany},
+  year = {2015}
+}


### PR DESCRIPTION
# Description

Adds a proof that coherently constant maps into groupoids factor through the propositional truncation using a higher inductive type.

Also an unrelated trivial result that was itching me: `f` is an embedding if `f x ≡ f y` is an identity system.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [X] All new code blocks have "agda" as their language.

If a commit affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message with `chore:`
or include the word `NOAUTHOR` anywhere.
