### PR TITLE
Classical Propositional Logic

### DIFF
--- a/src/Algebra/Monoid/Category.lagda.md
+++ b/src/Algebra/Monoid/Category.lagda.md
@@ -127,14 +127,6 @@ We call this functor `Free`{.Agda}, since it is a [[left adjoint]] to the
 a `set`{.Agda ident=Set} into a monoid in the most efficient way.
 
 ```agda
-map-id : ∀ {ℓ} {A : Type ℓ} (xs : List A) → map (λ x → x) xs ≡ xs
-map-id [] = refl
-map-id (x ∷ xs) = ap (x ∷_) (map-id xs)
-
-map-++ : ∀ {ℓ} {x y : Type ℓ} (f : x → y) xs ys → map f (xs ++ ys) ≡ map f xs ++ map f ys
-map-++ f [] ys = refl
-map-++ f (x ∷ xs) ys = ap (f x ∷_) (map-++ f xs ys)
-
 Free : ∀ {ℓ} → Functor (Sets ℓ) (Monoids ℓ)
 Free .F₀ A = el! (List ∣ A ∣) , List-is-monoid (A .is-tr)
 ```

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -17,7 +17,7 @@ open import 1Lab.Type hiding (id ; _∘_)
 module Cat.Base where
 ```
 
-# Precategories {defines=category}
+# Precategories {defines="category precategory"}
 
 In univalent mathematics, it makes sense to distinguish two stages in
 the construction of categories: A **precategory** is the object that

--- a/src/Data/Bool.lagda.md
+++ b/src/Data/Bool.lagda.md
@@ -133,6 +133,16 @@ and-idempotent true = refl
 or-idempotent : (x : Bool) → or x x ≡ x
 or-idempotent false = refl
 or-idempotent true = refl
+
+and-distrib-orr : (x y z : Bool) → and (or x y) z ≡ or (and x z) (and y z)
+and-distrib-orr true y z =
+  sym (or-absorbs-andr z y) ∙ ap (or z) (and-commutative z y)
+and-distrib-orr false y z = refl
+
+or-distrib-andr : (x y z : Bool) → or (and x y) z ≡ and (or x z) (or y z)
+or-distrib-andr true y z = refl
+or-distrib-andr false y z =
+  sym (and-absorbs-orr z y) ∙ ap (and z) (or-commutative z y)
 ```
 
 <!--
@@ -306,6 +316,16 @@ equivalence:
 not-is-equiv : is-equiv not
 not-is-equiv = is-iso→is-equiv (iso not not-involutive not-involutive)
 ```
+
+<!--
+```agda
+not-inj : ∀ {x y} → not x ≡ not y → x ≡ y
+not-inj {x = true} {y = true} p = refl
+not-inj {x = true} {y = false} p = sym p
+not-inj {x = false} {y = true} p = sym p
+not-inj {x = false} {y = false} p = refl
+```
+-->
 
 ## Aut(Bool)
 

--- a/src/Data/Bool.lagda.md
+++ b/src/Data/Bool.lagda.md
@@ -171,6 +171,10 @@ or-reflect-false-r {x = true} {y = true} p = absurd (true≠false p)
 or-reflect-false-r {x = true} {y = false} p = refl
 or-reflect-false-r {x = false} {y = true} p = absurd (true≠false p)
 or-reflect-false-r {x = false} {y = false} p = refl
+
+and-reflect-false : ∀ {x y} → and x y ≡ false → x ≡ false ⊎ y ≡ false
+and-reflect-false {x = true} {y = y} p = inr p
+and-reflect-false {x = false} {y = y} p = inl refl
 ```
 -->
 

--- a/src/Data/Bool.lagda.md
+++ b/src/Data/Bool.lagda.md
@@ -9,6 +9,7 @@ open import 1Lab.Path
 open import 1Lab.Type
 
 open import Data.Dec.Base
+open import Data.Sum.Base
 
 open is-equiv
 open is-contr
@@ -134,6 +135,35 @@ or-idempotent false = refl
 or-idempotent true = refl
 ```
 
+<!--
+```agda
+and-reflect-true-l : ∀ {x y} → and x y ≡ true → x ≡ true
+and-reflect-true-l {x = true} p = refl
+and-reflect-true-l {x = false} p = p
+
+and-reflect-true-r : ∀ {x y} → and x y ≡ true → y ≡ true
+and-reflect-true-r {x = true} {y = true} p = refl
+and-reflect-true-r {x = false} {y = true} p = refl
+and-reflect-true-r {x = true} {y = false} p = p
+and-reflect-true-r {x = false} {y = false} p = p
+
+or-reflect-true : ∀ {x y} → or x y ≡ true → x ≡ true ⊎ y ≡ true
+or-reflect-true {x = true} {y = y} p = inl refl
+or-reflect-true {x = false} {y = true} p = inr refl
+or-reflect-true {x = false} {y = false} p = absurd (true≠false (sym p))
+
+or-reflect-false-l : ∀ {x y} → or x y ≡ false → x ≡ false
+or-reflect-false-l {x = true} p = absurd (true≠false p)
+or-reflect-false-l {x = false} p = refl
+
+or-reflect-false-r : ∀ {x y} → or x y ≡ false → y ≡ false
+or-reflect-false-r {x = true} {y = true} p = absurd (true≠false p)
+or-reflect-false-r {x = true} {y = false} p = refl
+or-reflect-false-r {x = false} {y = true} p = absurd (true≠false p)
+or-reflect-false-r {x = false} {y = false} p = refl
+```
+-->
+
 All the properties above hold both in classical and constructive mathematics, even in
 *[minimal logic][2]* that fails to validate both the law of the excluded middle as well
 as the law of noncontradiction. However, the boolean operations satisfy both of these laws:
@@ -162,6 +192,14 @@ and-complementl true = refl
 
 [1]: <https://en.wikipedia.org/wiki/Boolean_algebra_(structure)> "Boolean algebra"
 [2]: <https://en.wikipedia.org/wiki/Minimal_logic> "Minimal logic"
+
+Furthermore, note that `not` has no fixed points.
+
+```agda
+not-no-fixed : ∀ {x} → x ≡ not x → ⊥
+not-no-fixed {x = true} p = absurd (true≠false p)
+not-no-fixed {x = false} p = absurd (true≠false (sym p))
+```
 
 Exclusive disjunction (usually known as *XOR*) also yields additional structure -
 in particular, it can be viewed as an addition operator in a ring whose multiplication
@@ -213,6 +251,13 @@ imp-truer false = refl
 imp-truer true = refl
 ```
 
+Furthermore, material implication is equivalent to the classical definition.
+
+```agda
+imp-not-or : ∀ x y → or (not x) y ≡ imp x y
+imp-not-or false y = refl
+imp-not-or true y = refl
+```
 
 ## Discreteness
 

--- a/src/Data/Dec/Base.lagda.md
+++ b/src/Data/Dec/Base.lagda.md
@@ -28,6 +28,13 @@ Dec-elim
   → ∀ x → P x
 Dec-elim P f g (yes x) = f x
 Dec-elim P f g (no x)  = g x
+
+Dec-rec
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {X : Type ℓ'}
+  → (A → X)
+  → (¬ A → X)
+  → Dec A → X
+Dec-rec = Dec-elim _
 ```
 
 <!--
@@ -45,4 +52,35 @@ A type is _discrete_ if it has decidable equality.
 ```agda
 Discrete : ∀ {ℓ} → Type ℓ → Type ℓ
 Discrete A = (x y : A) → Dec (x ≡ y)
+```
+
+<!--
+```agda
+private variable
+  ℓ ℓ' : Level
+  A B : Type ℓ
+```
+-->
+
+If we can construct a pair of maps $A \to B$ and $B \to A$,
+then we can deduce decidability of $B$ from decidability of $A$.
+
+```agda
+Dec-map
+  : (A → B) → (B → A)
+  → Dec A → Dec B
+Dec-map to from (yes a) = yes (to a)
+Dec-map to from (no ¬a) = no (¬a ∘ from)
+```
+
+This lets us show the following useful lemma: if $A$ injects into a
+discrete type, then $A$ is also discrete.
+
+```agda
+Discrete-inj
+  : (f : A → B)
+  → (∀ {x y} → f x ≡ f y → x ≡ y)
+  → Discrete B → Discrete A
+Discrete-inj f inj eq? x y =
+  Dec-map inj (ap f) (eq? (f x) (f y))
 ```

--- a/src/Data/Fin/Base.lagda.md
+++ b/src/Data/Fin/Base.lagda.md
@@ -259,6 +259,24 @@ weaken-≤ : ∀ {m n} → m Nat.≤ n → Fin m → Fin n
 weaken-≤ {suc m} {suc n} m≤n fzero = fzero
 weaken-≤ {suc m} {suc n} (Nat.s≤s m≤n) (fsuc i) = fsuc (weaken-≤ m≤n i)
 
+shift-≤ : ∀ {m n} → m Nat.≤ n → Fin m → Fin n
+shift-≤ {n = suc zero} (Nat.s≤s 0≤x) i = i
+shift-≤ {n = suc (suc n)} (Nat.s≤s 0≤x) i = fsuc (shift-≤ (Nat.s≤s 0≤x) i)
+shift-≤ {n = n} (Nat.s≤s (Nat.s≤s m≤n)) fzero = weaken (shift-≤ (Nat.s≤s m≤n) fzero)
+shift-≤ {n = n} (Nat.s≤s (Nat.s≤s m≤n)) (fsuc i) = fsuc (shift-≤ (Nat.s≤s m≤n) i)
+
+split-+ : ∀ {m n} → Fin (m + n) → Fin m ⊎ Fin n
+split-+ {m = zero} i = inr i
+split-+ {m = suc m} fzero = inl fzero
+split-+ {m = suc m} (fsuc i) = ⊎-map fsuc id (split-+ i)
+
+avoid : ∀ {n} (i j : Fin (suc n)) → (¬ i ≡ j) → Fin n
+avoid {n = zero} fzero fzero i≠j = absurd (i≠j refl)
+avoid {n = suc n} fzero fzero i≠j = absurd (i≠j refl)
+avoid {n = suc n} fzero (fsuc j) i≠j = j
+avoid {n = suc n} (fsuc i) fzero i≠j = fzero
+avoid {n = suc n} (fsuc i) (fsuc j) i≠j = fsuc (avoid i j (i≠j ∘ ap fsuc))
+
 fshift : ∀ {n} (m : Nat) → Fin n → Fin (m + n)
 fshift zero i = i
 fshift (suc m) i = fsuc (fshift m i)
@@ -266,4 +284,23 @@ fshift (suc m) i = fsuc (fshift m i)
 opposite : ∀ {n} → Fin n → Fin n
 opposite {n = suc n} fzero = from-nat n
 opposite {n = suc n} (fsuc i) = weaken (opposite i)
+```
+
+## Vector Operations
+
+```agda
+_[_≔_]
+  : ∀ {ℓ} {A : Type ℓ} {n}
+  → (Fin n → A) → Fin (suc n) → A
+  → Fin (suc n) → A
+_[_≔_] {n = n} ρ fzero a fzero = a
+_[_≔_] {n = n} ρ fzero a (fsuc j) = ρ j
+_[_≔_] {n = suc n} ρ (fsuc i) a fzero = ρ fzero
+_[_≔_] {n = suc n} ρ (fsuc i) a (fsuc j) = ((ρ ∘ fsuc) [ i ≔ a ]) j
+
+delete
+  : ∀ {ℓ} {A : Type ℓ} {n}
+  → (Fin (suc n) → A) → Fin (suc n)
+  → Fin n → A
+delete ρ i j = ρ (skip i j)
 ```

--- a/src/Data/Fin/Properties.lagda.md
+++ b/src/Data/Fin/Properties.lagda.md
@@ -196,3 +196,48 @@ finite-surjection-split
   → ∥ (∀ x → fibre f x) ∥
 finite-surjection-split f = finite-choice _
 ```
+
+## Vector Operations
+
+```agda
+avoid-insert
+  : ∀ {n} {ℓ} {A : Type ℓ}
+  → (ρ : Fin n → A)
+  → (i : Fin (suc n)) (a : A)
+  → (j : Fin (suc n))
+  → (i≠j : ¬ i ≡ j)
+  → (ρ [ i ≔ a ]) j ≡ ρ (avoid i j i≠j)
+avoid-insert {n = n} ρ fzero a fzero i≠j = absurd (i≠j refl)
+avoid-insert {n = suc n} ρ fzero a (fsuc j) i≠j = refl
+avoid-insert {n = suc n} ρ (fsuc i) a fzero i≠j = refl
+avoid-insert {n = suc n} ρ (fsuc i) a (fsuc j) i≠j =
+  avoid-insert (ρ ∘ fsuc) i a j (i≠j ∘ ap fsuc)
+
+insert-lookup
+  : ∀ {n} {ℓ} {A : Type ℓ}
+  → (ρ : Fin n → A)
+  → (i : Fin (suc n)) (a : A)
+  → (ρ [ i ≔ a ]) i ≡ a
+insert-lookup {n = n} ρ fzero a = refl
+insert-lookup {n = suc n} ρ (fsuc i) a = insert-lookup (ρ ∘ fsuc) i a
+
+delete-insert
+  : ∀ {n} {ℓ} {A : Type ℓ}
+  → (ρ : Fin n → A)
+  → (i : Fin (suc n)) (a : A)
+  → ∀ j → delete (ρ [ i ≔ a ]) i j ≡ ρ j
+delete-insert ρ fzero a j = refl
+delete-insert ρ (fsuc i) a fzero = refl
+delete-insert ρ (fsuc i) a (fsuc j) = delete-insert (ρ ∘ fsuc) i a j
+
+insert-delete
+  : ∀ {n} {ℓ} {A : Type ℓ}
+  → (ρ : Fin (suc n) → A)
+  → (i : Fin (suc n)) (a : A)
+  → ρ i ≡ a
+  → ∀ j → ((delete ρ i) [ i ≔ a ]) j ≡ ρ j
+insert-delete {n = n} ρ fzero a p fzero = sym p
+insert-delete {n = n} ρ fzero a p (fsuc j) = refl
+insert-delete {n = suc n} ρ (fsuc i) a p fzero = refl
+insert-delete {n = suc n} ρ (fsuc i) a p (fsuc j) = insert-delete (ρ ∘ fsuc) i a p j
+```

--- a/src/Data/List.lagda.md
+++ b/src/Data/List.lagda.md
@@ -168,6 +168,15 @@ map-id
 map-id [] = refl
 map-id (x ∷ xs) = ap (x ∷_) (map-id xs)
 
+map-++
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → (f : A → B)
+  → (xs ys : List A)
+  → map f (xs ++ ys) ≡ map f xs ++ map f ys
+map-++ f [] ys = refl
+map-++ f (x ∷ xs) ys = ap (f x ∷_) (map-++ f xs ys)
+
+
 take-length : ∀ {ℓ} {A : Type ℓ} (xs : List A) → take (length xs) xs ≡ xs
 take-length [] = refl
 take-length (x ∷ xs) = ap (x ∷_) (take-length xs)

--- a/src/Data/List.lagda.md
+++ b/src/Data/List.lagda.md
@@ -7,8 +7,8 @@ open import 1Lab.Equiv
 open import 1Lab.Path
 open import 1Lab.Type
 
-open import Data.Sum.Base
 open import Data.Nat.Base
+open import Data.Sum.Base
 open import Data.Bool
 open import Data.Dec
 ```

--- a/src/Data/List.lagda.md
+++ b/src/Data/List.lagda.md
@@ -7,7 +7,10 @@ open import 1Lab.Equiv
 open import 1Lab.Path
 open import 1Lab.Type
 
+open import Data.Sum.Base
 open import Data.Nat.Base
+open import Data.Bool
+open import Data.Dec
 ```
 -->
 
@@ -15,6 +18,7 @@ open import Data.Nat.Base
 module Data.List where
 
 open import Data.List.Base public
+open import Data.List.Membership public
 ```
 
 # Lists
@@ -157,6 +161,12 @@ ap-∷ x≡y xs≡ys i = x≡y i ∷ xs≡ys i
 ⚠️ TODO: Explain these ⚠️
 
 ```agda
+map-id
+  : ∀ {ℓ} {A : Type ℓ}
+  → (xs : List A)
+  → map id xs ≡ xs
+map-id [] = refl
+map-id (x ∷ xs) = ap (x ∷_) (map-id xs)
 
 take-length : ∀ {ℓ} {A : Type ℓ} (xs : List A) → take (length xs) xs ≡ xs
 take-length [] = refl
@@ -177,3 +187,100 @@ instance
   decomp-list = decomp (quote ListPath.List-is-hlevel) (`level-minus 2 ∷ `search ∷ [])
 ```
 -->
+
+<!--
+```agda
+all-of-++
+  : ∀ {ℓ} {A : Type ℓ}
+  → (f : A → Bool)
+  → (xs ys : List A)
+  → all-of f (xs ++ ys) ≡ and (all-of f xs) (all-of f ys)
+all-of-++ f [] ys = refl
+all-of-++ f (x ∷ xs) ys =
+  ap (and (f x)) (all-of-++ f xs ys)
+  ∙ and-associative (f x) (all-of f xs) (all-of f ys)
+
+all-of-map
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → (f : B → Bool)
+  → (g : A → B)
+  → (xs : List A)
+  → all-of f (map g xs) ≡ all-of (f ∘ g) xs
+all-of-map f g [] = refl
+all-of-map f g (x ∷ xs) = ap (and (f (g x))) (all-of-map f g xs)
+
+any-of-++
+  : ∀ {ℓ} {A : Type ℓ}
+  → (f : A → Bool)
+  → (xs ys : List A)
+  → any-of f (xs ++ ys) ≡ or (any-of f xs) (any-of f ys)
+any-of-++ f [] ys = refl
+any-of-++ f (x ∷ xs) ys =
+  ap (or (f x)) (any-of-++ f xs ys)
+  ∙ or-associative (f x) (any-of f xs) (any-of f ys)
+
+any-of-map
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → (f : B → Bool)
+  → (g : A → B)
+  → (xs : List A)
+  → any-of f (map g xs) ≡ any-of (f ∘ g) xs
+any-of-map f g [] = refl
+any-of-map f g (x ∷ xs) = ap (or (f (g x))) (any-of-map f g xs)
+
+all-of-or
+  : ∀ {ℓ} {A : Type ℓ}
+  → (f : A → Bool)
+  → (b : Bool) (xs : List A)
+  → all-of (λ x → or b (f x)) xs ≡ or b (all-of f xs)
+all-of-or f b [] = sym (or-truer b)
+all-of-or f b (x ∷ xs) =
+  ap (and (or b (f x))) (all-of-or f b xs)
+  ∙ sym (or-distrib-andl b (f x) (all-of f xs))
+
+not-all-of
+  : ∀ {ℓ} {A : Type ℓ}
+  → (f : A → Bool)
+  → (xs : List A)
+  → not (all-of f xs) ≡ any-of (not ∘ f) xs
+not-all-of f [] = refl
+not-all-of f (x ∷ xs) =
+  not-and≡or-not (f x) (all-of f xs)
+  ∙ ap (or (not (f x))) (not-all-of f xs)
+
+not-any-of
+  : ∀ {ℓ} {A : Type ℓ}
+  → (f : A → Bool)
+  → (xs : List A)
+  → not (any-of f xs) ≡ all-of (not ∘ f) xs
+not-any-of f [] = refl
+not-any-of f (x ∷ xs) =
+  not-or≡and-not (f x) (any-of f xs)
+  ∙ ap (and (not (f x))) (not-any-of f xs)
+
+any-one-of
+  : ∀ {ℓ} {A : Type ℓ}
+  → (f : A → Bool)
+  → (x : A) (xs : List A)
+  → x ∈ₗ xs → f x ≡ true
+  → any-of f xs ≡ true
+any-one-of f x (y ∷ xs) (inl x=y) x-true =
+  ap₂ or (subst (λ e → f e ≡ true) x=y x-true) refl
+any-one-of f x (y ∷ xs) (inr x∈xs) x-true =
+  ap₂ or refl (any-one-of f x xs x∈xs x-true) ∙ or-truer _
+```
+-->
+
+```agda
+filter : ∀ {ℓ} {A : Type ℓ} → (A → Bool) → List A → List A
+filter p [] = []
+filter p (x ∷ xs) = if p x then x ∷ filter p xs else filter p xs
+
+is-empty : List A → Type
+is-empty [] = ⊤
+is-empty (_ ∷ _) = ⊥
+
+is-empty? : ∀ (xs : List A) → Dec (is-empty xs)
+is-empty? [] = yes tt
+is-empty? (x ∷ xs) = no id
+```

--- a/src/Data/List.lagda.md
+++ b/src/Data/List.lagda.md
@@ -264,9 +264,9 @@ any-one-of
   → (x : A) (xs : List A)
   → x ∈ₗ xs → f x ≡ true
   → any-of f xs ≡ true
-any-one-of f x (y ∷ xs) (inl x=y) x-true =
+any-one-of f x (y ∷ xs) (here x=y) x-true =
   ap₂ or (subst (λ e → f e ≡ true) x=y x-true) refl
-any-one-of f x (y ∷ xs) (inr x∈xs) x-true =
+any-one-of f x (y ∷ xs) (there x∈xs) x-true =
   ap₂ or refl (any-one-of f x xs x∈xs x-true) ∙ or-truer _
 ```
 -->

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -112,7 +112,10 @@ _++_ : ∀ {ℓ} {A : Type ℓ} → List A → List A → List A
 (x ∷ xs) ++ ys = x ∷ (xs ++ ys)
 
 infixr 5 _++_
+```
 
+<!--
+```agda
 mapUp : (Nat → A → B) → Nat → List A → List B
 mapUp f _ [] = []
 mapUp f n (x ∷ xs) = f n x ∷ mapUp f (suc n) xs
@@ -150,4 +153,25 @@ take : ∀ {ℓ} {A : Type ℓ} → Nat → List A → List A
 take 0 xs = []
 take (suc n) [] = []
 take (suc n) (x ∷ xs) = x ∷ take n xs
+```
+-->
+
+## Predicates
+
+We can define a function that determines if a boolean-valued
+predicate holds on every element of a list.
+
+```agda
+all-of : ∀ {ℓ} {A : Type ℓ} → (A → Bool) → List A → Bool
+all-of f [] = true
+all-of f (x ∷ xs) = and (f x) (all-of f xs)
+```
+
+Dually, we can also define a function that determines if a boolean-valued
+predicate holds on some element of a list.
+
+```
+any-of : ∀ {ℓ} {A : Type ℓ} → (A → Bool) → List A → Bool
+any-of f [] = false
+any-of f (x ∷ xs) = or (f x) (any-of f xs)
 ```

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -170,7 +170,7 @@ all-of f (x ∷ xs) = and (f x) (all-of f xs)
 Dually, we can also define a function that determines if a boolean-valued
 predicate holds on some element of a list.
 
-```
+```agda
 any-of : ∀ {ℓ} {A : Type ℓ} → (A → Bool) → List A → Bool
 any-of f [] = false
 any-of f (x ∷ xs) = or (f x) (any-of f xs)

--- a/src/Data/List/Membership.lagda.md
+++ b/src/Data/List/Membership.lagda.md
@@ -1,0 +1,41 @@
+<!--
+```agda
+open import 1Lab.Prelude
+open import Data.List.Base
+open import Data.Sum
+open import Data.Dec
+```
+-->
+
+```agda
+module Data.List.Membership where
+
+data Some {ℓ ℓ'} {A : Type ℓ} (P : A → Type ℓ') : List A → Type (ℓ ⊔ ℓ') where
+  here : ∀ {x xs} → P x → Some P (x ∷ xs)
+  there : ∀ {x xs} → Some P xs → Some P (x ∷ xs)
+
+_∈ₗ_ : ∀ {ℓ} {A : Type ℓ} → A → List A → Type ℓ
+x ∈ₗ [] = Lift _ ⊥
+x ∈ₗ (y ∷ xs) = x ≡ y ⊎ (x ∈ₗ xs)
+```
+
+<!--
+```agda
+private
+  variable
+    ℓ : Level
+    A : Type ℓ
+```
+-->
+
+```agda
+elem? : Discrete A → (x : A) → (xs : List A) → Dec (x ∈ₗ xs)
+elem? eq? x [] = no Lift.lower
+elem? eq? x (y ∷ xs) =
+  Dec-rec (yes ∘ inl)
+    (λ x≠y →
+      Dec-rec (yes ∘ inr)
+        (λ x∉xs → no [ x≠y , x∉xs ])
+        (elem? eq? x xs))
+    (eq? x y)
+```

--- a/src/Data/List/Membership.lagda.md
+++ b/src/Data/List/Membership.lagda.md
@@ -1,9 +1,10 @@
 <!--
 ```agda
 open import 1Lab.Prelude
+
 open import Data.List.Base
-open import Data.Sum
 open import Data.Dec
+open import Data.Sum
 ```
 -->
 

--- a/src/Data/List/Membership.lagda.md
+++ b/src/Data/List/Membership.lagda.md
@@ -14,7 +14,7 @@ module Data.List.Membership where
 
 ## Pointwise Predicates
 
-```
+```agda
 data Some {ℓ ℓ'} {A : Type ℓ} (P : A → Type ℓ') : List A → Type (ℓ ⊔ ℓ') where
   here : ∀ {x xs} → P x → Some P (x ∷ xs)
   there : ∀ {x xs} → Some P xs → Some P (x ∷ xs)

--- a/src/Data/Sum/Properties.lagda.md
+++ b/src/Data/Sum/Properties.lagda.md
@@ -180,18 +180,13 @@ disjoint-⊎-is-prop Ap Bp notab (inr x) (inr y) = ap inr (Bp x y)
 
 ## Decidability
 
-If `A` and `B` are [[decidable]] then so is `A ⊎ B`.
+If `A` and `B` are [[decidable]], then so is `A ⊎ B`.
 
 ```agda
 Dec-⊎ : Dec A → Dec B → Dec (A ⊎ B)
-Dec-⊎ a? b? =
-  Dec-rec
-    (yes ∘ inl)
-    (λ ¬a →
-      Dec-rec
-        (yes ∘ inr)
-        (λ ¬b → no [ ¬a , ¬b ])
-        b?)
-    a?
+Dec-⊎ (yes A) _       = yes (inl A)
+Dec-⊎ (no ¬A) (yes B) = yes (inr B)
+Dec-⊎ (no ¬A) (no ¬B) = no λ where
+  (inl A) → ¬A A
+  (inr B) → ¬B B
 ```
-

--- a/src/Data/Sum/Properties.lagda.md
+++ b/src/Data/Sum/Properties.lagda.md
@@ -10,6 +10,7 @@ open import 1Lab.Type
 
 open import Data.List.Base
 open import Data.Sum.Base
+open import Data.Dec
 ```
 -->
 
@@ -176,3 +177,21 @@ disjoint-⊎-is-prop Ap Bp notab (inl x) (inr y) = absurd (notab (x , y))
 disjoint-⊎-is-prop Ap Bp notab (inr x) (inl y) = absurd (notab (y , x))
 disjoint-⊎-is-prop Ap Bp notab (inr x) (inr y) = ap inr (Bp x y)
 ```
+
+## Decidability
+
+If `A` and `B` are [[decidable]] then so is `A ⊎ B`.
+
+```agda
+Dec-⊎ : Dec A → Dec B → Dec (A ⊎ B)
+Dec-⊎ a? b? =
+  Dec-rec
+    (yes ∘ inl)
+    (λ ¬a →
+      Dec-rec
+        (yes ∘ inr)
+        (λ ¬b → no [ ¬a , ¬b ])
+        b?)
+    a?
+```
+

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -1,10 +1,11 @@
 <!--
 ```agda
 open import 1Lab.Prelude hiding (_∈_)
-open import Data.Fin using (Fin; fzero; fsuc; weaken; inject)
-open import Data.Nat
-open import Data.List hiding (_++_)
+
 open import Data.Bool
+open import Data.Fin using (Fin; fzero; fsuc; weaken; inject)
+open import Data.List hiding (_++_)
+open import Data.Nat
 open import Data.Sum
 
 open import Meta.Brackets
@@ -337,4 +338,16 @@ sound (¬-elim {P = P} p q) ρ hyps-true =
   absurd $ not-no-fixed (sound q ρ hyps-true ∙ sym (sound p ρ hyps-true))
 sound (dneg-elim {P = P} p) ρ hyps-true =
   sym (not-involutive (⟦ P ⟧ ρ)) ∙ sound p ρ hyps-true
+```
+
+## Satisfiability
+
+```agda
+is-satisfiable : Proposition Γ → Type _
+is-satisfiable {Γ = Γ} P = Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ P ⟧ ρ ≡ true)
+
+equisat : Proposition Γ → Proposition Δ → Type _
+equisat P Q =
+  (is-satisfiable P → is-satisfiable Q) ×
+  (is-satisfiable Q → is-satisfiable P)
 ```

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -27,12 +27,10 @@ the following indexed inductive type.
 
 ```agda
 data Proposition (Γ : Nat) : Type where
-  atom : Fin Γ → Proposition Γ
-  “⊤” : Proposition Γ
-  “⊥” : Proposition Γ
-  _“∧”_ : Proposition Γ → Proposition Γ → Proposition Γ
-  _“∨”_ : Proposition Γ → Proposition Γ → Proposition Γ
-  “¬”_ : Proposition Γ → Proposition Γ
+  atom        : Fin Γ → Proposition Γ
+  “⊤” “⊥”     : Proposition Γ
+  _“∧”_ _“∨”_ : Proposition Γ → Proposition Γ → Proposition Γ
+  “¬”_        : Proposition Γ → Proposition Γ
 ```
 
 We represent atomic propositions as elements of `Fin`{.Agda},
@@ -43,7 +41,7 @@ Next, we introduce contexts; these are simply lists of propositions.
 
 ```agda
 data Ctx (Γ : Nat) : Type where
-  [] : Ctx Γ
+  []  : Ctx Γ
   _⨾_ : Ctx Γ → Proposition Γ → Ctx Γ
 
 _++_ : ∀ {Γ} → Ctx Γ → Ctx Γ → Ctx Γ
@@ -55,7 +53,7 @@ We also define a membership relation for contexts.
 
 ```agda
 data _∈_ {Γ : Nat} (P : Proposition Γ) : Ctx Γ → Type where
-  here : ∀ {ψ} → P ∈ (ψ ⨾ P)
+  here  : ∀ {ψ} → P ∈ (ψ ⨾ P)
   there : ∀ {ψ Q} → P ∈ ψ → P ∈ (ψ ⨾ Q)
 ```
 
@@ -90,13 +88,13 @@ for "false".
 
 ```agda
   ⊤-intro : ψ ⊢ “⊤”
-  ⊥-elim : ∀ {P} → ψ ⊢ “⊥” → ψ ⊢ P
+  ⊥-elim  : ∀ {P} → ψ ⊢ “⊥” → ψ ⊢ P
 ```
 
 The rules for "and" are more or less what one would expect.
 
 ```agda
-  ∧-intro : ∀ {P Q} → ψ ⊢ P → ψ ⊢ Q → ψ ⊢ P “∧” Q
+  ∧-intro  : ∀ {P Q} → ψ ⊢ P → ψ ⊢ Q → ψ ⊢ P “∧” Q
   ∧-elim-l : ∀ {P Q} → ψ ⊢ P “∧” Q → ψ ⊢ P
   ∧-elim-r : ∀ {P Q} → ψ ⊢ P “∧” Q → ψ ⊢ Q
 ```
@@ -105,9 +103,9 @@ However, "or" is a bit trickier, as we need to add things to our
 hypotheses in the elimination rule.
 
 ```agda
-  ∨-intro-l : ∀ {P Q} → ψ ⊢ P → ψ ⊢ P “∨” Q
-  ∨-intro-r : ∀ {P Q} → ψ ⊢ Q → ψ ⊢ P “∨” Q
-  ∨-elim : ∀ {P Q R} → ψ ⊢ P “∨” Q → ψ ⨾ P ⊢ R → ψ ⨾ Q ⊢ R → ψ ⊢ R
+  ∨-intro-l : ∀ {P Q}   → ψ ⊢ P → ψ ⊢ P “∨” Q
+  ∨-intro-r : ∀ {P Q}   → ψ ⊢ Q → ψ ⊢ P “∨” Q
+  ∨-elim    : ∀ {P Q R} → ψ ⊢ P “∨” Q → ψ ⨾ P ⊢ R → ψ ⨾ Q ⊢ R → ψ ⊢ R
 ```
 
 Finally, we add the rules for negation. To ensure that we
@@ -115,8 +113,8 @@ are working with classical logic, we add a rule for double-negation
 elimination.
 
 ```agda
-  ¬-intro : ∀ {P} → ψ ⨾ P ⊢ “⊥” → ψ ⊢ “¬” P
-  ¬-elim : ∀ {P} → ψ ⊢ “¬” P → ψ ⊢ P → ψ ⊢ “⊥”
+  ¬-intro   : ∀ {P} → ψ ⨾ P ⊢ “⊥” → ψ ⊢ “¬” P
+  ¬-elim    : ∀ {P} → ψ ⊢ “¬” P → ψ ⊢ P → ψ ⊢ “⊥”
   dneg-elim : ∀ {P} → ψ ⊢ “¬” (“¬” P) → ψ ⊢ P
 ```
 
@@ -143,8 +141,9 @@ data Weakening (Γ : Nat) : Nat → Type where
 ```
 
 <details>
-<summary>We omit the details of weakening, as it is more or less
-boilerplate.
+<summary>
+We omit the implementation of applying weakenings to the syntactic
+types, since it's pretty much mechanical.
 </summary>
 
 ```agda
@@ -152,102 +151,102 @@ boilerplate.
 ¬weaken-suc-zero (weak σ) = ¬weaken-suc-zero σ
 
 wk-suc : Weakening Γ Δ → Weakening Γ (suc Δ)
-wk-suc done = weak done
+wk-suc done     = weak done
 wk-suc (weak σ) = weak (wk-suc σ)
 
 !wk : Weakening 0 Γ
-!wk {Γ = zero} = done
+!wk {Γ = zero}  = done
 !wk {Γ = suc Γ} = wk-suc !wk
 
 inc-prop : Proposition Γ → Proposition (suc Γ)
-inc-prop (atom x) = atom (weaken x)
-inc-prop “⊤” = “⊤”
-inc-prop “⊥” = “⊥”
+inc-prop (atom x)  = atom (weaken x)
+inc-prop “⊤”       = “⊤”
+inc-prop “⊥”       = “⊥”
 inc-prop (p “∧” q) = inc-prop p “∧” inc-prop q
 inc-prop (p “∨” q) = inc-prop p “∨” inc-prop q
-inc-prop (“¬” p) = “¬” (inc-prop p)
+inc-prop (“¬” p)   = “¬” (inc-prop p)
 
 inc-ctx : Ctx Γ → Ctx (suc Γ)
-inc-ctx [] = []
+inc-ctx []      = []
 inc-ctx (ψ ⨾ P) = inc-ctx ψ ⨾ inc-prop P
 
 inc-atom : P ∈ ψ → inc-prop P ∈ inc-ctx ψ
-inc-atom here = here
+inc-atom here      = here
 inc-atom (there x) = there (inc-atom x)
 
 inc-proof : ψ ⊢ P → inc-ctx ψ ⊢ inc-prop P
-inc-proof (hyp x) = hyp (inc-atom  x)
-inc-proof ⊤-intro = ⊤-intro
-inc-proof (⊥-elim p) = ⊥-elim (inc-proof p)
-inc-proof (∧-intro p q) = ∧-intro (inc-proof p) (inc-proof q)
-inc-proof (∧-elim-l p) = ∧-elim-l (inc-proof p)
-inc-proof (∧-elim-r p) = ∧-elim-r (inc-proof p)
-inc-proof (∨-intro-l p) = ∨-intro-l (inc-proof p)
-inc-proof (∨-intro-r p) = ∨-intro-r (inc-proof p)
+inc-proof (hyp x)        = hyp (inc-atom  x)
+inc-proof ⊤-intro        = ⊤-intro
+inc-proof (⊥-elim p)     = ⊥-elim (inc-proof p)
+inc-proof (∧-intro p q)  = ∧-intro (inc-proof p) (inc-proof q)
+inc-proof (∧-elim-l p)   = ∧-elim-l (inc-proof p)
+inc-proof (∧-elim-r p)   = ∧-elim-r (inc-proof p)
+inc-proof (∨-intro-l p)  = ∨-intro-l (inc-proof p)
+inc-proof (∨-intro-r p)  = ∨-intro-r (inc-proof p)
 inc-proof (∨-elim p q r) = ∨-elim (inc-proof p) (inc-proof q) (inc-proof r)
-inc-proof (¬-intro p) = ¬-intro (inc-proof p)
-inc-proof (¬-elim p q) = ¬-elim (inc-proof p) (inc-proof q)
-inc-proof (dneg-elim p) = dneg-elim (inc-proof p)
+inc-proof (¬-intro p)    = ¬-intro (inc-proof p)
+inc-proof (¬-elim p q)   = ¬-elim (inc-proof p) (inc-proof q)
+inc-proof (dneg-elim p)  = dneg-elim (inc-proof p)
 
 bump-prop : Proposition Γ → Proposition (suc Γ)
-bump-prop (atom x) = atom (fsuc x)
-bump-prop “⊤” = “⊤”
-bump-prop “⊥” = “⊥”
+bump-prop (atom x)  = atom (fsuc x)
+bump-prop “⊤”       = “⊤”
+bump-prop “⊥”       = “⊥”
 bump-prop (p “∧” q) = bump-prop p “∧” bump-prop q
 bump-prop (p “∨” q) = bump-prop p “∨” bump-prop q
-bump-prop (“¬” p) = “¬” bump-prop p
+bump-prop (“¬” p)   = “¬” bump-prop p
 
 bump-ctx : Ctx Γ → Ctx (suc Γ)
-bump-ctx [] = []
+bump-ctx []      = []
 bump-ctx (ψ ⨾ P) = bump-ctx ψ ⨾ bump-prop P
 
 bump-atom : P ∈ ψ → bump-prop P ∈ bump-ctx ψ
-bump-atom here = here
+bump-atom here      = here
 bump-atom (there p) = there (bump-atom p)
 
 bump-proof : ψ ⊢ P → bump-ctx ψ ⊢ bump-prop P
-bump-proof (hyp x) = hyp (bump-atom x)
-bump-proof ⊤-intro = ⊤-intro
-bump-proof (⊥-elim p) = ⊥-elim (bump-proof p)
-bump-proof (∧-intro p q) = ∧-intro (bump-proof p) (bump-proof q)
-bump-proof (∧-elim-l p) = ∧-elim-l (bump-proof p)
-bump-proof (∧-elim-r p) = ∧-elim-r (bump-proof p)
-bump-proof (∨-intro-l p) = ∨-intro-l (bump-proof p)
-bump-proof (∨-intro-r p) = ∨-intro-r (bump-proof p)
+bump-proof (hyp x)        = hyp (bump-atom x)
+bump-proof ⊤-intro        = ⊤-intro
+bump-proof (⊥-elim p)     = ⊥-elim (bump-proof p)
+bump-proof (∧-intro p q)  = ∧-intro (bump-proof p) (bump-proof q)
+bump-proof (∧-elim-l p)   = ∧-elim-l (bump-proof p)
+bump-proof (∧-elim-r p)   = ∧-elim-r (bump-proof p)
+bump-proof (∨-intro-l p)  = ∨-intro-l (bump-proof p)
+bump-proof (∨-intro-r p)  = ∨-intro-r (bump-proof p)
 bump-proof (∨-elim p q r) = ∨-elim (bump-proof p) (bump-proof q) (bump-proof r)
-bump-proof (¬-intro p) = ¬-intro (bump-proof p)
-bump-proof (¬-elim p q) = ¬-elim (bump-proof p) (bump-proof q)
-bump-proof (dneg-elim p) = dneg-elim (bump-proof p)
+bump-proof (¬-intro p)    = ¬-intro (bump-proof p)
+bump-proof (¬-elim p q)   = ¬-elim (bump-proof p) (bump-proof q)
+bump-proof (dneg-elim p)  = dneg-elim (bump-proof p)
 
 wk-atom : Weakening Γ Δ → Fin Γ → Fin Δ
-wk-atom done x = x
+wk-atom done     x = x
 wk-atom (weak σ) x = wk-atom σ (weaken x)
 
 wk-prop : Weakening Γ Δ → Proposition Γ → Proposition Δ
-wk-prop done P = P
+wk-prop done     P = P
 wk-prop (weak σ) P = wk-prop σ (inc-prop P)
 
 wk-ctx : Weakening Γ Δ → Ctx Γ → Ctx Δ
-wk-ctx done ψ = ψ
+wk-ctx done     ψ = ψ
 wk-ctx (weak σ) ψ = wk-ctx σ (inc-ctx ψ)
 
 wk-proof : (σ : Weakening Γ Δ) → ψ ⊢ P → wk-ctx σ ψ ⊢ wk-prop σ P
-wk-proof done pf = pf
+wk-proof done     pf = pf
 wk-proof (weak σ) pf = wk-proof σ (inc-proof pf)
 
 shift-atom : Weakening Γ Δ → Fin Γ → Fin Δ
-shift-atom done i = i
+shift-atom done     i = i
 shift-atom (weak σ) i = shift-atom σ (fsuc i)
 
 shift-prop : Weakening Γ Δ → Proposition Γ → Proposition Δ
-shift-prop done p = p
+shift-prop done     p = p
 shift-prop (weak σ) p = shift-prop σ (bump-prop p)
 
 shift-ctx : Weakening Γ Δ → Ctx Γ → Ctx Δ
-shift-ctx done ψ = ψ
+shift-ctx done     ψ = ψ
 shift-ctx (weak σ) ψ = shift-ctx σ (bump-ctx ψ)
 
-shift-ctx-[] 
+shift-ctx-[]
   : (σ : Weakening Γ Δ)
   → shift-ctx σ [] ≡ []
 shift-ctx-[] done = refl
@@ -257,14 +256,14 @@ shift-ctx-⨾
   : (σ : Weakening Γ Δ)
   → (ψ : Ctx Γ) (P : Proposition Γ)
   → shift-ctx σ (ψ ⨾ P) ≡ shift-ctx σ ψ ⨾ shift-prop σ P
-shift-ctx-⨾ done ψ P = refl
+shift-ctx-⨾ done     ψ P = refl
 shift-ctx-⨾ (weak σ) ψ P = shift-ctx-⨾ σ (bump-ctx ψ) (bump-prop P)
 
 shift-prop-“¬”
   : (σ : Weakening Γ Δ)
   → (P : Proposition Γ)
   → shift-prop σ (“¬” P) ≡ “¬” (shift-prop σ P)
-shift-prop-“¬” done P = refl
+shift-prop-“¬” done     P = refl
 shift-prop-“¬” (weak σ) P = shift-prop-“¬” σ (bump-prop P)
 ```
 </details>
@@ -293,9 +292,9 @@ idrn : Rename ψ ψ
 idrn {ψ = []} = done
 idrn {ψ = ψ ⨾ P} = keep (idrn {ψ = ψ})
 
-_∘rn_ : Rename θ ζ → Rename ψ θ → Rename ψ ζ 
-p ∘rn done = p
-p ∘rn drop q = drop (p ∘rn q)
+_∘rn_ : Rename θ ζ → Rename ψ θ → Rename ψ ζ
+p      ∘rn done   = p
+p      ∘rn drop q = drop (p ∘rn q)
 drop p ∘rn keep q = drop (p ∘rn q)
 keep p ∘rn keep q = keep (p ∘rn q)
 ```
@@ -307,15 +306,15 @@ and maps out of the [[product]], resp.
 
 ```agda
 !rn : Rename ψ []
-!rn {ψ = []} = done
+!rn {ψ = []}    = done
 !rn {ψ = ψ ⨾ x} = drop !rn
 
 π₁-rn : Rename (ψ ++ θ) ψ
-π₁-rn {θ = []} = idrn
+π₁-rn {θ = []}    = idrn
 π₁-rn {θ = θ ⨾ P} = drop π₁-rn
 
 π₂-rn : Rename (ψ ++ θ) θ
-π₂-rn {θ = []} = !rn
+π₂-rn {θ = []}    = !rn
 π₂-rn {θ = θ ⨾ P} = keep π₂-rn
 ```
 
@@ -325,23 +324,24 @@ contexts.
 
 ```agda
 rename-hyp : Rename ψ θ → P ∈ θ → P ∈ ψ
-rename-hyp (drop rn) mem = there (rename-hyp rn mem)
-rename-hyp (keep rn) here = here
+rename-hyp (drop rn) mem         = there (rename-hyp rn mem)
+rename-hyp (keep rn) here        = here
 rename-hyp (keep rn) (there mem) = there (rename-hyp rn mem)
 
 rename : Rename ψ θ → θ ⊢ P → ψ ⊢ P
-rename rn (hyp x) = hyp (rename-hyp rn x)
-rename rn ⊤-intro = ⊤-intro
-rename rn (⊥-elim p) = ⊥-elim (rename rn p)
-rename rn (∧-intro p q) = ∧-intro (rename rn p) (rename rn q)
-rename rn (∧-elim-l p) = ∧-elim-l (rename rn p)
-rename rn (∧-elim-r p) = ∧-elim-r (rename rn p)
-rename rn (∨-intro-l p) = ∨-intro-l (rename rn p)
-rename rn (∨-intro-r p) = ∨-intro-r (rename rn p)
-rename rn (∨-elim p q r) = ∨-elim (rename rn p) (rename (keep rn) q) (rename (keep rn) r)
-rename rn (¬-intro p) = ¬-intro (rename (keep rn) p)
-rename rn (¬-elim p q) = ¬-elim (rename rn p) (rename rn q)
-rename rn (dneg-elim p) = dneg-elim (rename rn p)
+rename rn (hyp x)        = hyp (rename-hyp rn x)
+rename rn ⊤-intro        = ⊤-intro
+rename rn (⊥-elim p)     = ⊥-elim (rename rn p)
+rename rn (∧-intro p q)  = ∧-intro (rename rn p) (rename rn q)
+rename rn (∧-elim-l p)   = ∧-elim-l (rename rn p)
+rename rn (∧-elim-r p)   = ∧-elim-r (rename rn p)
+rename rn (∨-intro-l p)  = ∨-intro-l (rename rn p)
+rename rn (∨-intro-r p)  = ∨-intro-r (rename rn p)
+rename rn (∨-elim p q r) = ∨-elim
+  (rename rn p) (rename (keep rn) q) (rename (keep rn) r)
+rename rn (¬-intro p)    = ¬-intro (rename (keep rn) p)
+rename rn (¬-elim p q)   = ¬-elim (rename rn p) (rename rn q)
+rename rn (dneg-elim p)  = dneg-elim (rename rn p)
 ```
 
 ## Some Elementary Theorems
@@ -352,16 +352,16 @@ to some theorems. First, note that we can prove the law of excluded middle.
 ```agda
 lem : ∀ {Γ} {ψ : Ctx Γ} (P : Proposition Γ) → ψ ⊢ P “∨” (“¬” P)
 lem P =
-  dneg-elim $
-  ¬-intro $
-  ¬-elim (hyp here) $
-  ∨-intro-r $
-  ¬-intro $
+  dneg-elim                 $
+  ¬-intro                   $
+  ¬-elim (hyp here)         $
+  ∨-intro-r                 $
+  ¬-intro                   $
   ¬-elim (hyp (there here)) $
   ∨-intro-l (hyp here)
 ```
 
-We also have all four DeMorgan laws.
+We also have all four De Morgan laws.
 
 ```agda
 dneg-intro : ψ ⊢ P → ψ ⊢ “¬” (“¬” P)
@@ -399,15 +399,14 @@ rules for implications are theorems.
 opaque
   _“⇒”_ : ∀ {Γ} → Proposition Γ → Proposition Γ → Proposition Γ
   P “⇒” Q = (“¬” P) “∨” Q
-  
+
   ⇒-intro : ψ ⨾ P ⊢ Q → ψ ⊢ P “⇒” Q
   ⇒-intro {P = P} pf = ∨-elim (lem P) (∨-intro-r pf) (∨-intro-l (hyp here))
-  
+
   ⇒-elim : ψ ⊢ P “⇒” Q → ψ ⊢ P → ψ ⊢ Q
-  ⇒-elim {Q = Q} imp p =
-    ∨-elim imp
-      (⊥-elim (¬-elim (hyp here) (rename (drop idrn) p)))
-      (hyp here)
+  ⇒-elim {Q = Q} imp p = ∨-elim imp
+    (⊥-elim (¬-elim (hyp here) (rename (drop idrn) p)))
+    (hyp here)
 ```
 
 We also prove some helpful extra lemmas regarding implications.
@@ -429,15 +428,15 @@ propositions.
 
 ```agda
 “⋀” : Ctx Γ → Proposition Γ
-“⋀” [] = “⊤”
+“⋀” []      = “⊤”
 “⋀” (ψ ⨾ P) = “⋀” ψ “∧” P
 
-⋀-intro : (∀ {P} → P ∈ ψ → θ ⊢ P) → θ ⊢ “⋀” ψ  
-⋀-intro {ψ = []} pfs = ⊤-intro
+⋀-intro : (∀ {P} → P ∈ ψ → θ ⊢ P) → θ ⊢ “⋀” ψ
+⋀-intro {ψ = []}    pfs = ⊤-intro
 ⋀-intro {ψ = ψ ⨾ P} pfs = ∧-intro (⋀-intro (pfs ∘ there)) (pfs here)
 
 ⋀-elim : P ∈ ψ → θ ⊢ “⋀” ψ → θ ⊢ P
-⋀-elim here p = ∧-elim-r p
+⋀-elim here      p = ∧-elim-r p
 ⋀-elim (there x) p = ⋀-elim x (∧-elim-l p)
 ```
 
@@ -445,15 +444,15 @@ We can also define an n-ary implication connective.
 
 ```agda
 _“⇛”_ : Ctx Γ → Proposition Γ → Proposition Γ
-[] “⇛” P = P
+[]      “⇛” P = P
 (ψ ⨾ Q) “⇛” P = ψ “⇛” (Q “⇒” P)
 
 ⇛-intro : θ ++ ψ ⊢ P → θ ⊢ ψ “⇛” P
-⇛-intro {ψ = []} p = p
+⇛-intro {ψ = []}    p = p
 ⇛-intro {ψ = ψ ⨾ Q} p = ⇛-intro (⇒-intro p)
 
 ⇛-uncurry : θ ⊢ ψ “⇛” P → θ ++ ψ ⊢ P
-⇛-uncurry {ψ = []} p = p
+⇛-uncurry {ψ = []}    p = p
 ⇛-uncurry {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-uncurry p)
 
 ⇛-elim : θ ⊢ (ψ ⨾ P) “⇛” Q → θ ⊢ P → θ ⊢ ψ “⇛” Q
@@ -462,31 +461,35 @@ _“⇛”_ : Ctx Γ → Proposition Γ → Proposition Γ
 
 ## Semantics
 
-The most obvious way to interpret classical logic is as operations
-on booleans.
+The most obvious way to interpret classical logic is as operations on
+booleans.
 
 ```agda
 sem-prop : ∀ {Γ} → Proposition Γ → (Fin Γ → Bool) → Bool
-sem-prop (atom x) ρ = ρ x
-sem-prop “⊤” ρ = true
-sem-prop “⊥” ρ = false
+sem-prop (atom x)  ρ = ρ x
+sem-prop “⊤”       ρ = true
+sem-prop “⊥”       ρ = false
 sem-prop (P “∧” Q) ρ = and (sem-prop P ρ) (sem-prop Q ρ)
 sem-prop (P “∨” Q) ρ = or (sem-prop P ρ) (sem-prop Q ρ)
-sem-prop (“¬” P) ρ = not (sem-prop P ρ)
+sem-prop (“¬” P)   ρ = not (sem-prop P ρ)
 
 sem-ctx : ∀ {Γ} → Ctx Γ → (Fin Γ → Bool) → Bool
 sem-ctx ψ ρ = sem-prop (“⋀” ψ) ρ
+```
 
+<!--
+```agda
 instance
   ⟦⟧-Proposition : ∀ {Γ} → ⟦⟧-notation (Proposition Γ)
   ⟦⟧-Proposition {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) sem-prop
 
   ⟦⟧-Ctx : ∀ {Γ} → ⟦⟧-notation (Ctx Γ)
   ⟦⟧-Ctx {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) sem-ctx
-```
 
-<!--
-```agda
+  Number-Proposition : ∀ {Γ} → Number (Proposition Γ)
+  Number-Proposition {Γ} .Number.Constraint k = k Data.Nat.< Γ
+  Number-Proposition .Number.fromNat n        = atom (fromNat n)
+
 opaque
   unfolding _“⇒”_
   ⇒-sem
@@ -497,9 +500,9 @@ opaque
 ```
 -->
 
-We also define a notion of semantic entailment, wherein `ψ`
-semantically entails `P` when for every assigment of variables
-`ρ`, if `⟦ ψ ⟧ ρ ≡ true`, then `⟦ P ⟧ ρ ≡ true`.
+We also define a notion of semantic entailment, wherein `ψ` semantically
+entails `P` when for every assigment of variables `ρ`, if `⟦ ψ ⟧ ρ ≡
+true`, then `⟦ P ⟧ ρ ≡ true`.
 
 ```agda
 _⊨_ : ∀ {Γ} → Ctx Γ → Proposition Γ → Type
@@ -509,43 +512,48 @@ _⊨_ {Γ} ψ P = ∀ (ρ : Fin Γ → Bool) → ⟦ ψ ⟧ ρ ≡ true → ⟦ 
 ## Soundness
 
 Soundness is something that is often poorly explained in classical logic.
-The "normal" definition goes something like this: a logic is sound
-if every provable theorem `ψ ⊢ P` is true. This definition obscures
+
+The traditional definition goes something like this: a logic is sound if
+every _provable_ theorem `ψ ⊢ P` is _true_. This definition obscures
 what is really going on: what we care about is that a provable theorem
-`ψ ⊢ P` is true **in some semantics**. For classical propositional logic,
-it just so happens that we only care about one semantics[^1] (the booleans),
-so authors often conflate "true" with "true in this particular semantics".
+`ψ ⊢ P` is true **in some semantics**.
 
-[^1]: We will see why this is the case in just a bit!
+For classical propositional logic, it _happens to be the case_ that we
+can focus our attention on one semantics (the booleans) --- we'll see
+ahead why this is the case --- so authors often conflate "true" with
+"true _in this particular semantics_".
 
-The actual statement of soundness that we will be using is the following:
-if `ψ ⊢ P` is provable, then we have the semantic entailment `ψ ⊨ P`.
-This follows by a rather easy induction on proof trees.
+The actual statement of soundness that we will be using is the
+following: if `ψ ⊢ P` is provable, then we have the semantic entailment
+`ψ ⊨ P`. This follows by induction on the proof trees, and it's mostly
+mechanical.
 
 ```agda
 hyp-sound : ∀ {Γ} {ψ : Ctx Γ} {P : Proposition Γ} → P ∈ ψ → ψ ⊨ P
-hyp-sound here ρ hyps-true = and-reflect-true-r hyps-true
+hyp-sound here      ρ hyps-true = and-reflect-true-r hyps-true
 hyp-sound (there m) ρ hyps-true = hyp-sound m ρ (and-reflect-true-l hyps-true)
 
 sound : ψ ⊢ P → ψ ⊨ P
-sound (hyp x) ρ hyps-true = hyp-sound x ρ hyps-true
-sound ⊤-intro ρ hyps-true = refl
+sound (hyp x)    ρ hyps-true = hyp-sound x ρ hyps-true
+sound ⊤-intro    ρ hyps-true = refl
 sound (⊥-elim p) ρ hyps-true =
   absurd (true≠false (sym (sound p ρ hyps-true)))
+
 sound (∧-intro p q) ρ hyps-true =
   ap₂ and (sound p ρ hyps-true) (sound q ρ hyps-true)
 sound (∧-elim-l p) ρ hyps-true =
   and-reflect-true-l (sound p ρ hyps-true)
 sound (∧-elim-r p) ρ hyps-true =
   and-reflect-true-r (sound p ρ hyps-true)
+
 sound (∨-intro-l p) ρ hyps-true =
   ap₂ or (sound p ρ hyps-true) refl
 sound (∨-intro-r p) ρ hyps-true =
   ap₂ or refl (sound p ρ hyps-true) ∙ or-truer _
-sound (∨-elim p q r) ρ hyps-true =
-  [ (λ P-true → sound q ρ (ap₂ and hyps-true P-true))
-  , (λ Q-true → sound r ρ (ap₂ and hyps-true Q-true))
-  ] (or-reflect-true (sound p ρ hyps-true))
+sound (∨-elim p q r) ρ hyps-true with or-reflect-true (sound p ρ hyps-true)
+... | inl P-true = sound q ρ (ap₂ and hyps-true P-true)
+... | inr Q-true = sound r ρ (ap₂ and hyps-true Q-true)
+
 sound (¬-intro {P = P} p) ρ hyps-true =
   Bool-elim (λ b → ⟦ P ⟧ ρ ≡ b → not b ≡ true)
     (λ P-true → sound p ρ (ap₂ and hyps-true P-true))
@@ -560,47 +568,48 @@ sound (dneg-elim {P = P} p) ρ hyps-true =
 ## Completeness
 
 As mentioned earlier, we often think of classical propositional logic as
-having a **single** semantics. This is largely due to the fact that
-if `ψ` semantically entails `P` in the booleans, then we can prove that
-`ψ ⊢ P`! In other words, classical propositional logic is **complete**.
+having a *single* semantics. This is largely justified by to the fact
+that if `ψ` semantically entails `P` in the booleans, then we can prove
+that `ψ ⊢ P`! In other words, the Boolean semantics for classical
+propositional logic is **complete**.
 
-This somewhat miraculous is often taken for granted. Completeness
-is why truth-tables are a valid form of reasoning, yet this is rarely
-mentioned when teaching logic. As we shall soon see, this is not exactly
-a trivial theorem.
+This somewhat miraculous theorem is often taken for granted.
+Completeness is why truth-tables are a valid form of reasoning, but this
+is hardly ever mentioned when teaching logic. As we shall soon see, this
+theorem isn't exactly trivial, either.
 
-First, let us lay out our general proof strategy. We shall start
-by building a context $\hat{\rho}$ from an assignment $\rho$ that contains only
-(potentially negated) atoms. If $\rho$ assigns `true` to an atom $x$, we will
-add $x$ to $\hat{\rho}$. Conversely, if $\rho$ assigns false to $x$, we
-add $\neg x$ to $\hat{\rho}$.
+First, let us lay out our general proof strategy. We shall start by
+building a context $\hat{\rho}$ from an assignment $\rho$ that contains
+only (potentially negated) atoms. If $\rho$ assigns `true` to an atom
+$x$, we will add $x$ to $\hat{\rho}$. Conversely, if $\rho$ assigns
+false to $x$, we add $\neg x$ to $\hat{\rho}$.
 
-We will then show that for any assignment $\rho$, if
-$\llbracket P \rrbracket \rho$ is true, then $\hat{\rho} \vdash P$;
-likewise, if $\llbracket P \rrbracket \rho$ is false, then
-$\hat{\rho} \vdash \neg P$.
+We will then show that for any assignment $\rho$, if $\sem{P} \rho$ is
+true, then $\hat{\rho} \vdash P$; likewise, if $\sem{P} \rho$ is false,
+then $\hat{\rho} \vdash \neg P$.
 
 From this fact, we can deduce that $\vDash P$ entails $\vdash P$ by
-repeatedly applying excluded middle on every single atom in $P$, and
+repeatedly applying excluded middle to every single atom in $P$, and
 applying our previous lemmas when we are done. Finally, we can transform
-any sequent $\psi \vdash P$ into an equivalent sequent in a closed context
-by repeatedly introducing functions, which lets us apply the argument
-involving excluded middle.
+any sequent $\psi \vdash P$ into an equivalent sequent in a closed
+context by repeatedly introducing implications, which lets us apply the
+argument involving excluded middle.
 
-With that sketch out of the way, let's dive into the details!
-First, we define a function `tabulate` that forms a context from an assignment;
+With that sketch out of the way, let's dive into the details!  First, we
+define a function `tabulate` that forms a context from an assignment;
 this is the $\hat{\rho}$ from the proof sketch. Some variable munging is
-required to make Agda happy, but it is more or less what one would expect.
+required to make Agda happy, but it is more or less what one would
+expect.
 
 ```agda
 tabulate : (Fin Γ → Bool) → Ctx Γ
-tabulate {Γ = zero} ρ = []
+tabulate {Γ = zero}  ρ = []
 tabulate {Γ = suc Γ} ρ =
-  bump-ctx (tabulate (ρ ∘ fsuc)) ⨾ (if ρ 0 then atom 0 else “¬” atom 0)
+  bump-ctx (tabulate (ρ ∘ fsuc)) ⨾ (if ρ 0 then 0 else “¬” 0)
 ```
 
-Next, some small helper lemmas that let us link assignments of atoms
-to proofs of those atoms. Essentially, these state that if $\rho x$
+Next, some small helper lemmas that let us link assignments of atoms and
+proofs of those atoms. Essentially, these state that if $\rho(x)$
 assigns a truth value to $x$, then we should be able to prove this under
 the assumptions $\hat{\rho}$.
 
@@ -611,7 +620,7 @@ tabulate-atom-true
   → ρ x ≡ true
   → tabulate ρ ⊢ atom x
 tabulate-atom-true {Γ = suc Γ} fzero ρ x-true with ρ 0
-... | true = hyp here
+... | true  = hyp here
 ... | false = absurd (true≠false $ sym x-true)
 tabulate-atom-true {Γ = suc Γ} (fsuc x) ρ x-true =
   rename (drop idrn) (bump-proof (tabulate-atom-true x (ρ ∘ fsuc) x-true))
@@ -623,50 +632,46 @@ tabulate-atom-false
   → tabulate ρ ⊢ “¬” atom x
 tabulate-atom-false {Γ = suc Γ} fzero ρ x-false with ρ 0
 ... | false = hyp here
-... | true = absurd (true≠false x-false)
+... | true  = absurd (true≠false x-false)
 tabulate-atom-false {Γ = suc Γ} (fsuc x) ρ x-false =
   rename (drop idrn) (bump-proof (tabulate-atom-false x (ρ ∘ fsuc) x-false))
 ```
 
-On to the key lemmas. By performing mutual induction on $P$, we can note
-that if $\llbracket P \rrbracket \rho$ is true, then $\hat{\rho} \vdash P$,
-and conversely $\hat{\rho} \vdash \neg P$ if $\llbracket P \rrbracket \rho$
-is false.
+Now onto the key lemmas. By performing mutual induction on $P$, we can
+note that if $\sem{P} \rho$ is true, then $\hat{\rho} \vdash P$ and,
+conversely, that $\hat{\rho} \vdash \neg P$ if $\sem{P} \rho$ is false.
 
 ```agda
 tabulate-true
-  : ∀ (P : Proposition Γ)
-  → (ρ : Fin Γ → Bool)
+  : ∀ (P : Proposition Γ) (ρ : Fin Γ → Bool)
   → ⟦ P ⟧ ρ ≡ true
   → tabulate ρ ⊢ P
+
 tabulate-false
-  : ∀ (P : Proposition Γ)
-  → (ρ : Fin Γ → Bool)
+  : ∀ (P : Proposition Γ) (ρ : Fin Γ → Bool)
   → ⟦ P ⟧ ρ ≡ false
   → tabulate ρ ⊢ “¬” P
 
-tabulate-true (atom x) ρ P-true = tabulate-atom-true x ρ P-true
-tabulate-true “⊤” ρ P-true = ⊤-intro
-tabulate-true “⊥” ρ P-true = absurd (true≠false $ sym P-true)
-tabulate-true (P “∧” Q) ρ P∧Q-true =
-  ∧-intro
-    (tabulate-true P ρ (and-reflect-true-l P∧Q-true))
-    (tabulate-true Q ρ (and-reflect-true-r P∧Q-true))
+tabulate-true (atom x)  ρ P-true = tabulate-atom-true x ρ P-true
+tabulate-true “⊤”       ρ P-true = ⊤-intro
+tabulate-true “⊥”       ρ P-true = absurd (true≠false $ sym P-true)
+tabulate-true (P “∧” Q) ρ P∧Q-true = ∧-intro
+  (tabulate-true P ρ (and-reflect-true-l P∧Q-true))
+  (tabulate-true Q ρ (and-reflect-true-r P∧Q-true))
 tabulate-true (P “∨” Q) ρ P∨Q-true with or-reflect-true P∨Q-true
 ... | inl P-true = ∨-intro-l (tabulate-true P ρ P-true)
 ... | inr Q-true = ∨-intro-r (tabulate-true Q ρ Q-true)
 tabulate-true (“¬” P) ρ P-true = tabulate-false P ρ (not-inj P-true)
 
-tabulate-false (atom x) ρ P-false = tabulate-atom-false x ρ P-false
-tabulate-false “⊤” ρ P-false = absurd (true≠false P-false)
-tabulate-false “⊥” ρ P-false = ¬-intro (hyp here)
+tabulate-false (atom x)  ρ P-false = tabulate-atom-false x ρ P-false
+tabulate-false “⊤”       ρ P-false = absurd (true≠false P-false)
+tabulate-false “⊥”       ρ P-false = ¬-intro (hyp here)
 tabulate-false (P “∧” Q) ρ P∧Q-false with and-reflect-false P∧Q-false
 ... | inl P-false = ¬∧-intro-l (tabulate-false P ρ P-false)
 ... | inr Q-false = ¬∧-intro-r (tabulate-false Q ρ Q-false)
-tabulate-false (P “∨” Q) ρ P∨Q-false =
-  ¬∨-intro
-    (tabulate-false P ρ (or-reflect-false-l P∨Q-false))
-    (tabulate-false Q ρ (or-reflect-false-r P∨Q-false))
+tabulate-false (P “∨” Q) ρ P∨Q-false = ¬∨-intro
+  (tabulate-false P ρ (or-reflect-false-l P∨Q-false))
+  (tabulate-false Q ρ (or-reflect-false-r P∨Q-false))
 tabulate-false (“¬” P) ρ P-false =
   dneg-intro (tabulate-true P ρ (not-inj P-false))
 ```
@@ -676,33 +681,56 @@ first $n$ atoms in $P$. If $P$ is a tautology, then $\hat{\rho} \vdash P$.
 This follows from induction on the number of atoms not assigned by $\rho$.
 If $\rho$ assigns all of the atoms of $P$, then by our previous lemma we
 have $\hat{\rho} \vdash P$. For the inductive step, let $x$ be a atom
-not covered by $\rho$. Excluded middle lets us case on the truth value of
-$x$; if it is true, then we extend $\rho$ with $x := \top$, and induct.
-Likewise, if $x$ is false, then we extend $\rho$ with $x := \bot$.
+not covered by $\rho$. Excluded middle lets us case on the truth value
+of $x$; if it is true, then we extend $\rho$ with $x := \top$, and use
+the induction hypothesis. Likewise, if $x$ is false, then we extend
+$\rho$ with $x := \bot$.
 
-The Agda proof of this is somewhat gnarly due to variable nonsense,
-but it more or less follows the sketch outlined above.
+We'll then show an appropriate generalisation of the completeness
+theorem, which will allow us to apply induction. Specifically, we'll
+show that, if $P$ is a tautology in $k+n$ atoms, and we have an
+assignment $\rho$ of truth values for the first $k$ atoms in $P$, then
+$\hat{\rho} \vdash P$, by induction on $n$, i.e. the number of atoms
+which $\rho$ does _not_ assign.
 
 ```agda
 tabulate-complete
   : ∀ {Δ Γ} (P : Proposition Γ)
-  → (σ : Weakening Δ Γ)
-  → (ρ : Fin Δ → Bool) → [] ⊨ P → shift-ctx σ (tabulate ρ) ⊢ P
-tabulate-complete P done ρ P-taut = tabulate-true P ρ (P-taut ρ refl)
-tabulate-complete {Γ = Γ} P (weak σ) ρ P-taut =
-  ∨-elim (lem (shift-prop σ (atom 0)))
-    (subst (_⊢ P)
-      (shift-ctx-⨾ σ _ _)
-      (tabulate-complete P σ (ρ [ 0 ≔ true ]) P-taut))
-    (subst (_⊢ P)
-      (shift-ctx-⨾ σ _ _ ∙ ap₂ _⨾_ refl (shift-prop-“¬” σ (atom 0)))
-      (tabulate-complete P σ (ρ [ 0 ≔ false ]) P-taut))
+  → (σ : Weakening Δ Γ) (ρ : Fin Δ → Bool)
+  → [] ⊨ P → shift-ctx σ (tabulate ρ) ⊢ P
 ```
 
-If we start this with an empty assignment, we will construct a
-giant proof that applies excluded middle to every single atom in $P$, and
-then applies the relevant introduction rules at the leaves. This allows
-us to deduce that we have completeness for tautologies.
+The base case is when we have _no_ new atoms: we can then appeal to our
+previous theorem `tabulate-true`{.Agda}.
+
+```agda
+tabulate-complete P done ρ P-taut =
+  tabulate-true P ρ (P-taut ρ refl)
+```
+
+For the inductive step, we have some $1+n$ new atoms, and we're free to
+assume that any tautology in $k+n$ atoms is a theorem. We use this
+induction hypothesis twice, once on $\rho$ extended with $x := \top$,
+and once on it extended with $x := \bot$. We now have proofs that $x
+\vdash P$ and $\neg x \vdash P$; but by the excluded middle (and
+disjunction elimination), this suffices to prove $P$!
+
+```agda
+tabulate-complete {Γ = Γ} P (weak σ) ρ P-taut = ∨-elim
+  (lem (shift-prop σ (atom 0)))
+  (subst (_⊢ P)
+    (shift-ctx-⨾ σ _ _)
+    (tabulate-complete P σ (ρ [ 0 ≔ true ]) P-taut))
+  (subst (_⊢ P)
+    (shift-ctx-⨾ σ _ _ ∙ ap₂ _⨾_ refl (shift-prop-“¬” σ (atom 0)))
+    (tabulate-complete P σ (ρ [ 0 ≔ false ]) P-taut))
+```
+
+If we start this with an empty assignment, we will construct a gigantic
+proof, which applies excluded middle to every single atom in $P$, and
+then applies the relevant introduction rules at the leaves. Despite the
+obvious inefficiency of this procedure, it allows us to deduce that we
+have completeness for tautologies.
 
 ```agda
 taut-complete : (P : Proposition Γ) → [] ⊨ P → [] ⊢ P
@@ -710,53 +738,41 @@ taut-complete P taut =
   subst (_⊢ P) (shift-ctx-[] !wk) (tabulate-complete P !wk (λ ()) taut)
 ```
 
-
-Finally, we note that proofs of $P_1 \to \cdots \to P_n \to Q$
-yield proofs of $P_1, \cdots, P_n \vdash Q$, and likewise for semantic
+Finally, we note that proofs of $P_1 \to \cdots \to P_n \to Q$ yield
+proofs of $P_1, \cdots, P_n \vdash Q$, and likewise for semantic
 entailments.
 
 ```agda
 ⇛-closed : [] ⊢ ψ “⇛” P → ψ ⊢ P
-⇛-closed {ψ = []} p = p
+⇛-closed {ψ = []}    p = p
 ⇛-closed {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-closed p)
 
 ⇛-valid : ∀ (ψ : Ctx Γ) (P : Proposition Γ) → ψ ⊨ P → [] ⊨ (ψ “⇛” P)
-⇛-valid [] P valid = valid
-⇛-valid (ψ ⨾ Q) P valid ρ taut =
-  ap₂ and
-    refl
-    (⇛-valid ψ (Q “⇒” P)
-      (λ ρ' ψ-true →
-        Bool-elim (λ b → ⟦ Q ⟧ ρ' ≡ b → ⟦ Q “⇒” P ⟧ ρ' ≡ true)
-          (λ Q-true →
-            ⇒-sem ρ'
-            ∙ ap₂ imp refl (valid ρ' (ap₂ and ψ-true Q-true))
-            ∙ imp-truer _)
-          (λ Q-false →
-            ⇒-sem ρ'
-            ∙ ap₂ imp Q-false refl)
-          (⟦ Q ⟧ ρ') refl)
-      ρ taut)
+⇛-valid []      P valid = valid
+⇛-valid (ψ ⨾ Q) P valid ρ taut = ap₂ and refl
+  (⇛-valid ψ (Q “⇒” P) (λ ρ' ψ-true → it ρ' ψ-true (⟦ Q ⟧ ρ') refl) ρ taut)
 ```
 
+<!--
+```agda
+  where
+  it : ∀ ρ' (ψ-true : ⟦ ψ ⟧ ρ' ≡ true) (b : Bool)
+     → ⟦ Q ⟧ ρ' ≡ b
+     → ⟦ Q “⇒” P ⟧ ρ' ≡ true
+  it ρ' ψ-true true Q-true =
+    ⇒-sem ρ'
+    ∙ ap₂ imp refl (valid ρ' (ap₂ and ψ-true Q-true))
+    ∙ imp-truer _
+  it ρ' ψ-true false Q-false =
+    ⇒-sem ρ' ∙ ap₂ imp Q-false refl
+```
+-->
+
 This lets us generalize our result for tautologies to any
-proposition $P$!
+proposition-in-context $\psi \vDash P$!
 
 ```agda
 complete : ψ ⊨ P → ψ ⊢ P
 complete {ψ = ψ} {P = P} valid =
-   ⇛-closed $ taut-complete (ψ “⇛” P) (⇛-valid ψ P valid)
+  ⇛-closed $ taut-complete (ψ “⇛” P) (⇛-valid ψ P valid)
 ```
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -514,7 +514,7 @@ if every provable theorem `ψ ⊢ P` is true. This definition obscures
 what is really going on: what we care about is that a provable theorem
 `ψ ⊢ P` is true **in some semantics**. For classical propositional logic,
 it just so happens that we only care about one semantics[^1] (the booleans),
-so authors often conflate "true" with "true in thhis particular semantics".
+so authors often conflate "true" with "true in this particular semantics".
 
 [^1]: We will see why this is the case in just a bit!
 
@@ -564,14 +564,14 @@ having a **single** semantics. This is largely due to the fact that
 if `ψ` semantically entails `P` in the booleans, then we can prove that
 `ψ ⊢ P`! In other words, classical propositional logic is **complete**.
 
-This somewhat miraculous is often taken for granted. Completeness is
+This somewhat miraculous is often taken for granted. Completeness
 is why truth-tables are a valid form of reasoning, yet this is rarely
 mentioned when teaching logic. As we shall soon see, this is not exactly
 a trivial theorem.
 
 First, let us lay out our general proof strategy. We shall start
 by building a context $\hat{\rho}$ from an assignment $\rho$ that contains only
-(potentially negated) atoms. If $rho$ assigns `true` to an atom $x$, we will
+(potentially negated) atoms. If $\rho$ assigns `true` to an atom $x$, we will
 add $x$ to $\hat{\rho}$. Conversely, if $\rho$ assigns false to $x$, we
 add $\neg x$ to $\hat{\rho}$.
 
@@ -605,14 +605,22 @@ assigns a truth value to $x$, then we should be able to prove this under
 the assumptions $\hat{\rho}$.
 
 ```agda
-tabulate-atom-true : (x : Fin Γ) (ρ : Fin Γ → Bool) → ρ x ≡ true → tabulate ρ ⊢ atom x
+tabulate-atom-true
+  : (x : Fin Γ)
+  → (ρ : Fin Γ → Bool)
+  → ρ x ≡ true
+  → tabulate ρ ⊢ atom x
 tabulate-atom-true {Γ = suc Γ} fzero ρ x-true with ρ 0
 ... | true = hyp here
 ... | false = absurd (true≠false $ sym x-true)
 tabulate-atom-true {Γ = suc Γ} (fsuc x) ρ x-true =
   rename (drop idrn) (bump-proof (tabulate-atom-true x (ρ ∘ fsuc) x-true))
 
-tabulate-atom-false : (x : Fin Γ) (ρ : Fin Γ → Bool) → ρ x ≡ false → tabulate ρ ⊢ “¬” atom x
+tabulate-atom-false
+  : (x : Fin Γ)
+  → (ρ : Fin Γ → Bool)
+  → ρ x ≡ false
+  → tabulate ρ ⊢ “¬” atom x
 tabulate-atom-false {Γ = suc Γ} fzero ρ x-false with ρ 0
 ... | false = hyp here
 ... | true = absurd (true≠false x-false)
@@ -626,8 +634,16 @@ and conversely $\hat{\rho} \vdash \neg P$ if $\llbracket P \rrbracket \rho$
 is false.
 
 ```agda
-tabulate-true : ∀ (P : Proposition Γ) (ρ : Fin Γ → Bool) → ⟦ P ⟧ ρ ≡ true → tabulate ρ ⊢ P
-tabulate-false : ∀ (P : Proposition Γ) (ρ : Fin Γ → Bool) → ⟦ P ⟧ ρ ≡ false → tabulate ρ ⊢ “¬” P
+tabulate-true
+  : ∀ (P : Proposition Γ)
+  → (ρ : Fin Γ → Bool)
+  → ⟦ P ⟧ ρ ≡ true
+  → tabulate ρ ⊢ P
+tabulate-false
+  : ∀ (P : Proposition Γ)
+  → (ρ : Fin Γ → Bool)
+  → ⟦ P ⟧ ρ ≡ false
+  → tabulate ρ ⊢ “¬” P
 
 tabulate-true (atom x) ρ P-true = tabulate-atom-true x ρ P-true
 tabulate-true “⊤” ρ P-true = ⊤-intro

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -1,0 +1,340 @@
+<!--
+```agda
+open import 1Lab.Prelude hiding (_∈_)
+open import Data.Fin using (Fin; fzero; fsuc; weaken; inject)
+open import Data.Nat
+open import Data.List hiding (_++_)
+open import Data.Bool
+open import Data.Sum
+
+open import Meta.Brackets
+```
+-->
+
+```agda
+module Logic.Propositional.Classical where
+```
+
+# Classical Propositional Logic
+
+```agda
+data Proposition (Γ : Nat) : Type where
+  var : Fin Γ → Proposition Γ
+  “⊤” : Proposition Γ
+  “⊥” : Proposition Γ
+  _“∧”_ : Proposition Γ → Proposition Γ → Proposition Γ
+  _“∨”_ : Proposition Γ → Proposition Γ → Proposition Γ
+  “¬”_ : Proposition Γ → Proposition Γ
+
+data Ctx (Γ : Nat) : Type where
+  [] : Ctx Γ
+  _⨾_ : Ctx Γ → Proposition Γ → Ctx Γ
+
+_++_ : ∀ {Γ} → Ctx Γ → Ctx Γ → Ctx Γ
+ψ ++ [] = ψ
+ψ ++ (θ ⨾ P) = (ψ ++ θ) ⨾ P
+
+data _∈_ {Γ : Nat} (P : Proposition Γ) : Ctx Γ → Type where
+  here : ∀ {ψ} → P ∈ (ψ ⨾ P)
+  there : ∀ {ψ Q} → P ∈ ψ → P ∈ (ψ ⨾ Q)
+
+infixr 12 _“⇒”_
+infixr 11 _“∧”_
+infixr 10 _“∨”_
+infixl 10 _⨾_
+infix 9 _⊢_ _⊨_
+
+data _⊢_ {Γ : Nat} (ψ : Ctx Γ) : Proposition Γ → Type where
+  hyp : ∀ {P} → P ∈ ψ → ψ ⊢ P
+  ⊤-intro : ψ ⊢ “⊤”
+  ⊥-elim : ∀ {P} → ψ ⊢ “⊥” → ψ ⊢ P
+  ∧-intro : ∀ {P Q} → ψ ⊢ P → ψ ⊢ Q → ψ ⊢ P “∧” Q
+  ∧-elim-l : ∀ {P Q} → ψ ⊢ P “∧” Q → ψ ⊢ P
+  ∧-elim-r : ∀ {P Q} → ψ ⊢ P “∧” Q → ψ ⊢ Q
+  ∨-intro-l : ∀ {P Q} → ψ ⊢ P → ψ ⊢ P “∨” Q
+  ∨-intro-r : ∀ {P Q} → ψ ⊢ Q → ψ ⊢ P “∨” Q
+  ∨-elim : ∀ {P Q R} → ψ ⊢ P “∨” Q → ψ ⨾ P ⊢ R → ψ ⨾ Q ⊢ R → ψ ⊢ R
+  ¬-intro : ∀ {P} → ψ ⨾ P ⊢ “⊥” → ψ ⊢ “¬” P
+  ¬-elim : ∀ {P} → ψ ⊢ “¬” P → ψ ⊢ P → ψ ⊢ “⊥”
+  dneg-elim : ∀ {P} → ψ ⊢ “¬” (“¬” P) → ψ ⊢ P
+```
+
+<!--
+```agda
+private variable
+  Γ Δ Θ : Nat
+  ψ θ ζ : Ctx Γ
+  P Q R : Proposition Γ
+```
+-->
+
+## Weakening
+
+```agda
+data Weakening (Γ : Nat) : Nat → Type where
+  done : Weakening Γ Γ
+  weak : ∀ {Δ} → Weakening (suc Γ) Δ → Weakening Γ Δ
+
+¬weaken-suc-zero : Weakening (suc Γ) 0 → ⊥
+¬weaken-suc-zero (weak σ) = ¬weaken-suc-zero σ
+
+inc-prop : Proposition Γ → Proposition (suc Γ)
+inc-prop (var x) = var (weaken x)
+inc-prop “⊤” = “⊤”
+inc-prop “⊥” = “⊥”
+inc-prop (p “∧” q) = inc-prop p “∧” inc-prop q
+inc-prop (p “∨” q) = inc-prop p “∨” inc-prop q
+inc-prop (“¬” p) = “¬” (inc-prop p)
+
+inc-ctx : Ctx Γ → Ctx (suc Γ)
+inc-ctx [] = []
+inc-ctx (ψ ⨾ P) = inc-ctx ψ ⨾ inc-prop P
+
+inc-var : P ∈ ψ → inc-prop P ∈ inc-ctx ψ
+inc-var here = here
+inc-var (there x) = there (inc-var x)
+
+inc-proof : ψ ⊢ P → inc-ctx ψ ⊢ inc-prop P
+inc-proof (hyp x) = hyp (inc-var  x)
+inc-proof ⊤-intro = ⊤-intro
+inc-proof (⊥-elim p) = ⊥-elim (inc-proof p)
+inc-proof (∧-intro p q) = ∧-intro (inc-proof p) (inc-proof q)
+inc-proof (∧-elim-l p) = ∧-elim-l (inc-proof p)
+inc-proof (∧-elim-r p) = ∧-elim-r (inc-proof p)
+inc-proof (∨-intro-l p) = ∨-intro-l (inc-proof p)
+inc-proof (∨-intro-r p) = ∨-intro-r (inc-proof p)
+inc-proof (∨-elim p q r) = ∨-elim (inc-proof p) (inc-proof q) (inc-proof r)
+inc-proof (¬-intro p) = ¬-intro (inc-proof p)
+inc-proof (¬-elim p q) = ¬-elim (inc-proof p) (inc-proof q)
+inc-proof (dneg-elim p) = dneg-elim (inc-proof p)
+
+wk-var : Weakening Γ Δ → Fin Γ → Fin Δ
+wk-var done x = x
+wk-var (weak σ) x = wk-var σ (fsuc x)
+
+wk-prop : Weakening Γ Δ → Proposition Γ → Proposition Δ
+wk-prop done P = P
+wk-prop (weak σ) P = wk-prop σ (inc-prop P)
+
+wk-ctx : Weakening Γ Δ → Ctx Γ → Ctx Δ
+wk-ctx done ψ = ψ
+wk-ctx (weak σ) ψ = wk-ctx σ (inc-ctx ψ)
+
+wk-proof : (σ : Weakening Γ Δ) → ψ ⊢ P → wk-ctx σ ψ ⊢ wk-prop σ P
+wk-proof done pf = pf
+wk-proof (weak σ) pf = wk-proof σ (inc-proof pf)
+```
+
+## Renamings
+
+```agda
+data Rename {Γ} : Ctx Γ → Ctx Γ → Type where
+  done : Rename [] []
+  drop : ∀ {ψ θ P} → Rename ψ θ → Rename (ψ ⨾ P) θ
+  keep : ∀ {ψ θ P} → Rename ψ θ → Rename (ψ ⨾ P) (θ ⨾ P)
+
+idrn : Rename ψ ψ
+idrn {ψ = []} = done
+idrn {ψ = ψ ⨾ P} = keep (idrn {ψ = ψ})
+
+_∘rn_ : Rename θ ζ → Rename ψ θ → Rename ψ ζ 
+p ∘rn done = p
+p ∘rn drop q = drop (p ∘rn q)
+drop p ∘rn keep q = drop (p ∘rn q)
+keep p ∘rn keep q = keep (p ∘rn q)
+
+!rn : Rename ψ []
+!rn {ψ = []} = done
+!rn {ψ = ψ ⨾ x} = drop !rn
+
+π₁-rn : Rename (ψ ++ θ) ψ
+π₁-rn {θ = []} = idrn
+π₁-rn {θ = θ ⨾ P} = drop π₁-rn
+
+π₂-rn : Rename (ψ ++ θ) θ
+π₂-rn {θ = []} = !rn
+π₂-rn {θ = θ ⨾ P} = keep π₂-rn
+
+rename-hyp : Rename ψ θ → P ∈ θ → P ∈ ψ
+rename-hyp (drop rn) mem = there (rename-hyp rn mem)
+rename-hyp (keep rn) here = here
+rename-hyp (keep rn) (there mem) = there (rename-hyp rn mem)
+
+rename : Rename ψ θ → θ ⊢ P → ψ ⊢ P
+rename rn (hyp x) = hyp (rename-hyp rn x)
+rename rn ⊤-intro = ⊤-intro
+rename rn (⊥-elim p) = ⊥-elim (rename rn p)
+rename rn (∧-intro p q) = ∧-intro (rename rn p) (rename rn q)
+rename rn (∧-elim-l p) = ∧-elim-l (rename rn p)
+rename rn (∧-elim-r p) = ∧-elim-r (rename rn p)
+rename rn (∨-intro-l p) = ∨-intro-l (rename rn p)
+rename rn (∨-intro-r p) = ∨-intro-r (rename rn p)
+rename rn (∨-elim p q r) = ∨-elim (rename rn p) (rename (keep rn) q) (rename (keep rn) r)
+rename rn (¬-intro p) = ¬-intro (rename (keep rn) p)
+rename rn (¬-elim p q) = ¬-elim (rename rn p) (rename rn q)
+rename rn (dneg-elim p) = dneg-elim (rename rn p)
+```
+
+## Some Elementary Theorems
+
+```agda
+lem : ∀ {Γ} {ψ : Ctx Γ} (P : Proposition Γ) → ψ ⊢ P “∨” (“¬” P)
+lem P =
+  dneg-elim $
+  ¬-intro $
+  ¬-elim (hyp here) $
+  ∨-intro-r $
+  ¬-intro $
+  ¬-elim (hyp (there here)) $
+  ∨-intro-l (hyp here)
+
+dneg-intro : ψ ⊢ P → ψ ⊢ “¬” (“¬” P)
+dneg-intro p = ¬-intro (¬-elim (hyp here) (rename (drop idrn) p))
+
+¬∧-intro-l : ψ ⊢ “¬” P → ψ ⊢ “¬” (P “∧” Q)
+¬∧-intro-l p = ¬-intro (¬-elim (rename (drop idrn) p) (∧-elim-l (hyp here)))
+
+¬∧-intro-r : ψ ⊢ “¬” Q → ψ ⊢ “¬” (P “∧” Q)
+¬∧-intro-r p = ¬-intro (¬-elim (rename (drop idrn) p) (∧-elim-r (hyp here)))
+
+¬∧-elim : ψ ⊢ “¬” (P “∧” Q) → ψ ⊢ (“¬” P) “∨” (“¬” Q)
+¬∧-elim {P = P} {Q = Q} p =
+  ∨-elim (lem P)
+    (∨-elim (lem Q)
+      (⊥-elim
+        (¬-elim (rename (drop (drop idrn)) p)
+        (∧-intro (hyp (there here)) (hyp here))))
+      (∨-intro-r (hyp here)))
+    (∨-intro-l (hyp here))
+
+¬∨-intro : ψ ⊢ “¬” P → ψ ⊢ “¬” Q → ψ ⊢ “¬” (P “∨” Q)
+¬∨-intro p q =
+  ¬-intro $
+  ∨-elim (hyp here)
+    (¬-elim (rename (drop (drop idrn)) p) (hyp here))
+    (¬-elim (rename (drop (drop idrn)) q) (hyp here))
+
+opaque
+  _“⇒”_ : ∀ {Γ} → Proposition Γ → Proposition Γ → Proposition Γ
+  P “⇒” Q = (“¬” P) “∨” Q
+  
+  ⇒-intro : ψ ⨾ P ⊢ Q → ψ ⊢ P “⇒” Q
+  ⇒-intro {P = P} pf = ∨-elim (lem P) (∨-intro-r pf) (∨-intro-l (hyp here))
+  
+  ⇒-elim : ψ ⊢ P “⇒” Q → ψ ⊢ P → ψ ⊢ Q
+  ⇒-elim {Q = Q} imp p =
+    ∨-elim imp
+      (⊥-elim (¬-elim (hyp here) (rename (drop idrn) p)))
+      (hyp here)
+
+⇒-uncurry : ψ ⊢ P “⇒” Q → ψ ⨾ P ⊢ Q
+⇒-uncurry p = ⇒-elim (rename (drop idrn) p) (hyp here)
+
+⇒-flip : ψ ⊢ P “⇒” Q “⇒” R → ψ ⊢ Q “⇒” P “⇒” R
+⇒-flip p =
+  ⇒-intro $ ⇒-intro $
+  ⇒-elim
+    (⇒-elim (rename (drop (drop idrn)) p) (hyp here))
+    (hyp (there here))
+
+“⋀” : Ctx Γ → Proposition Γ
+“⋀” [] = “⊤”
+“⋀” (ψ ⨾ P) = “⋀” ψ “∧” P
+
+⋀-intro : (∀ {P} → P ∈ ψ → θ ⊢ P) → θ ⊢ “⋀” ψ  
+⋀-intro {ψ = []} pfs = ⊤-intro
+⋀-intro {ψ = ψ ⨾ P} pfs = ∧-intro (⋀-intro (pfs ∘ there)) (pfs here)
+
+⋀-elim : P ∈ ψ → θ ⊢ “⋀” ψ → θ ⊢ P
+⋀-elim here p = ∧-elim-r p
+⋀-elim (there x) p = ⋀-elim x (∧-elim-l p)
+
+_“⇛”_ : Ctx Γ → Proposition Γ → Proposition Γ
+[] “⇛” P = P
+(ψ ⨾ Q) “⇛” P = ψ “⇛” (Q “⇒” P)
+
+⇛-intro : θ ++ ψ ⊢ P → θ ⊢ ψ “⇛” P
+⇛-intro {ψ = []} p = p
+⇛-intro {ψ = ψ ⨾ Q} p = ⇛-intro (⇒-intro p)
+
+⇛-uncurry : θ ⊢ ψ “⇛” P → θ ++ ψ ⊢ P
+⇛-uncurry {ψ = []} p = p
+⇛-uncurry {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-uncurry p)
+
+⇛-closed : [] ⊢ ψ “⇛” P → ψ ⊢ P
+⇛-closed {ψ = []} p = p
+⇛-closed {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-closed p)
+
+⇛-elim : θ ⊢ (ψ ⨾ P) “⇛” Q → θ ⊢ P → θ ⊢ ψ “⇛” Q
+⇛-elim {ψ = ψ} p q = ⇛-intro (⇒-elim (⇛-uncurry {ψ = ψ} p) (rename π₁-rn q))
+```
+
+## Semantics
+
+```agda
+sem-prop : ∀ {Γ} → Proposition Γ → (Fin Γ → Bool) → Bool
+sem-prop (var x) ρ = ρ x
+sem-prop “⊤” ρ = true
+sem-prop “⊥” ρ = false
+sem-prop (P “∧” Q) ρ = and (sem-prop P ρ) (sem-prop Q ρ)
+sem-prop (P “∨” Q) ρ = or (sem-prop P ρ) (sem-prop Q ρ)
+sem-prop (“¬” P) ρ = not (sem-prop P ρ)
+
+sem-ctx : ∀ {Γ} → Ctx Γ → (Fin Γ → Bool) → Bool
+sem-ctx ψ ρ = sem-prop (“⋀” ψ) ρ
+
+instance
+  ⟦⟧-Proposition : ∀ {Γ} → ⟦⟧-notation (Proposition Γ)
+  ⟦⟧-Proposition {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) sem-prop
+
+  ⟦⟧-Ctx : ∀ {Γ} → ⟦⟧-notation (Ctx Γ)
+  ⟦⟧-Ctx {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) sem-ctx
+
+opaque
+  unfolding _“⇒”_
+  ⇒-sem
+    : ∀ {Γ} {P Q : Proposition Γ}
+    → ∀ (ρ : Fin Γ → Bool) → ⟦ P “⇒” Q ⟧ ρ ≡ imp (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
+  ⇒-sem {P = P} {Q = Q} ρ =
+    imp-not-or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
+
+_⊨_ : ∀ {Γ} → Ctx Γ → Proposition Γ → Type
+_⊨_ {Γ} ψ P = ∀ (ρ : Fin Γ → Bool) → ⟦ ψ ⟧ ρ ≡ true → ⟦ P ⟧ ρ ≡ true
+```
+
+## Soundness
+
+```agda
+hyp-sound : ∀ {Γ} {ψ : Ctx Γ} {P : Proposition Γ} → P ∈ ψ → ψ ⊨ P
+hyp-sound here ρ hyps-true = and-reflect-true-r hyps-true
+hyp-sound (there m) ρ hyps-true = hyp-sound m ρ (and-reflect-true-l hyps-true)
+
+sound : ψ ⊢ P → ψ ⊨ P
+sound (hyp x) ρ hyps-true = hyp-sound x ρ hyps-true
+sound ⊤-intro ρ hyps-true = refl
+sound (⊥-elim p) ρ hyps-true =
+  absurd (true≠false (sym (sound p ρ hyps-true)))
+sound (∧-intro p q) ρ hyps-true =
+  ap₂ and (sound p ρ hyps-true) (sound q ρ hyps-true)
+sound (∧-elim-l p) ρ hyps-true =
+  and-reflect-true-l (sound p ρ hyps-true)
+sound (∧-elim-r p) ρ hyps-true =
+  and-reflect-true-r (sound p ρ hyps-true)
+sound (∨-intro-l p) ρ hyps-true =
+  ap₂ or (sound p ρ hyps-true) refl
+sound (∨-intro-r p) ρ hyps-true =
+  ap₂ or refl (sound p ρ hyps-true) ∙ or-truer _
+sound (∨-elim p q r) ρ hyps-true =
+  [ (λ P-true → sound q ρ (ap₂ and hyps-true P-true))
+  , (λ Q-true → sound r ρ (ap₂ and hyps-true Q-true))
+  ] (or-reflect-true (sound p ρ hyps-true))
+sound (¬-intro {P = P} p) ρ hyps-true =
+  Bool-elim (λ b → ⟦ P ⟧ ρ ≡ b → not b ≡ true)
+    (λ P-true → sound p ρ (ap₂ and hyps-true P-true))
+    (λ _ → refl)
+    (⟦ P ⟧ ρ) refl
+sound (¬-elim {P = P} p q) ρ hyps-true =
+  absurd $ not-no-fixed (sound q ρ hyps-true ∙ sym (sound p ρ hyps-true))
+sound (dneg-elim {P = P} p) ρ hyps-true =
+  sym (not-involutive (⟦ P ⟧ ρ)) ∙ sound p ρ hyps-true
+```

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -270,11 +270,11 @@ shift-prop-“¬” (weak σ) P = shift-prop-“¬” σ (bump-prop P)
 
 ## Context inclusions
 
-We also want to be able to modify our collection of hypotheses.
-We do this by defining a notion of context inclusion, where
-an inclusion $\Gamma \to \Delta$ denotes that we can obtain every
-hypotheses in $\Delta$ dropping some hypotheses in $\Gamma$. We call
-such context inclusions **renamings**.
+We also want to be able to modify our collection of hypotheses.  We do
+this by defining a notion of context inclusion, where an inclusion
+$\Gamma \to \Delta$ denotes that we can obtain every hypothesis in
+$\Delta$ by dropping hypotheses from $\Gamma$. We call such context
+inclusions **renamings**.
 
 ```agda
 data Rename {Γ} : Ctx Γ → Ctx Γ → Type where
@@ -568,9 +568,9 @@ sound (dneg-elim {P = P} p) ρ hyps-true =
 ## Completeness
 
 As mentioned earlier, we often think of classical propositional logic as
-having a *single* semantics. This is largely justified by to the fact
-that if `ψ` semantically entails `P` in the booleans, then we can prove
-that `ψ ⊢ P`! In other words, the Boolean semantics for classical
+having a *single* semantics. This is largely justified by the fact that
+if `ψ` semantically entails `P` in the booleans, then we can prove that
+`ψ ⊢ P`! In other words, the Boolean semantics for classical
 propositional logic is **complete**.
 
 This somewhat miraculous theorem is often taken for granted.

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -3,8 +3,8 @@
 open import 1Lab.Prelude hiding (_∈_)
 
 open import Data.Bool
-open import Data.Fin using (Fin; fzero; fsuc; weaken; inject; _[_≔_])
 open import Data.List hiding (_++_)
+open import Data.Fin using (Fin; fzero; fsuc; weaken; inject; _[_≔_])
 open import Data.Nat
 open import Data.Sum
 

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -16,17 +16,32 @@ open import Meta.Brackets
 module Logic.Propositional.Classical where
 ```
 
-# Classical Propositional Logic
+# Classical Propositional Logic {defines="classical-propositional-logic"}
+
+Classical propositional logic is a simple classical logic that only
+contains "atomic" propositions and connectives like "and", "or" and "not".
+Notably, it does not contain any quantifiers like "forall" and "exists".
+
+We can define the syntax of classical propositional logic in Agda as
+the following indexed inductive type.
 
 ```agda
 data Proposition (Γ : Nat) : Type where
-  var : Fin Γ → Proposition Γ
+  atom : Fin Γ → Proposition Γ
   “⊤” : Proposition Γ
   “⊥” : Proposition Γ
   _“∧”_ : Proposition Γ → Proposition Γ → Proposition Γ
   _“∨”_ : Proposition Γ → Proposition Γ → Proposition Γ
   “¬”_ : Proposition Γ → Proposition Γ
+```
 
+We represent atomic propositions as elements of `Fin`{.Agda},
+and our indexing scheme gives an upper bound on the number of
+atomic propositions.
+
+Next, we introduce contexts; these are simply lists of propositions.
+
+```agda
 data Ctx (Γ : Nat) : Type where
   [] : Ctx Γ
   _⨾_ : Ctx Γ → Proposition Γ → Ctx Γ
@@ -34,27 +49,72 @@ data Ctx (Γ : Nat) : Type where
 _++_ : ∀ {Γ} → Ctx Γ → Ctx Γ → Ctx Γ
 ψ ++ [] = ψ
 ψ ++ (θ ⨾ P) = (ψ ++ θ) ⨾ P
+```
 
+We also define a membership relation for contexts.
+
+```agda
 data _∈_ {Γ : Nat} (P : Proposition Γ) : Ctx Γ → Type where
   here : ∀ {ψ} → P ∈ (ψ ⨾ P)
   there : ∀ {ψ Q} → P ∈ ψ → P ∈ (ψ ⨾ Q)
+```
 
+<!--
+```agda
 infixr 12 _“⇒”_
 infixr 11 _“∧”_
 infixr 10 _“∨”_
 infixl 10 _⨾_
 infix 9 _⊢_ _⊨_
+```
+-->
 
+Finally, we define a natural deduction proof calculus for classical
+propositional logic. Our proof systems is encoded as an indexed inductive
+`_⊢_`{.Agda}; elements of `ψ ⊢ P` are proof trees that show `P` from some
+set of hypotheses `ψ`.
+
+```agda
 data _⊢_ {Γ : Nat} (ψ : Ctx Γ) : Proposition Γ → Type where
+```
+
+Our first rule is pretty intuitive: If `P` is in our hypotheses `ψ`,
+then we can deduce `P` from `ψ`.
+
+```agda
   hyp : ∀ {P} → P ∈ ψ → ψ ⊢ P
+```
+
+Next, we give an introduction rule for "true" and an elimination rule
+for "false".
+
+```agda
   ⊤-intro : ψ ⊢ “⊤”
   ⊥-elim : ∀ {P} → ψ ⊢ “⊥” → ψ ⊢ P
+```
+
+The rules for "and" are more or less what one would expect.
+
+```agda
   ∧-intro : ∀ {P Q} → ψ ⊢ P → ψ ⊢ Q → ψ ⊢ P “∧” Q
   ∧-elim-l : ∀ {P Q} → ψ ⊢ P “∧” Q → ψ ⊢ P
   ∧-elim-r : ∀ {P Q} → ψ ⊢ P “∧” Q → ψ ⊢ Q
+```
+
+However, "or" is a bit trickier, as we need to add things to our
+hypotheses in the elimination rule.
+
+```agda
   ∨-intro-l : ∀ {P Q} → ψ ⊢ P → ψ ⊢ P “∨” Q
   ∨-intro-r : ∀ {P Q} → ψ ⊢ Q → ψ ⊢ P “∨” Q
   ∨-elim : ∀ {P Q R} → ψ ⊢ P “∨” Q → ψ ⨾ P ⊢ R → ψ ⨾ Q ⊢ R → ψ ⊢ R
+```
+
+Finally, we add the rules for negation. To ensure that we
+are working with classical logic, we add a rule for double-negation
+elimination.
+
+```agda
   ¬-intro : ∀ {P} → ψ ⨾ P ⊢ “⊥” → ψ ⊢ “¬” P
   ¬-elim : ∀ {P} → ψ ⊢ “¬” P → ψ ⊢ P → ψ ⊢ “⊥”
   dneg-elim : ∀ {P} → ψ ⊢ “¬” (“¬” P) → ψ ⊢ P
@@ -71,16 +131,28 @@ private variable
 
 ## Weakening
 
+Indexing the type of propositions by the number of atomic propositions
+makes our life easier later. However, it does mean that we need to
+define **weakening**, which lets us increase the upper bound on the
+number of atoms in a proposition.
+
 ```agda
 data Weakening (Γ : Nat) : Nat → Type where
   done : Weakening Γ Γ
   weak : ∀ {Δ} → Weakening (suc Γ) Δ → Weakening Γ Δ
+```
 
+<details>
+<summary>We omit the details of weakening, as it is more or less
+boilerplate.
+</summary>
+
+```agda
 ¬weaken-suc-zero : Weakening (suc Γ) 0 → ⊥
 ¬weaken-suc-zero (weak σ) = ¬weaken-suc-zero σ
 
 inc-prop : Proposition Γ → Proposition (suc Γ)
-inc-prop (var x) = var (weaken x)
+inc-prop (atom x) = atom (weaken x)
 inc-prop “⊤” = “⊤”
 inc-prop “⊥” = “⊥”
 inc-prop (p “∧” q) = inc-prop p “∧” inc-prop q
@@ -91,12 +163,12 @@ inc-ctx : Ctx Γ → Ctx (suc Γ)
 inc-ctx [] = []
 inc-ctx (ψ ⨾ P) = inc-ctx ψ ⨾ inc-prop P
 
-inc-var : P ∈ ψ → inc-prop P ∈ inc-ctx ψ
-inc-var here = here
-inc-var (there x) = there (inc-var x)
+inc-atom : P ∈ ψ → inc-prop P ∈ inc-ctx ψ
+inc-atom here = here
+inc-atom (there x) = there (inc-atom x)
 
 inc-proof : ψ ⊢ P → inc-ctx ψ ⊢ inc-prop P
-inc-proof (hyp x) = hyp (inc-var  x)
+inc-proof (hyp x) = hyp (inc-atom  x)
 inc-proof ⊤-intro = ⊤-intro
 inc-proof (⊥-elim p) = ⊥-elim (inc-proof p)
 inc-proof (∧-intro p q) = ∧-intro (inc-proof p) (inc-proof q)
@@ -109,9 +181,9 @@ inc-proof (¬-intro p) = ¬-intro (inc-proof p)
 inc-proof (¬-elim p q) = ¬-elim (inc-proof p) (inc-proof q)
 inc-proof (dneg-elim p) = dneg-elim (inc-proof p)
 
-wk-var : Weakening Γ Δ → Fin Γ → Fin Δ
-wk-var done x = x
-wk-var (weak σ) x = wk-var σ (fsuc x)
+wk-atom : Weakening Γ Δ → Fin Γ → Fin Δ
+wk-atom done x = x
+wk-atom (weak σ) x = wk-atom σ (fsuc x)
 
 wk-prop : Weakening Γ Δ → Proposition Γ → Proposition Δ
 wk-prop done P = P
@@ -125,15 +197,28 @@ wk-proof : (σ : Weakening Γ Δ) → ψ ⊢ P → wk-ctx σ ψ ⊢ wk-prop σ P
 wk-proof done pf = pf
 wk-proof (weak σ) pf = wk-proof σ (inc-proof pf)
 ```
+</details>
 
-## Renamings
+## Context inclusions
+
+We also want to be able to modify our collection of hypotheses.
+We do this by defining a notion of context inclusion, where
+an inclusion $\Gamma \to \Delta$ denotes that we can obtain every
+hypotheses in $\Delta$ dropping some hypotheses in $\Gamma$. We call
+such context inclusions **renamings**.
 
 ```agda
 data Rename {Γ} : Ctx Γ → Ctx Γ → Type where
   done : Rename [] []
   drop : ∀ {ψ θ P} → Rename ψ θ → Rename (ψ ⨾ P) θ
   keep : ∀ {ψ θ P} → Rename ψ θ → Rename (ψ ⨾ P) (θ ⨾ P)
+```
 
+Identity renamings exist, and renamings are closed under composition.
+With a bit of elbow grease, we could show that contexts and renamings
+form a [[precategory]], thought we do not do so here.
+
+```agda
 idrn : Rename ψ ψ
 idrn {ψ = []} = done
 idrn {ψ = ψ ⨾ P} = keep (idrn {ψ = ψ})
@@ -143,7 +228,14 @@ p ∘rn done = p
 p ∘rn drop q = drop (p ∘rn q)
 drop p ∘rn keep q = drop (p ∘rn q)
 keep p ∘rn keep q = keep (p ∘rn q)
+```
 
+We also have a renaming that drops every hypothesis, and
+renamings that project out half of a context. Categorically,
+these correspond to the maps into the [[terminal object]]
+and maps out of the [[product]], resp.
+
+```agda
 !rn : Rename ψ []
 !rn {ψ = []} = done
 !rn {ψ = ψ ⨾ x} = drop !rn
@@ -155,7 +247,13 @@ keep p ∘rn keep q = keep (p ∘rn q)
 π₂-rn : Rename (ψ ++ θ) θ
 π₂-rn {θ = []} = !rn
 π₂-rn {θ = θ ⨾ P} = keep π₂-rn
+```
 
+Renamings act contravariantly on variables and derivations.
+In categorical terms, this induces a presheaf on the category of
+contexts.
+
+```agda
 rename-hyp : Rename ψ θ → P ∈ θ → P ∈ ψ
 rename-hyp (drop rn) mem = there (rename-hyp rn mem)
 rename-hyp (keep rn) here = here
@@ -178,6 +276,9 @@ rename rn (dneg-elim p) = dneg-elim (rename rn p)
 
 ## Some Elementary Theorems
 
+With those bits of structural work completed, we can focus our attention
+to some theorems. First, note that we can prove the law of excluded middle.
+
 ```agda
 lem : ∀ {Γ} {ψ : Ctx Γ} (P : Proposition Γ) → ψ ⊢ P “∨” (“¬” P)
 lem P =
@@ -188,7 +289,11 @@ lem P =
   ¬-intro $
   ¬-elim (hyp (there here)) $
   ∨-intro-l (hyp here)
+```
 
+We also have all four DeMorgan laws.
+
+```agda
 dneg-intro : ψ ⊢ P → ψ ⊢ “¬” (“¬” P)
 dneg-intro p = ¬-intro (¬-elim (hyp here) (rename (drop idrn) p))
 
@@ -214,7 +319,13 @@ dneg-intro p = ¬-intro (¬-elim (hyp here) (rename (drop idrn) p))
   ∨-elim (hyp here)
     (¬-elim (rename (drop (drop idrn)) p) (hyp here))
     (¬-elim (rename (drop (drop idrn)) q) (hyp here))
+```
 
+As we are working in a classical setting, we can define implication
+`P ⇒ Q` as `¬ P ∨ Q`. Note that the normal introduction and elimination
+rules for implications are theorems.
+
+```agda
 opaque
   _“⇒”_ : ∀ {Γ} → Proposition Γ → Proposition Γ → Proposition Γ
   P “⇒” Q = (“¬” P) “∨” Q
@@ -227,7 +338,11 @@ opaque
     ∨-elim imp
       (⊥-elim (¬-elim (hyp here) (rename (drop idrn) p)))
       (hyp here)
+```
 
+We also prove some helpful extra lemmas regarding implications.
+
+```agda
 ⇒-uncurry : ψ ⊢ P “⇒” Q → ψ ⨾ P ⊢ Q
 ⇒-uncurry p = ⇒-elim (rename (drop idrn) p) (hyp here)
 
@@ -237,7 +352,12 @@ opaque
   ⇒-elim
     (⇒-elim (rename (drop (drop idrn)) p) (hyp here))
     (hyp (there here))
+```
 
+Next, we define a conjunction operator that works on lists of
+propositions.
+
+```agda
 “⋀” : Ctx Γ → Proposition Γ
 “⋀” [] = “⊤”
 “⋀” (ψ ⨾ P) = “⋀” ψ “∧” P
@@ -249,7 +369,11 @@ opaque
 ⋀-elim : P ∈ ψ → θ ⊢ “⋀” ψ → θ ⊢ P
 ⋀-elim here p = ∧-elim-r p
 ⋀-elim (there x) p = ⋀-elim x (∧-elim-l p)
+```
 
+We can also define an n-ary implication connective.
+
+```agda
 _“⇛”_ : Ctx Γ → Proposition Γ → Proposition Γ
 [] “⇛” P = P
 (ψ ⨾ Q) “⇛” P = ψ “⇛” (Q “⇒” P)
@@ -262,19 +386,27 @@ _“⇛”_ : Ctx Γ → Proposition Γ → Proposition Γ
 ⇛-uncurry {ψ = []} p = p
 ⇛-uncurry {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-uncurry p)
 
-⇛-closed : [] ⊢ ψ “⇛” P → ψ ⊢ P
-⇛-closed {ψ = []} p = p
-⇛-closed {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-closed p)
-
 ⇛-elim : θ ⊢ (ψ ⨾ P) “⇛” Q → θ ⊢ P → θ ⊢ ψ “⇛” Q
 ⇛-elim {ψ = ψ} p q = ⇛-intro (⇒-elim (⇛-uncurry {ψ = ψ} p) (rename π₁-rn q))
 ```
 
+This connective has a very useful property: if `ψ “⇛” P` in
+an empty context, then `ψ ⊢ P`.
+
+```agda
+⇛-closed : [] ⊢ ψ “⇛” P → ψ ⊢ P
+⇛-closed {ψ = []} p = p
+⇛-closed {ψ = ψ ⨾ Q} p = ⇒-uncurry (⇛-closed p)
+```
+
 ## Semantics
+
+The most obvious way to interpret classical logic is as operations
+on booleans.
 
 ```agda
 sem-prop : ∀ {Γ} → Proposition Γ → (Fin Γ → Bool) → Bool
-sem-prop (var x) ρ = ρ x
+sem-prop (atom x) ρ = ρ x
 sem-prop “⊤” ρ = true
 sem-prop “⊥” ρ = false
 sem-prop (P “∧” Q) ρ = and (sem-prop P ρ) (sem-prop Q ρ)
@@ -290,7 +422,10 @@ instance
 
   ⟦⟧-Ctx : ∀ {Γ} → ⟦⟧-notation (Ctx Γ)
   ⟦⟧-Ctx {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) sem-ctx
+```
 
+<!--
+```agda
 opaque
   unfolding _“⇒”_
   ⇒-sem
@@ -298,12 +433,33 @@ opaque
     → ∀ (ρ : Fin Γ → Bool) → ⟦ P “⇒” Q ⟧ ρ ≡ imp (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
   ⇒-sem {P = P} {Q = Q} ρ =
     imp-not-or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
+```
+-->
 
+We also define a notion of semantic entailment, wherein `ψ`
+semantically entails `P` when for every assigment of variables
+`ρ`, if `⟦ ψ ⟧ ρ ≡ true`, then `⟦ P ⟧ ρ ≡ true`.
+
+```agda
 _⊨_ : ∀ {Γ} → Ctx Γ → Proposition Γ → Type
 _⊨_ {Γ} ψ P = ∀ (ρ : Fin Γ → Bool) → ⟦ ψ ⟧ ρ ≡ true → ⟦ P ⟧ ρ ≡ true
 ```
 
 ## Soundness
+
+Soundness is something that is often poorly explained in classical logic.
+The "normal" definition goes something like this: a logic is sound
+if every provable theorem `ψ ⊢ P` is true. This definition obscures
+what is really going on: what we care about is that a provable theorem
+`ψ ⊢ P` is true **in some semantics**. For classical propositional logic,
+it just so happens that we only care about one semantics[^1] (the booleans),
+so authors often conflate "true" with "true in thhis particular semantics".
+
+[^1]: We will see why this is the case in just a bit!
+
+The actual statement of soundness that we will be using is the following:
+if `ψ ⊢ P` is provable, then we have the semantic entailment `ψ ⊨ P`.
+This follows by a rather easy induction on proof trees.
 
 ```agda
 hyp-sound : ∀ {Γ} {ψ : Ctx Γ} {P : Proposition Γ} → P ∈ ψ → ψ ⊨ P
@@ -338,16 +494,4 @@ sound (¬-elim {P = P} p q) ρ hyps-true =
   absurd $ not-no-fixed (sound q ρ hyps-true ∙ sym (sound p ρ hyps-true))
 sound (dneg-elim {P = P} p) ρ hyps-true =
   sym (not-involutive (⟦ P ⟧ ρ)) ∙ sound p ρ hyps-true
-```
-
-## Satisfiability
-
-```agda
-is-satisfiable : Proposition Γ → Type _
-is-satisfiable {Γ = Γ} P = Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ P ⟧ ρ ≡ true)
-
-equisat : Proposition Γ → Proposition Δ → Type _
-equisat P Q =
-  (is-satisfiable P → is-satisfiable Q) ×
-  (is-satisfiable Q → is-satisfiable P)
 ```

--- a/src/Logic/Propositional/Classical/CNF.lagda.md
+++ b/src/Logic/Propositional/Classical/CNF.lagda.md
@@ -29,7 +29,7 @@ normal-form for logical and algebraic expressions, and
 possible choices of normal form, but we will be focusing on
 **conjunctive normal form**, or CNF for short.
 
-An statement in propositional logic is in conjunctive normal form if
+A statement in propositional logic is in conjunctive normal form if
 it is written as a conjunction of disjunctions of (potentially negated)
 atoms. As an example, something like $(P \vee \neg Q) \wedge (\neg R \vee P)$
 is in conjunctive normal form, yet something like $(P \wedge Q) \vee \neg R$
@@ -97,7 +97,7 @@ avoid-lit i (neg x) p = neg (avoid i x p)
 
 ## Semantics
 
-Like their non-normal form bretheren, expressions in CNF have a natural
+Like their non-normal form brethren, expressions in CNF have a natural
 semantics in booleans. However, evaluation is particularly easy!
 
 ```agda

--- a/src/Logic/Propositional/Classical/CNF.lagda.md
+++ b/src/Logic/Propositional/Classical/CNF.lagda.md
@@ -3,9 +3,9 @@
 open import 1Lab.Prelude hiding (_∈_)
 
 open import Data.Bool
+open import Data.List hiding (_++_)
 open import Data.Dec
 open import Data.Fin using (Fin; fzero; fsuc; Discrete-Fin; avoid)
-open import Data.List hiding (_++_)
 open import Data.Nat
 open import Data.Sum
 

--- a/src/Logic/Propositional/Classical/CNF.lagda.md
+++ b/src/Logic/Propositional/Classical/CNF.lagda.md
@@ -1,0 +1,263 @@
+<!--
+```agda
+open import 1Lab.Prelude hiding (_∈_)
+
+open import Data.Bool
+open import Data.Dec
+open import Data.Fin using (Fin; fzero; fsuc; Discrete-Fin; avoid)
+open import Data.List hiding (_++_)
+open import Data.Nat
+open import Data.Sum
+
+open import Logic.Propositional.Classical
+
+open import Meta.Brackets
+
+import Data.List as List
+```
+-->
+
+```agda
+module Logic.Propositional.Classical.CNF where
+```
+
+## Conjunctive Normal Forms
+
+```agda
+data Literal (Γ : Nat) : Type where
+  lit : Fin Γ → Literal Γ
+  neg : Fin Γ → Literal Γ
+
+Disjunction : (Γ : Nat) → Type
+Disjunction Γ = List (Literal Γ)
+
+CNF : (Γ : Nat) → Type
+CNF Γ = List (Disjunction Γ)
+```
+
+<!--
+```agda
+private variable
+  Γ Δ Θ : Nat
+  ψ θ ζ : Ctx Γ
+  P Q R : Proposition Γ
+```
+-->
+
+<!--
+```agda
+lit≠neg : ∀ {x y : Fin Γ} → lit x ≡ neg y → ⊥
+lit≠neg {Γ = Γ} p = subst is-lit p tt where
+  is-lit : Literal Γ → Type
+  is-lit (lit x) = ⊤
+  is-lit (neg x) = ⊥
+
+lit-var : Literal Γ → Fin Γ
+lit-var (lit x) = x
+lit-var (neg x) = x
+
+lit-val : Literal Γ → Bool
+lit-val (lit x) = true
+lit-val (neg x) = false
+
+lit-inj : ∀ {x y : Fin Γ} → lit x ≡ lit y → x ≡ y
+lit-inj p = ap lit-var p
+
+neg-inj : ∀ {x y : Fin Γ} → neg x ≡ neg y → x ≡ y
+neg-inj p = ap lit-var p
+
+Discrete-Literal : Discrete (Literal Γ)
+Discrete-Literal (lit x) (lit y) = Dec-map (ap lit) lit-inj (Discrete-Fin x y)
+Discrete-Literal (lit x) (neg y) = no lit≠neg
+Discrete-Literal (neg x) (lit y) = no (lit≠neg ∘ sym)
+Discrete-Literal (neg x) (neg y) = Dec-map (ap neg) neg-inj (Discrete-Fin x y)
+
+avoid-lit : (i : Fin (suc Γ)) → (x : Literal (suc Γ)) → ¬ i ≡ lit-var x → Literal Γ
+avoid-lit i (lit x) p = lit (avoid i x p)
+avoid-lit i (neg x) p = neg (avoid i x p)
+
+```
+-->
+
+
+## Semantics
+
+```agda
+lit-sem : Literal Γ → (Fin Γ → Bool) → Bool
+lit-sem (lit x) ρ = ρ x
+lit-sem (neg x) ρ = not (ρ x)
+
+disj-sem : Disjunction Γ → (Fin Γ → Bool) → Bool
+disj-sem Ps ρ = any-of (λ a → lit-sem a ρ) Ps
+
+cnf-sem : CNF Γ → (Fin Γ → Bool) → Bool
+cnf-sem Ps ρ = all-of (λ d → disj-sem d ρ) Ps
+
+instance
+  ⟦⟧-Literal : ⟦⟧-notation (Literal Γ)
+  ⟦⟧-Literal {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) lit-sem
+
+  ⟦⟧-Disjunction : ⟦⟧-notation (Disjunction Γ)
+  ⟦⟧-Disjunction {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) disj-sem
+
+  ⟦⟧-CNF : ⟦⟧-notation (CNF Γ)
+  ⟦⟧-CNF {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) cnf-sem
+
+cnf-lit : Fin Γ → CNF Γ
+cnf-lit x = (lit x ∷ []) ∷ []
+
+⊤cnf : CNF Γ
+⊤cnf = []
+
+⊥cnf : CNF Γ
+⊥cnf = [] ∷ []
+
+⊥cnf-sound : ∀ (ρ : Fin Γ → Bool) → ⟦ ⊥cnf ⟧ ρ ≡ false
+⊥cnf-sound ρ = refl
+
+_∧cnf_ : CNF Γ → CNF Γ → CNF Γ
+xs ∧cnf ys = xs List.++ ys
+
+cnf-distrib : Disjunction Γ → CNF Γ → CNF Γ
+cnf-distrib P Q = map (P List.++_) Q
+
+_∨cnf_ : CNF Γ → CNF Γ → CNF Γ
+[] ∨cnf Q = []
+(P ∷ Ps) ∨cnf Q = cnf-distrib P Q ∧cnf (Ps ∨cnf Q)
+
+¬lit : Literal Γ → Literal Γ
+¬lit (lit x) = neg x
+¬lit (neg x) = lit x
+
+¬disj : Disjunction Γ → CNF Γ
+¬disj P = map (λ a → ¬lit a ∷ []) P
+
+¬cnf : CNF Γ → CNF Γ
+¬cnf [] = ⊥cnf
+¬cnf (P ∷ Q) = ¬disj P ∨cnf ¬cnf Q
+```
+
+## Soundness
+
+```agda
+cnf-lit-sound : ∀ (x : Fin Γ) (ρ : Fin Γ → Bool) → ⟦ cnf-lit x ⟧ ρ ≡ ρ x
+cnf-lit-sound x ρ = and-truer _ ∙ or-falser _
+
+⊤cnf-sound : ∀ (ρ : Fin Γ → Bool) → ⟦ ⊤cnf ⟧ ρ ≡ true
+⊤cnf-sound ρ = refl
+
+∧cnf-sound : ∀ (P Q : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ P ∧cnf Q ⟧ ρ ≡ and (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
+∧cnf-sound P Q ρ = all-of-++ (any-of (λ a → lit-sem a ρ)) P Q
+
+cnf-distrib-sound
+  : (P : Disjunction Γ) (Q : CNF Γ)
+  → (ρ : Fin Γ → Bool)
+  → ⟦ cnf-distrib P Q ⟧ ρ ≡ or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
+cnf-distrib-sound [] Q ρ = ap (all-of (λ d → disj-sem d ρ)) (map-id Q)
+cnf-distrib-sound (P ∷ Ps) Q ρ =
+  all-of (λ d → ⟦ d ⟧ ρ) (map (λ ys → P ∷ (Ps List.++ ys)) Q) ≡⟨ all-of-map _ _ Q ⟩
+  all-of (λ d → ⟦ P ∷ (Ps List.++ d) ⟧ ρ) Q                   ≡⟨ ap (λ ϕ → all-of ϕ Q) (funext λ d → any-of-++ _ (P ∷ Ps) d) ⟩
+  all-of (λ d → or (⟦ P ∷ Ps ⟧ ρ) (⟦ d ⟧ ρ)) Q                ≡⟨ all-of-or (λ d → ⟦ d ⟧ ρ) (⟦ P ∷ Ps ⟧ ρ) Q ⟩
+  or (⟦ P ∷ Ps ⟧ ρ) (⟦ Q ⟧ ρ)                                 ∎
+
+∨cnf-sound : ∀ (P Q : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ P ∨cnf Q ⟧ ρ ≡ or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
+∨cnf-sound [] Q ρ = refl
+∨cnf-sound (P ∷ Ps) Q ρ =
+  ⟦ (P ∷ Ps) ∨cnf Q ⟧ ρ                                  ≡⟨ all-of-++ (λ d → disj-sem d ρ) (cnf-distrib P Q) (Ps ∨cnf Q) ⟩
+  and (⟦ cnf-distrib P Q ⟧ ρ) (⟦ Ps ∨cnf Q ⟧ ρ)          ≡⟨ ap₂ and (cnf-distrib-sound P Q ρ) (∨cnf-sound Ps Q ρ) ⟩
+  and (or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)) (or (⟦ Ps ⟧ ρ) (⟦ Q ⟧ ρ)) ≡˘⟨ or-distrib-andr (⟦ P ⟧ ρ) (⟦ Ps ⟧ ρ) (⟦ Q ⟧ ρ) ⟩
+  or (⟦ P ∷ Ps ⟧ ρ) (⟦ Q ⟧ ρ) ∎
+
+¬lit-sound : (a : Literal Γ) → (ρ : Fin Γ → Bool) → ⟦ ¬lit a ⟧ ρ ≡ not (⟦ a ⟧ ρ)
+¬lit-sound (lit x) ρ = refl
+¬lit-sound (neg x) ρ = sym (not-involutive (ρ x))
+
+¬disj-sound : ∀ (P : Disjunction Γ) → (ρ : Fin Γ → Bool) → ⟦ ¬disj P ⟧ ρ ≡ not (⟦ P ⟧ ρ)
+¬disj-sound P ρ =
+  all-of (λ d → ⟦ d ⟧ ρ) (map (λ a → ¬lit a ∷ []) P) ≡⟨ all-of-map (λ d → ⟦ d ⟧ ρ) (λ a → ¬lit a ∷ []) P ⟩
+  all-of (λ a → or (⟦ ¬lit a ⟧ ρ) false) P       ≡⟨ ap (λ ϕ → all-of ϕ P) (funext λ a → or-falser (⟦ ¬lit a ⟧ ρ)) ⟩
+  all-of (λ a → ⟦ ¬lit a ⟧ ρ) P                  ≡⟨ ap (λ ϕ → all-of ϕ P) (funext λ a → ¬lit-sound a ρ) ⟩
+  all-of (λ a → not (⟦ a ⟧ ρ)) P                  ≡˘⟨ not-any-of (λ a → ⟦ a ⟧ ρ) P ⟩
+  not (⟦ P ⟧ ρ)                                   ∎
+
+¬cnf-sound : ∀ (P : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ ¬cnf P ⟧ ρ ≡ not (⟦ P ⟧ ρ)
+¬cnf-sound [] ρ = refl
+¬cnf-sound (P ∷ Ps) ρ =
+  ⟦ (¬disj P ∨cnf ¬cnf Ps) ⟧ ρ        ≡⟨ ∨cnf-sound (¬disj P) (¬cnf Ps) ρ ⟩
+  or (⟦ ¬disj P ⟧ ρ) (⟦ ¬cnf Ps ⟧ ρ)  ≡⟨ ap₂ or (¬disj-sound P ρ) (¬cnf-sound Ps ρ) ⟩
+  or (not (⟦ P ⟧ ρ)) (not (⟦ Ps ⟧ ρ)) ≡˘⟨ not-and≡or-not (⟦ P  ⟧ ρ) (⟦ Ps ⟧ ρ) ⟩
+  not (⟦ P ∷ Ps ⟧ ρ)                  ∎
+```
+
+## A Naive Algorithm
+
+```agda
+cnf : Proposition Γ → CNF Γ
+cnf (var x) = cnf-lit x
+cnf “⊤” = ⊤cnf
+cnf “⊥” = ⊥cnf
+cnf (P “∧” Q) = cnf P ∧cnf cnf Q
+cnf (P “∨” Q) = cnf P ∨cnf cnf Q
+cnf (“¬” P) = ¬cnf (cnf P)
+
+cnf-sound
+  : ∀ (P : Proposition Γ)
+  → (ρ : Fin Γ → Bool)
+  → ⟦ cnf P ⟧ ρ ≡ ⟦ P ⟧ ρ
+cnf-sound (var x) ρ =
+  and-truer (or (ρ x) false)
+  ∙ or-falser (ρ x)
+cnf-sound “⊤” ρ = refl
+cnf-sound “⊥” ρ = refl
+cnf-sound (P “∧” Q) ρ =
+  ∧cnf-sound (cnf P) (cnf Q) ρ
+  ∙ ap₂ and (cnf-sound P ρ) (cnf-sound Q ρ)
+cnf-sound (P “∨” Q) ρ =
+  ∨cnf-sound (cnf P) (cnf Q) ρ
+  ∙ ap₂ or (cnf-sound P ρ) (cnf-sound Q ρ)
+cnf-sound (“¬” P) ρ =
+  ¬cnf-sound (cnf P) ρ
+  ∙ ap not (cnf-sound P ρ)
+```
+
+## Quotation
+
+```agda
+quote-lit : Literal Γ → Proposition Γ
+quote-lit (lit x) = var x
+quote-lit (neg x) = “¬” (var x)
+
+quote-disj : Disjunction Γ → Proposition Γ
+quote-disj [] = “⊥”
+quote-disj (x ∷ ϕ) = quote-lit x “∨” quote-disj ϕ
+
+quote-cnf : CNF Γ → Proposition Γ
+quote-cnf [] = “⊤”
+quote-cnf (ϕ ∷ ϕs) = quote-disj ϕ “∧” quote-cnf ϕs
+
+quote-lit-sound : ∀ (x : Literal Γ) → (ρ : Fin Γ → Bool) → ⟦ x ⟧ ρ ≡ ⟦ quote-lit x ⟧ ρ
+quote-lit-sound (lit x) ρ = refl
+quote-lit-sound (neg x) ρ = refl
+
+quote-disj-sound : ∀ (ϕ : Disjunction Γ) → (ρ : Fin Γ → Bool) → ⟦ ϕ ⟧ ρ ≡ ⟦ quote-disj ϕ ⟧ ρ
+quote-disj-sound [] ρ = refl
+quote-disj-sound (x ∷ ϕ) ρ = ap₂ or (quote-lit-sound x ρ) (quote-disj-sound ϕ ρ)
+
+quote-cnf-sound : ∀ (ϕ : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ ϕ ⟧ ρ ≡ ⟦ quote-cnf ϕ ⟧ ρ
+quote-cnf-sound [] ρ = refl
+quote-cnf-sound (ϕ ∷ ϕs) ρ = ap₂ and (quote-disj-sound ϕ ρ) (quote-cnf-sound ϕs ρ)
+```
+
+<!--
+```agda
+literal-eq-negate : ∀ (x y : Literal Γ) → ¬ x ≡ y → lit-var x ≡ lit-var y → x ≡ ¬lit y
+literal-eq-negate (lit x) (lit y) x≠y p = absurd (x≠y (ap lit p))
+literal-eq-negate (lit x) (neg y) x≠y p = ap lit p
+literal-eq-negate (neg x) (lit y) x≠y p = ap neg p
+literal-eq-negate (neg x) (neg y) x≠y p = absurd (x≠y (ap neg p))
+
+literal-sat-val : ∀ (x : Literal Γ) → (ρ : Fin Γ → Bool) → ⟦ x ⟧ ρ ≡ true → ρ (lit-var x) ≡ lit-val x
+literal-sat-val (lit x) ρ x-true = x-true
+literal-sat-val (neg x) ρ x-true = not-inj x-true
+```
+-->

--- a/src/Logic/Propositional/Classical/CNF.lagda.md
+++ b/src/Logic/Propositional/Classical/CNF.lagda.md
@@ -21,18 +21,33 @@ import Data.List as List
 module Logic.Propositional.Classical.CNF where
 ```
 
-## Conjunctive Normal Forms
+## Conjunctive Normal Forms {defines="conjunctive-normal-form CNF"}
+
+As a general theme, it is often very useful to have some notion of
+normal-form for logical and algebraic expressions, and
+[[Classical propositional logic]] is no different! There are multiple
+possible choices of normal form, but we will be focusing on
+**conjunctive normal form**, or CNF for short.
+
+An statement in propositional logic is in conjunctive normal form if
+it is written as a conjunction of disjunctions of (potentially negated)
+atoms. As an example, something like $(P \vee \neg Q) \wedge (\neg R \vee P)$
+is in conjunctive normal form, yet something like $(P \wedge Q) \vee \neg R$
+is not.
+
+We call the potentially negated atoms in a CNF expression **literals**,
+and the disjunctions **clauses**.
 
 ```agda
 data Literal (Γ : Nat) : Type where
   lit : Fin Γ → Literal Γ
   neg : Fin Γ → Literal Γ
 
-Disjunction : (Γ : Nat) → Type
-Disjunction Γ = List (Literal Γ)
+Clause : (Γ : Nat) → Type
+Clause Γ = List (Literal Γ)
 
 CNF : (Γ : Nat) → Type
-CNF Γ = List (Disjunction Γ)
+CNF Γ = List (Clause Γ)
 ```
 
 <!--
@@ -82,66 +97,100 @@ avoid-lit i (neg x) p = neg (avoid i x p)
 
 ## Semantics
 
+Like their non-normal form bretheren, expressions in CNF have a natural
+semantics in booleans. However, evaluation is particularly easy!
+
 ```agda
 lit-sem : Literal Γ → (Fin Γ → Bool) → Bool
 lit-sem (lit x) ρ = ρ x
 lit-sem (neg x) ρ = not (ρ x)
 
-disj-sem : Disjunction Γ → (Fin Γ → Bool) → Bool
-disj-sem Ps ρ = any-of (λ a → lit-sem a ρ) Ps
+clause-sem : Clause Γ → (Fin Γ → Bool) → Bool
+clause-sem Ps ρ = any-of (λ a → lit-sem a ρ) Ps
 
 cnf-sem : CNF Γ → (Fin Γ → Bool) → Bool
-cnf-sem Ps ρ = all-of (λ d → disj-sem d ρ) Ps
+cnf-sem Ps ρ = all-of (λ d → clause-sem d ρ) Ps
 
 instance
   ⟦⟧-Literal : ⟦⟧-notation (Literal Γ)
   ⟦⟧-Literal {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) lit-sem
 
-  ⟦⟧-Disjunction : ⟦⟧-notation (Disjunction Γ)
-  ⟦⟧-Disjunction {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) disj-sem
+  ⟦⟧-Clause : ⟦⟧-notation (Clause Γ)
+  ⟦⟧-Clause {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) clause-sem
 
   ⟦⟧-CNF : ⟦⟧-notation (CNF Γ)
   ⟦⟧-CNF {Γ = Γ} = brackets ((Fin Γ → Bool) → Bool) cnf-sem
+```
 
-cnf-lit : Fin Γ → CNF Γ
-cnf-lit x = (lit x ∷ []) ∷ []
+## Soundness
 
+We can extend the normal operations on propositions to expressions
+in CNF.
+
+Atoms $P$ are represented by a single clause.
+
+```agda
+cnf-atom : Fin Γ → CNF Γ
+cnf-atom x = (lit x ∷ []) ∷ []
+```
+
+True and false are represented by an expression with no clauses,
+and an expression with a single empty clause, respectively.
+
+```agda
 ⊤cnf : CNF Γ
 ⊤cnf = []
 
 ⊥cnf : CNF Γ
 ⊥cnf = [] ∷ []
+```
 
-⊥cnf-sound : ∀ (ρ : Fin Γ → Bool) → ⟦ ⊥cnf ⟧ ρ ≡ false
-⊥cnf-sound ρ = refl
+Conjunction can be defined by appending lists.
 
+```agda
 _∧cnf_ : CNF Γ → CNF Γ → CNF Γ
 xs ∧cnf ys = xs List.++ ys
+```
 
-cnf-distrib : Disjunction Γ → CNF Γ → CNF Γ
+Disjunction is somewhat tricky, but can be handled by distributing
+each clause.
+
+```agda
+cnf-distrib : Clause Γ → CNF Γ → CNF Γ
 cnf-distrib P Q = map (P List.++_) Q
 
 _∨cnf_ : CNF Γ → CNF Γ → CNF Γ
 [] ∨cnf Q = []
 (P ∷ Ps) ∨cnf Q = cnf-distrib P Q ∧cnf (Ps ∨cnf Q)
+```
 
+Negation is performed by negating all the clauses, and then
+taking the disjunction of the negated clauses.
+
+```agda
 ¬lit : Literal Γ → Literal Γ
 ¬lit (lit x) = neg x
 ¬lit (neg x) = lit x
 
-¬disj : Disjunction Γ → CNF Γ
-¬disj P = map (λ a → ¬lit a ∷ []) P
+¬clause : Clause Γ → CNF Γ
+¬clause P = map (λ a → ¬lit a ∷ []) P
 
 ¬cnf : CNF Γ → CNF Γ
 ¬cnf [] = ⊥cnf
-¬cnf (P ∷ Q) = ¬disj P ∨cnf ¬cnf Q
+¬cnf (P ∷ Q) = ¬clause P ∨cnf ¬cnf Q
 ```
 
-## Soundness
+<details>
+<summary>All these operations are sound, but it is somewhat tedious
+to show this.
+</summary>
 
 ```agda
-cnf-lit-sound : ∀ (x : Fin Γ) (ρ : Fin Γ → Bool) → ⟦ cnf-lit x ⟧ ρ ≡ ρ x
-cnf-lit-sound x ρ = and-truer _ ∙ or-falser _
+cnf-atom-sound : ∀ (x : Fin Γ) (ρ : Fin Γ → Bool) → ⟦ cnf-atom x ⟧ ρ ≡ ρ x
+cnf-atom-sound x ρ = and-truer _ ∙ or-falser _
+
+⊥cnf-sound : ∀ (ρ : Fin Γ → Bool) → ⟦ ⊥cnf ⟧ ρ ≡ false
+⊥cnf-sound ρ = refl
 
 ⊤cnf-sound : ∀ (ρ : Fin Γ → Bool) → ⟦ ⊤cnf ⟧ ρ ≡ true
 ⊤cnf-sound ρ = refl
@@ -150,10 +199,10 @@ cnf-lit-sound x ρ = and-truer _ ∙ or-falser _
 ∧cnf-sound P Q ρ = all-of-++ (any-of (λ a → lit-sem a ρ)) P Q
 
 cnf-distrib-sound
-  : (P : Disjunction Γ) (Q : CNF Γ)
+  : (P : Clause Γ) (Q : CNF Γ)
   → (ρ : Fin Γ → Bool)
   → ⟦ cnf-distrib P Q ⟧ ρ ≡ or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
-cnf-distrib-sound [] Q ρ = ap (all-of (λ d → disj-sem d ρ)) (map-id Q)
+cnf-distrib-sound [] Q ρ = ap (all-of (λ d → clause-sem d ρ)) (map-id Q)
 cnf-distrib-sound (P ∷ Ps) Q ρ =
   all-of (λ d → ⟦ d ⟧ ρ) (map (λ ys → P ∷ (Ps List.++ ys)) Q) ≡⟨ all-of-map _ _ Q ⟩
   all-of (λ d → ⟦ P ∷ (Ps List.++ d) ⟧ ρ) Q                   ≡⟨ ap (λ ϕ → all-of ϕ Q) (funext λ d → any-of-++ _ (P ∷ Ps) d) ⟩
@@ -163,7 +212,7 @@ cnf-distrib-sound (P ∷ Ps) Q ρ =
 ∨cnf-sound : ∀ (P Q : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ P ∨cnf Q ⟧ ρ ≡ or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)
 ∨cnf-sound [] Q ρ = refl
 ∨cnf-sound (P ∷ Ps) Q ρ =
-  ⟦ (P ∷ Ps) ∨cnf Q ⟧ ρ                                  ≡⟨ all-of-++ (λ d → disj-sem d ρ) (cnf-distrib P Q) (Ps ∨cnf Q) ⟩
+  ⟦ (P ∷ Ps) ∨cnf Q ⟧ ρ                                  ≡⟨ all-of-++ (λ d → clause-sem d ρ) (cnf-distrib P Q) (Ps ∨cnf Q) ⟩
   and (⟦ cnf-distrib P Q ⟧ ρ) (⟦ Ps ∨cnf Q ⟧ ρ)          ≡⟨ ap₂ and (cnf-distrib-sound P Q ρ) (∨cnf-sound Ps Q ρ) ⟩
   and (or (⟦ P ⟧ ρ) (⟦ Q ⟧ ρ)) (or (⟦ Ps ⟧ ρ) (⟦ Q ⟧ ρ)) ≡˘⟨ or-distrib-andr (⟦ P ⟧ ρ) (⟦ Ps ⟧ ρ) (⟦ Q ⟧ ρ) ⟩
   or (⟦ P ∷ Ps ⟧ ρ) (⟦ Q ⟧ ρ) ∎
@@ -172,8 +221,8 @@ cnf-distrib-sound (P ∷ Ps) Q ρ =
 ¬lit-sound (lit x) ρ = refl
 ¬lit-sound (neg x) ρ = sym (not-involutive (ρ x))
 
-¬disj-sound : ∀ (P : Disjunction Γ) → (ρ : Fin Γ → Bool) → ⟦ ¬disj P ⟧ ρ ≡ not (⟦ P ⟧ ρ)
-¬disj-sound P ρ =
+¬clause-sound : ∀ (P : Clause Γ) → (ρ : Fin Γ → Bool) → ⟦ ¬clause P ⟧ ρ ≡ not (⟦ P ⟧ ρ)
+¬clause-sound P ρ =
   all-of (λ d → ⟦ d ⟧ ρ) (map (λ a → ¬lit a ∷ []) P) ≡⟨ all-of-map (λ d → ⟦ d ⟧ ρ) (λ a → ¬lit a ∷ []) P ⟩
   all-of (λ a → or (⟦ ¬lit a ⟧ ρ) false) P       ≡⟨ ap (λ ϕ → all-of ϕ P) (funext λ a → or-falser (⟦ ¬lit a ⟧ ρ)) ⟩
   all-of (λ a → ⟦ ¬lit a ⟧ ρ) P                  ≡⟨ ap (λ ϕ → all-of ϕ P) (funext λ a → ¬lit-sound a ρ) ⟩
@@ -183,17 +232,24 @@ cnf-distrib-sound (P ∷ Ps) Q ρ =
 ¬cnf-sound : ∀ (P : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ ¬cnf P ⟧ ρ ≡ not (⟦ P ⟧ ρ)
 ¬cnf-sound [] ρ = refl
 ¬cnf-sound (P ∷ Ps) ρ =
-  ⟦ (¬disj P ∨cnf ¬cnf Ps) ⟧ ρ        ≡⟨ ∨cnf-sound (¬disj P) (¬cnf Ps) ρ ⟩
-  or (⟦ ¬disj P ⟧ ρ) (⟦ ¬cnf Ps ⟧ ρ)  ≡⟨ ap₂ or (¬disj-sound P ρ) (¬cnf-sound Ps ρ) ⟩
+  ⟦ (¬clause P ∨cnf ¬cnf Ps) ⟧ ρ        ≡⟨ ∨cnf-sound (¬clause P) (¬cnf Ps) ρ ⟩
+  or (⟦ ¬clause P ⟧ ρ) (⟦ ¬cnf Ps ⟧ ρ)  ≡⟨ ap₂ or (¬clause-sound P ρ) (¬cnf-sound Ps ρ) ⟩
   or (not (⟦ P ⟧ ρ)) (not (⟦ Ps ⟧ ρ)) ≡˘⟨ not-and≡or-not (⟦ P  ⟧ ρ) (⟦ Ps ⟧ ρ) ⟩
   not (⟦ P ∷ Ps ⟧ ρ)                  ∎
 ```
+</details>
 
 ## A Naive Algorithm
 
+Armed with these operations on CNFs, we can give a translation
+from propositions into CNF. However, note that this is extremely
+naive, and will result in huge clause sizes! This is due to the fact that
+disjunction and negation distribute clauses, which will result in potentially
+exponential blow-ups in expression sizes.
+
 ```agda
 cnf : Proposition Γ → CNF Γ
-cnf (var x) = cnf-lit x
+cnf (atom x) = cnf-atom x
 cnf “⊤” = ⊤cnf
 cnf “⊥” = ⊥cnf
 cnf (P “∧” Q) = cnf P ∧cnf cnf Q
@@ -204,7 +260,7 @@ cnf-sound
   : ∀ (P : Proposition Γ)
   → (ρ : Fin Γ → Bool)
   → ⟦ cnf P ⟧ ρ ≡ ⟦ P ⟧ ρ
-cnf-sound (var x) ρ =
+cnf-sound (atom x) ρ =
   and-truer (or (ρ x) false)
   ∙ or-falser (ρ x)
 cnf-sound “⊤” ρ = refl
@@ -222,30 +278,33 @@ cnf-sound (“¬” P) ρ =
 
 ## Quotation
 
+We can also read expressions in CNF back into propositions. Luckily,
+there are no exponential blow-ups here!
+
 ```agda
 quote-lit : Literal Γ → Proposition Γ
-quote-lit (lit x) = var x
-quote-lit (neg x) = “¬” (var x)
+quote-lit (lit x) = atom x
+quote-lit (neg x) = “¬” (atom x)
 
-quote-disj : Disjunction Γ → Proposition Γ
-quote-disj [] = “⊥”
-quote-disj (x ∷ ϕ) = quote-lit x “∨” quote-disj ϕ
+quote-clause : Clause Γ → Proposition Γ
+quote-clause [] = “⊥”
+quote-clause (x ∷ ϕ) = quote-lit x “∨” quote-clause ϕ
 
 quote-cnf : CNF Γ → Proposition Γ
 quote-cnf [] = “⊤”
-quote-cnf (ϕ ∷ ϕs) = quote-disj ϕ “∧” quote-cnf ϕs
+quote-cnf (ϕ ∷ ϕs) = quote-clause ϕ “∧” quote-cnf ϕs
 
 quote-lit-sound : ∀ (x : Literal Γ) → (ρ : Fin Γ → Bool) → ⟦ x ⟧ ρ ≡ ⟦ quote-lit x ⟧ ρ
 quote-lit-sound (lit x) ρ = refl
 quote-lit-sound (neg x) ρ = refl
 
-quote-disj-sound : ∀ (ϕ : Disjunction Γ) → (ρ : Fin Γ → Bool) → ⟦ ϕ ⟧ ρ ≡ ⟦ quote-disj ϕ ⟧ ρ
-quote-disj-sound [] ρ = refl
-quote-disj-sound (x ∷ ϕ) ρ = ap₂ or (quote-lit-sound x ρ) (quote-disj-sound ϕ ρ)
+quote-clause-sound : ∀ (ϕ : Clause Γ) → (ρ : Fin Γ → Bool) → ⟦ ϕ ⟧ ρ ≡ ⟦ quote-clause ϕ ⟧ ρ
+quote-clause-sound [] ρ = refl
+quote-clause-sound (x ∷ ϕ) ρ = ap₂ or (quote-lit-sound x ρ) (quote-clause-sound ϕ ρ)
 
 quote-cnf-sound : ∀ (ϕ : CNF Γ) → (ρ : Fin Γ → Bool) → ⟦ ϕ ⟧ ρ ≡ ⟦ quote-cnf ϕ ⟧ ρ
 quote-cnf-sound [] ρ = refl
-quote-cnf-sound (ϕ ∷ ϕs) ρ = ap₂ and (quote-disj-sound ϕ ρ) (quote-cnf-sound ϕs ρ)
+quote-cnf-sound (ϕ ∷ ϕs) ρ = ap₂ and (quote-clause-sound ϕ ρ) (quote-cnf-sound ϕs ρ)
 ```
 
 <!--

--- a/src/Logic/Propositional/Classical/SAT.lagda.md
+++ b/src/Logic/Propositional/Classical/SAT.lagda.md
@@ -1,0 +1,319 @@
+<!--
+```agda
+open import 1Lab.Prelude
+
+open import Data.Bool
+open import Data.Dec
+open import Data.Fin using (Fin; fzero; fsuc; Discrete-Fin; avoid; _[_≔_]; delete)
+open import Data.List hiding (_++_)
+open import Data.Nat
+open import Data.Sum
+
+open import Logic.Propositional.Classical
+open import Logic.Propositional.Classical.CNF
+
+open import Meta.Brackets
+
+import Data.Fin as Fin
+```
+-->
+
+```agda
+module Logic.Propositional.Classical.SAT where
+```
+
+<!--
+```agda
+private variable
+  Γ Δ Θ : Nat
+  ψ θ ζ : Ctx Γ
+  P Q R : Proposition Γ
+```
+-->
+
+# Unit Propagation
+
+```agda
+delete-literals
+  : (x : Fin (suc Γ))
+  → (ϕ : Disjunction (suc Γ))
+  → Disjunction Γ
+delete-literals {Γ = zero} i ϕ = []
+delete-literals {Γ = suc Γ} i [] = []
+delete-literals {Γ = suc Γ} i (x ∷ ϕ) =
+  Dec-rec
+    (λ _ → delete-literals i ϕ)
+    (λ i≠x → avoid-lit i x i≠x ∷ delete-literals i ϕ)
+    (Discrete-Fin i (lit-var x))
+
+unit-propagate : Literal (suc Γ) → CNF (suc Γ) → CNF Γ
+unit-propagate x [] = []
+unit-propagate x (ϕ ∷ ϕs) =
+  Dec-rec
+    (λ _ → unit-propagate x ϕs)
+    (λ _ → delete-literals (lit-var x) ϕ ∷ unit-propagate x ϕs)
+    (elem? Discrete-Literal x ϕ)
+```
+
+```agda
+avoid-lit-insert
+  : ∀ (x y : Literal (suc Γ)) → (x≠y : ¬ (lit-var x ≡ lit-var y))
+  → (ρ : Fin Γ → Bool)
+  → ⟦ y ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ avoid-lit (lit-var x) y x≠y ⟧ ρ
+avoid-lit-insert {Γ = Γ} x (lit y) x≠y ρ = Fin.avoid-insert ρ (lit-var x) (lit-val x) y x≠y
+avoid-lit-insert {Γ = Γ} x (neg y) x≠y ρ = ap not (Fin.avoid-insert ρ (lit-var x) (lit-val x) y x≠y)
+
+lit-assign-neg-false
+  : ∀ (x : Literal (suc Γ))
+  → (ρ : Fin Γ → Bool)
+  → ⟦ x ⟧ (ρ [ lit-var (¬lit x) ≔ lit-val (¬lit x) ]) ≡ false
+lit-assign-neg-false (lit x) ρ = Fin.insert-lookup ρ x false
+lit-assign-neg-false (neg x) ρ = ap not (Fin.insert-lookup ρ x true)
+
+lit-assign-true
+  : ∀ (x : Literal (suc Γ))
+  → (ρ : Fin Γ → Bool)
+  → ⟦ x ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ true
+lit-assign-true (lit x) ρ = Fin.insert-lookup ρ x true
+lit-assign-true (neg x) ρ = ap not (Fin.insert-lookup ρ x false)
+
+delete-literals-sound
+  : (x : Literal (suc Γ))
+  → (ϕ : Disjunction (suc Γ))
+  → ¬ (x ∈ₗ ϕ)
+  → ∀ (ρ : Fin Γ → Bool)
+  → ⟦ ϕ ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ delete-literals (lit-var x) ϕ ⟧ ρ
+delete-literals-sound {zero} x [] x∉ϕ ρ = refl
+delete-literals-sound {zero} (lit fzero) (lit fzero ∷ ϕ) x∉ϕ ρ =
+  absurd (x∉ϕ (inl refl))
+delete-literals-sound {zero} (lit fzero) (neg fzero ∷ ϕ) x∉ϕ ρ =
+  delete-literals-sound (lit fzero) ϕ (x∉ϕ ∘ inr) ρ
+delete-literals-sound {zero} (neg fzero) (lit fzero ∷ ϕ) x∉ϕ ρ =
+  delete-literals-sound (neg fzero) ϕ (x∉ϕ ∘ inr) ρ
+delete-literals-sound {zero} (neg fzero) (neg fzero ∷ ϕ) x∉ϕ ρ =
+  absurd (x∉ϕ (inl refl))
+delete-literals-sound {suc Γ} x [] x∉ϕ ρ = refl
+delete-literals-sound {suc Γ} x (y ∷ ϕ) x∉ϕ ρ with Discrete-Fin (lit-var x) (lit-var y)
+... | yes x=y =
+  ap₂ or
+    (subst (λ e → ⟦ y ⟧ (ρ [ lit-var e ≔ lit-val e ]) ≡ false)
+      (sym (literal-eq-negate x y (x∉ϕ ∘ inl) x=y))
+      (lit-assign-neg-false y ρ))
+    refl
+  ∙ delete-literals-sound x ϕ (x∉ϕ ∘ inr) ρ
+... | no x≠y =
+  ap₂ or
+    (avoid-lit-insert x y x≠y ρ)
+    (delete-literals-sound x ϕ (x∉ϕ ∘ inr) ρ)
+
+unit-propagate-sound
+  : (x : Literal (suc Γ))
+  → (ϕs : CNF (suc Γ))
+  → ∀ (ρ : Fin Γ → Bool)
+  → ⟦ ϕs ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ unit-propagate x ϕs ⟧ ρ
+unit-propagate-sound x [] ρ = refl
+unit-propagate-sound x (ϕ ∷ ϕs) ρ with elem? Discrete-Literal x ϕ
+... | yes x∈ϕ =
+  ap₂ and
+    (any-one-of (λ l → ⟦ l ⟧ (ρ [ lit-var x ≔ lit-val x ]))
+      x ϕ x∈ϕ
+      (lit-assign-true x ρ))
+    (unit-propagate-sound x ϕs ρ)
+... | no ¬x∉ϕ =
+  ap₂ and
+    (delete-literals-sound x ϕ ¬x∉ϕ ρ)
+    (unit-propagate-sound x ϕs ρ)
+
+unit-propagate-complete
+  : (x : Literal (suc Γ))
+  → (ϕs : CNF (suc Γ))
+  → ∀ (ρ : Fin (suc Γ) → Bool)
+  → ⟦ x ⟧ ρ ≡ true
+  → ⟦ ϕs ⟧ ρ ≡ ⟦ unit-propagate x ϕs ⟧ (delete ρ (lit-var x))
+unit-propagate-complete x ϕs ρ x-true =
+  ap ⟦ ϕs ⟧ (sym $ funext $
+    Fin.insert-delete ρ (lit-var x) (lit-val x) (literal-sat-val x ρ x-true))
+  ∙ unit-propagate-sound x ϕs (delete ρ (lit-var x))
+```
+
+```agda
+has-unit-clause? : ∀ (ϕs : CNF Γ) → Dec (Σ[ x ∈ Literal Γ ] ((x ∷ []) ∈ₗ ϕs))
+has-unit-clause? [] = no (Lift.lower ∘ snd)
+has-unit-clause? ([] ∷ ϕs) =
+  Dec-rec
+    (λ (x , x∈ϕs) → yes (x , inr x∈ϕs))
+    (λ ¬ϕ-unit → no (λ (x , x∈ϕs) →
+      [ ∷≠[]
+      , (λ x∈ϕs → ¬ϕ-unit (x , x∈ϕs))
+      ] x∈ϕs))
+    (has-unit-clause? ϕs)
+has-unit-clause? ((x ∷ []) ∷ ϕs) = yes (x , inl refl)
+has-unit-clause? ((x ∷ y ∷ ϕ) ∷ ϕs) =
+  Dec-rec
+    (λ (x , x∈ϕs) → yes (x , inr x∈ϕs))
+    (λ ¬ϕ-unit → no (λ (x , x∈ϕs) →
+      [ ∷≠[] ∘ ∷-tail-inj ∘ sym
+      , (λ x∈ϕs → ¬ϕ-unit (x , x∈ϕs))
+      ] x∈ϕs))
+    (has-unit-clause? ϕs)
+
+unit-clause-sat
+  : (x : Literal Γ)
+  → (ϕs : CNF Γ)
+  → (x ∷ []) ∈ₗ ϕs
+  → (ρ : Fin Γ → Bool)
+  → ⟦ ϕs ⟧ ρ ≡ true
+  → ⟦ x ⟧ ρ ≡ true
+unit-clause-sat x (ϕ ∷ ϕs) (inl [x]=ϕ) ρ ϕs-sat =
+  sym (or-falser _)
+  ∙ ap (λ e → (⟦ e ⟧ ρ)) [x]=ϕ
+  ∙ and-reflect-true-l ϕs-sat
+unit-clause-sat x (y ∷ ϕs) (inr [x]∈ϕs) ρ ϕs-sat =
+  unit-clause-sat x ϕs [x]∈ϕs ρ (and-reflect-true-r ϕs-sat)
+```
+
+
+# Pure Literal Elimination
+
+```agda
+is-pure-literal : Fin Γ → CNF Γ → Type
+is-pure-literal {Γ = Γ} i ϕs =
+  Σ[ b ∈ Bool ] (∀ ϕ → ϕ ∈ₗ ϕs → (x : Literal Γ) → x ∈ₗ ϕ → lit-var x ≡ i → lit-val x ≡ b)
+  -- {!∀ ϕ → ϕ ∈ₗ !} ⊎ {!!}
+  -- (∀ ϕ → ϕ ∈ₗ ϕs → x ∈ₗ ϕ → ?) ⊎
+  -- (∀ ϕ → ϕ ∈ₗ ϕs → x ∈ₗ ϕ → ?)
+
+-- is-pure-literal? : (x : Literal Γ) → (ϕs : CNF Γ) → Dec (is-pure-literal x ϕs)
+-- is-pure-literal? x [] = yes (inl λ _ ff _ → absurd (Lift.lower ff))
+-- is-pure-literal? x (y ∷ ϕs) = {!!}
+-- data Polarity -- : Type where
+--   pos : Polarity
+--   neg : Polarity
+--   mixed : Polarity
+--   none : Polarity
+
+-- _⊗p_ : Polarity → Polarity → Polarity
+-- pos ⊗p pos = pos
+-- pos ⊗p neg = mixed
+-- pos ⊗p mixed = mixed
+-- pos ⊗p none = pos
+-- neg ⊗p pos = mixed
+-- neg ⊗p neg = neg
+-- neg ⊗p mixed = mixed
+-- neg ⊗p none = neg
+-- mixed ⊗p q = mixed
+-- none ⊗p q = q
+
+-- is-pos : Polarity → Type
+-- is-pos pos = ⊤
+-- is-pos neg = ⊥
+-- is-pos mixed = ⊥
+-- is-pos none = ⊥
+
+-- pos≠neg : pos ≡ neg → ⊥
+-- pos≠neg p = subst is-pos p tt 
+
+-- Discrete-Polarity : Discrete Polarity
+-- Discrete-Polarity pos pos = yes refl
+-- Discrete-Polarity pos neg = no pos≠neg
+-- Discrete-Polarity pos mixed = {!!}
+-- Discrete-Polarity pos none = {!!}
+-- Discrete-Polarity neg q = {!!}
+-- Discrete-Polarity mixed q = {!!}
+-- Discrete-Polarity none q = {!!}
+
+-- lit-polarity : Literal Γ → Polarity
+-- lit-polarity (lit _) = pos
+-- lit-polarity (neg _) = neg
+
+-- disj-polarity : Fin Γ → Disjunction Γ → Polarity
+-- disj-polarity i [] = none
+-- disj-polarity i (x ∷ ϕ) =
+--   Dec-rec
+--     (λ _ → lit-polarity x ⊗p disj-polarity i ϕ)
+--     (λ _ → disj-polarity i ϕ)
+--     (Discrete-Fin i (lit-var x))
+
+-- cnf-polarity : Fin Γ → CNF Γ → Polarity
+-- cnf-polarity i = foldr (λ ϕ p → disj-polarity i ϕ ⊗p p) none
+
+-- pure-literal : Fin Γ → CNF Γ → Type
+-- pure-literal i ϕs = cnf-polarity i ϕs ≡ pos ⊎ cnf-polarity i ϕs ≡ neg
+
+-- pure-literal? : (i : Fin Γ) → (ϕs : CNF Γ) → Dec (pure-literal i ϕs)
+-- pure-literal? i ϕs =
+--   Dec-⊎
+--     (Discrete-Polarity (cnf-polarity i ϕs) pos)
+--     (Discrete-Polarity (cnf-polarity i ϕs) neg)
+```
+
+
+```agda
+¬empty-disj-sat : ∀ (ϕ : Disjunction 0) → (ρ : Fin 0 → Bool) → ⟦ ϕ ⟧ ρ ≡ true → ⊥
+¬empty-disj-sat [] ρ sat = true≠false (sym sat)
+¬empty-disj-sat (lit () ∷ ϕ) ρ sat
+¬empty-disj-sat (neg () ∷ ϕ) ρ sat
+
+unit-propagate-sat
+  : (x : Literal (suc Γ))
+  → (ϕs : CNF (suc Γ))
+  → Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ unit-propagate x ϕs ⟧ ρ ≡ true)
+  → Σ[ ρ ∈ (Fin (suc Γ) → Bool) ] (⟦ ϕs ⟧ ρ ≡ true)
+unit-propagate-sat x ϕs (ρ , ρ-sat) =
+  (ρ [ lit-var x ≔ lit-val x ]) , unit-propagate-sound x ϕs ρ ∙ ρ-sat
+
+unit-propagate-unsat
+  : (x : Literal (suc Γ))
+  → (ϕs : CNF (suc Γ))
+  → ¬ Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ unit-propagate x ϕs ⟧ ρ ≡ true)
+  → ¬ Σ[ ρ ∈ (Fin (suc Γ) → Bool) ] ((⟦ ϕs ⟧ ρ ≡ true) × (⟦ x ⟧ ρ ≡ true))
+unit-propagate-unsat x ϕs ¬sat (ρ , ρ-sat , x-sat) =
+  ¬sat $
+  delete ρ (lit-var x) ,
+  sym (unit-propagate-complete x ϕs ρ x-sat)
+  ∙ ρ-sat
+
+cnf-sat? : (ϕs : CNF Γ) → Dec (Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ ϕs ⟧ ρ ≡ true))
+cnf-sat? {Γ = zero} [] =
+  yes (((λ ()) , refl))
+cnf-sat? {Γ = zero} (ϕ ∷ ϕs) =
+  no (λ (ρ , sat) → ¬empty-disj-sat ϕ ρ (and-reflect-true-l sat))
+cnf-sat? {Γ = suc Γ} ϕs =
+  Dec-rec
+    (λ (x , x∈ϕs) →
+      Dec-rec
+        (yes ∘ unit-propagate-sat x ϕs)
+        (λ ¬sat → no (λ (ρ , ρ-sat) → unit-propagate-unsat x ϕs ¬sat (ρ , ρ-sat , unit-clause-sat x ϕs x∈ϕs ρ ρ-sat)))
+        (cnf-sat? (unit-propagate x ϕs)))
+    (λ ¬ϕs-unit → -- TODO: pure literal elimination
+      Dec-rec
+        (yes ∘ unit-propagate-sat (lit fzero) ϕs)
+        (λ ¬sat-true →
+          Dec-rec
+            (yes ∘ unit-propagate-sat (neg fzero) ϕs)
+            (λ ¬sat-false → no λ (ρ , ρ-sat) →
+              Bool-elim (λ b → ρ fzero ≡ b → ⊥)
+                (λ ρ₀-true → unit-propagate-unsat (lit fzero) ϕs ¬sat-true (ρ , ρ-sat , ρ₀-true))
+                (λ ρ₀-false → unit-propagate-unsat (neg fzero) ϕs ¬sat-false (ρ , ρ-sat , ap not ρ₀-false))
+                (ρ fzero) refl)
+            (cnf-sat? (unit-propagate (neg fzero) ϕs)))
+        (cnf-sat? (unit-propagate (lit fzero) ϕs))) 
+    (has-unit-clause? ϕs)
+```
+
+```agda
+test-cnf : CNF 4
+test-cnf =
+  (neg 0 ∷ lit 1 ∷ lit 2 ∷ []) ∷
+  (lit 0 ∷ lit 2 ∷ lit 3 ∷ []) ∷
+  (lit 0 ∷ lit 2 ∷ neg 3 ∷ []) ∷
+  (lit 0 ∷ neg 2 ∷ lit 3 ∷ []) ∷
+  (lit 0 ∷ neg 2 ∷ neg 3 ∷ []) ∷
+  (lit 1 ∷ neg 2 ∷ lit 3 ∷ []) ∷
+  (neg 0 ∷ lit 1 ∷ neg 2 ∷ []) ∷
+  (neg 0 ∷ neg 1 ∷ lit 2 ∷ []) ∷
+  []
+
+test-sat : Dec (Σ[ ρ ∈ (Fin 4 → Bool) ] (⟦ test-cnf ⟧ ρ ≡ true))
+test-sat = cnf-sat? test-cnf
+```

--- a/src/Logic/Propositional/Classical/SAT.lagda.md
+++ b/src/Logic/Propositional/Classical/SAT.lagda.md
@@ -3,14 +3,14 @@
 open import 1Lab.Prelude
 
 open import Data.Bool
+open import Data.List hiding (_++_)
 open import Data.Dec
 open import Data.Fin using (Fin; fzero; fsuc; Discrete-Fin; avoid; _[_≔_]; delete)
-open import Data.List hiding (_++_)
 open import Data.Nat
 open import Data.Sum
 
-open import Logic.Propositional.Classical
 open import Logic.Propositional.Classical.CNF
+open import Logic.Propositional.Classical
 
 open import Meta.Brackets
 

--- a/src/Logic/Propositional/Classical/SAT.lagda.md
+++ b/src/Logic/Propositional/Classical/SAT.lagda.md
@@ -52,7 +52,7 @@ pruning the search space, known as **unit propagation**. The idea
 behind this is as follows: if we see an clause that contains a single
 literal $P$ in our expression, then we know that $P$ must be true.
 Furthermore, any clause containing $P$ can be deleted, as we know it must
-be true! Even better, we can remove any occurance of $\neg P$ from
+be true! Even better, we can remove any occurrence of $\neg P$ from
 our expression, as we know that $\neg P$ must be false. This reduces
 the size of the search space considerably, and makes the problem a bit
 more tractable.
@@ -291,7 +291,7 @@ cnf-sat? {Γ = suc Γ} ϕs | no ¬ϕs-unit with (cnf-sat? (unit-propagate (lit f
 
 And that's it! Note that "classic" DPLL also includes a second rule
 known as "pure literal elimination". The idea here is that if a literal
-only shows up as negated or not negated, then we can delete all occurances
+only shows up as negated or not negated, then we can delete all occurrences
 of that literal. However, this operation is somewhat expensive to perform,
 and also rather annoying to program in Agda. Therefore, it has been omitted
 from this implementation.

--- a/src/Logic/Propositional/Classical/SAT.lagda.md
+++ b/src/Logic/Propositional/Classical/SAT.lagda.md
@@ -34,87 +34,111 @@ private variable
 # SAT Solving {defines="SAT-solving SAT"}
 
 SAT solving is the process of determining if we can find some assignment
-of variables $\rho$ that makes a given formula $\phi$ in classical propositional
-logic true. Such an assignment is called a **satisfying** assignment,
-hence the name SAT. This is a classic problem in Computer Science, and
-many other important and interesting problems can be reduced to finding
-satisfying assignments to huge formulae.
+of variables $\rho$ that makes a given formula $\phi$ in classical
+propositional logic true. Such an assignment is called a **satisfying
+assignment**, hence the name SAT. This is a classic problem in the field
+of computer science, and many other important and interesting problems
+can be reduced to finding satisfying assignments to huge formulae.
 
-Unfortunately, SAT solving is provably hard from a complexity standpoint.
-However, this will not stop us from writing a solver anyways! For the sake
-of efficiency, our solver will operate on expressions in [[CNF]].
+Unfortunately, SAT solving is provably hard, from a complexity
+standpoint. However, this will not stop us from writing a solver
+anyways! For the sake of efficiency, our solver will operate on
+expressions in [[conjunctive normal form]].
 
-# Unit Propagation
+# Unit propagation
 
-The algorithm we will use is a simplified version of the classic DPLL
-algorithm, which combines backtracking search with a mechanism for
-pruning the search space, known as **unit propagation**. The idea
-behind this is as follows: if we see an clause that contains a single
-literal $P$ in our expression, then we know that $P$ must be true.
-Furthermore, any clause containing $P$ can be deleted, as we know it must
-be true! Even better, we can remove any occurrence of $\neg P$ from
-our expression, as we know that $\neg P$ must be false. This reduces
-the size of the search space considerably, and makes the problem a bit
-more tractable.
+The algorithm we will use is a simplified version of the classic
+[DPLL]{.abbrev title="Davis-Putnam-Logemann-Loveland"} algorithm, which
+combines backtracking search with a mechanism for pruning the search
+space, known as **unit propagation**.
 
-Luckily, unit propagation is rather easy to implement.
+The idea behind this is the observation `unit-clause-sat`{.Agda}.
+Translated into symbolic notation, it says that if our overall formula
+$\phi$ breaks down as $\phi_0 \land P \land \phi_1$ --- that is, we have
+a clause which consists of a single literal, then it's necessary for
+$\vDash \phi$ that $\vDash P$. Not only does this give us one datum of
+our satisfying assignment, it also lets us get rid of any clauses that
+mention $P$, since they must also be true!
+
+Even better, we can also remove any occurrences of $\neg P$ from our
+clauses --- since we've decided that $P$ is true, having $\rm{false}$ as
+a disjunct has no effect on the remaining clauses. This reduces the size
+of the search space considerably, and makes the problem a bit more
+tractable.
+
+Luckily, unit propagation is rather easy to implement. The workhorse is
+the recursive function `delete-literal`{.Agda}. Pay attention to its
+type: expressed non-numerically, it says that given the index of $\phi$
+and a formula in $\Gamma_0, \phi, \Gamma_1$, we'll return a formula in
+$\Gamma_0, \Gamma_1.$
 
 ```agda
 delete-literal
-  : (x : Fin (suc Γ))
-  → (ϕ : Clause (suc Γ))
+  : (x : Fin (suc Γ)) (ϕ : Clause (suc Γ))
   → Clause Γ
-delete-literal {Γ = zero} i ϕ = []
+delete-literal {Γ = zero}  i ϕ  = []
 delete-literal {Γ = suc Γ} i [] = []
 delete-literal {Γ = suc Γ} i (x ∷ ϕ) with Discrete-Fin i (lit-var x)
-... | yes _ = delete-literal i ϕ
+... | yes _  = delete-literal i ϕ
 ... | no i≠x = avoid-lit i x i≠x ∷ delete-literal i ϕ
+```
 
+Unit propagation is then applying this function to all the clauses in a
+CNF expression.
+
+```agda
 unit-propagate : Literal (suc Γ) → CNF (suc Γ) → CNF Γ
 unit-propagate x [] = []
 unit-propagate x (ϕ ∷ ϕs) with elem? Discrete-Literal x ϕ
 ... | yes _ = unit-propagate x ϕs
-... | no _ = delete-literal (lit-var x) ϕ ∷ unit-propagate x ϕs
+... | no _  = delete-literal (lit-var x) ϕ ∷ unit-propagate x ϕs
 ```
 
-However, it is slightly *less* trivial to prove correct. First,
-we will show a couple of quick lemmas regarding assignment of variables.
+However, while this procedure is easy to implement, it's actually
+slightly tricky to prove correct. We'll start by showing a couple of
+quick lemmas regarding assignment of variables.
 
 ```agda
 avoid-lit-insert
-  : ∀ (x y : Literal (suc Γ)) → (x≠y : ¬ (lit-var x ≡ lit-var y))
-  → (ρ : Fin Γ → Bool)
-  → ⟦ y ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ avoid-lit (lit-var x) y x≠y ⟧ ρ
-avoid-lit-insert {Γ = Γ} x (lit y) x≠y ρ = Fin.avoid-insert ρ (lit-var x) (lit-val x) y x≠y
-avoid-lit-insert {Γ = Γ} x (neg y) x≠y ρ = ap not (Fin.avoid-insert ρ (lit-var x) (lit-val x) y x≠y)
+  : (x y : Literal (suc Γ)) (x≠y : ¬ (lit-var x ≡ lit-var y)) (ρ : Fin Γ → Bool)
+  → ⟦ y ⟧ (ρ [ lit-var x ≔ lit-val x ])
+  ≡ ⟦ avoid-lit (lit-var x) y x≠y ⟧ ρ
 
 lit-assign-neg-false
-  : ∀ (x : Literal (suc Γ))
-  → (ρ : Fin Γ → Bool)
+  : (x : Literal (suc Γ)) (ρ : Fin Γ → Bool)
   → ⟦ x ⟧ (ρ [ lit-var (¬lit x) ≔ lit-val (¬lit x) ]) ≡ false
+
+lit-assign-true
+  : (x : Literal (suc Γ)) (ρ : Fin Γ → Bool)
+  → ⟦ x ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ true
+```
+
+<!--
+```agda
+avoid-lit-insert {Γ = Γ} x (lit y) x≠y ρ =
+  Fin.avoid-insert ρ (lit-var x) (lit-val x) y x≠y
+avoid-lit-insert {Γ = Γ} x (neg y) x≠y ρ =
+  ap not (Fin.avoid-insert ρ (lit-var x) (lit-val x) y x≠y)
+
 lit-assign-neg-false (lit x) ρ = Fin.insert-lookup ρ x false
 lit-assign-neg-false (neg x) ρ = ap not (Fin.insert-lookup ρ x true)
 
-
-lit-assign-true
-  : ∀ (x : Literal (suc Γ))
-  → (ρ : Fin Γ → Bool)
-  → ⟦ x ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ true
 lit-assign-true (lit x) ρ = Fin.insert-lookup ρ x true
 lit-assign-true (neg x) ρ = ap not (Fin.insert-lookup ρ x false)
 ```
+-->
 
-Next, we show that deleting literals preserves the truth value of
-a given assignment when the literal doesn't show up in the clause.
+Next, we show that deleting literals preserves the truth value of a
+given assignment, as long as the literal doesn't show up in the clause.
 This is not hard to show, just tedious.
 
 ```agda
 delete-literal-sound
-  : (x : Literal (suc Γ))
-  → (ϕ : Clause (suc Γ))
+  : (x : Literal (suc Γ)) (ϕ : Clause (suc Γ))
   → ¬ (x ∈ₗ ϕ)
-  → ∀ (ρ : Fin Γ → Bool)
+  → (ρ : Fin Γ → Bool)
   → ⟦ ϕ ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ delete-literal (lit-var x) ϕ ⟧ ρ
+
 delete-literal-sound {zero} x [] x∉ϕ ρ = refl
 delete-literal-sound {zero} (lit fzero) (lit fzero ∷ ϕ) x∉ϕ ρ =
   absurd (x∉ϕ (here refl))
@@ -124,47 +148,39 @@ delete-literal-sound {zero} (neg fzero) (lit fzero ∷ ϕ) x∉ϕ ρ =
   delete-literal-sound (neg fzero) ϕ (x∉ϕ ∘ there) ρ
 delete-literal-sound {zero} (neg fzero) (neg fzero ∷ ϕ) x∉ϕ ρ =
   absurd (x∉ϕ (here refl))
-delete-literal-sound {suc Γ} x [] x∉ϕ ρ = refl
+
+delete-literal-sound {suc Γ} x []      x∉ϕ ρ = refl
 delete-literal-sound {suc Γ} x (y ∷ ϕ) x∉ϕ ρ with Discrete-Fin (lit-var x) (lit-var y)
 ... | yes x=y =
   ap₂ or
     (subst (λ e → ⟦ y ⟧ (ρ [ lit-var e ≔ lit-val e ]) ≡ false)
       (sym (literal-eq-negate x y (x∉ϕ ∘ here) x=y))
-      (lit-assign-neg-false y ρ))
-    refl
+      (lit-assign-neg-false y ρ)) refl
   ∙ delete-literal-sound x ϕ (x∉ϕ ∘ there) ρ
-... | no x≠y =
-  ap₂ or
-    (avoid-lit-insert x y x≠y ρ)
-    (delete-literal-sound x ϕ (x∉ϕ ∘ there) ρ)
+... | no x≠y = ap₂ or
+  (avoid-lit-insert x y x≠y ρ)
+  (delete-literal-sound x ϕ (x∉ϕ ∘ there) ρ)
 ```
 
-Soundness and completeness of unit propagation follows quickly.
+Soundness and completeness of unit propagation follow quickly.
 
 ```agda
 unit-propagate-sound
-  : (x : Literal (suc Γ))
-  → (ϕs : CNF (suc Γ))
-  → ∀ (ρ : Fin Γ → Bool)
+  : (x : Literal (suc Γ)) (ϕs : CNF (suc Γ)) (ρ : Fin Γ → Bool)
   → ⟦ ϕs ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ unit-propagate x ϕs ⟧ ρ
-unit-propagate-sound x [] ρ = refl
+unit-propagate-sound x []       ρ = refl
 unit-propagate-sound x (ϕ ∷ ϕs) ρ with elem? Discrete-Literal x ϕ
-... | yes x∈ϕ =
-  ap₂ and
-    (any-one-of (λ l → ⟦ l ⟧ (ρ [ lit-var x ≔ lit-val x ]))
-      x ϕ x∈ϕ
-      (lit-assign-true x ρ))
-    (unit-propagate-sound x ϕs ρ)
-... | no ¬x∉ϕ =
-  ap₂ and
-    (delete-literal-sound x ϕ ¬x∉ϕ ρ)
-    (unit-propagate-sound x ϕs ρ)
+... | yes x∈ϕ = ap₂ and
+  (any-one-of (λ l → ⟦ l ⟧ (ρ [ lit-var x ≔ lit-val x ]))
+    x ϕ x∈ϕ (lit-assign-true x ρ))
+  (unit-propagate-sound x ϕs ρ)
+... | no ¬x∉ϕ = ap₂ and
+  (delete-literal-sound x ϕ ¬x∉ϕ ρ)
+  (unit-propagate-sound x ϕs ρ)
 
 unit-propagate-complete
-  : (x : Literal (suc Γ))
-  → (ϕs : CNF (suc Γ))
-  → ∀ (ρ : Fin (suc Γ) → Bool)
-  → ⟦ x ⟧ ρ ≡ true
+  : (x : Literal (suc Γ)) (ϕs : CNF (suc Γ)) (ρ : Fin (suc Γ) → Bool)
+  → ⟦ x  ⟧ ρ ≡ true
   → ⟦ ϕs ⟧ ρ ≡ ⟦ unit-propagate x ϕs ⟧ (delete ρ (lit-var x))
 unit-propagate-complete x ϕs ρ x-true =
   ap ⟦ ϕs ⟧ (sym $ funext $
@@ -172,46 +188,45 @@ unit-propagate-complete x ϕs ρ x-true =
   ∙ unit-propagate-sound x ϕs (delete ρ (lit-var x))
 ```
 
-We also have a decision procedure that determines if there are any
-unit clauses in an expression.
+Since the syntax of CNF is a very "discrete" object (it consists of
+lists of lists of numbers), it's possible to write a decision procedure
+which traverses a list of clauses and picks a clause consisting of a
+literal, if one exists.
 
 ```agda
-has-unit-clause? : ∀ (ϕs : CNF Γ) → Dec (Σ[ x ∈ Literal Γ ] ((x ∷ []) ∈ₗ ϕs))
+has-unit-clause? : (ϕs : CNF Γ) → Dec (Σ[ x ∈ Literal Γ ] ((x ∷ []) ∈ₗ ϕs))
 has-unit-clause? [] = no (¬some-[] ∘ snd)
-has-unit-clause? ([] ∷ ϕs) =
-  Dec-rec
-    (λ (x , x∈ϕs) → yes (x , there x∈ϕs))
-    (λ ¬ϕ-unit → no (λ (x , x∈ϕs) →
-      [ ∷≠[]
-      , (λ x∈ϕs → ¬ϕ-unit (x , x∈ϕs))
-      ] (∷-some-⊎ x∈ϕs)))
-    (has-unit-clause? ϕs)
-has-unit-clause? ((x ∷ []) ∷ ϕs) = yes (x , here refl)
-has-unit-clause? ((x ∷ y ∷ ϕ) ∷ ϕs) =
-  Dec-rec
-    (λ (x , x∈ϕs) → yes (x , there x∈ϕs))
-    (λ ¬ϕ-unit → no (λ (x , x∈ϕs) →
-      [ ∷≠[] ∘ ∷-tail-inj ∘ sym
-      , (λ x∈ϕs → ¬ϕ-unit (x , x∈ϕs))
-      ] (∷-some-⊎ x∈ϕs)))
-    (has-unit-clause? ϕs)
+
+has-unit-clause? ([] ∷ ϕs) with has-unit-clause? ϕs
+... | yes (x , x∈ϕs) = yes (x , there x∈ϕs)
+... | no  ¬ϕ-unit    = no λ where
+  (x , here  ∷=[]) → ∷≠[] ∷=[]
+  (x , there x∈ϕs) → ¬ϕ-unit (x , x∈ϕs)
+
+has-unit-clause? ((x ∷ []) ∷ ϕs)    = yes (x , here refl)
+has-unit-clause? ((x ∷ y ∷ ϕ) ∷ ϕs) with has-unit-clause? ϕs
+... | yes (x , x∈ϕs) = yes (x , there x∈ϕs)
+... | no  ¬ϕ-unit    = no λ where
+  (x , here  p)    → ∷≠[] (∷-tail-inj (sym p))
+  (x , there x∈ϕs) → ¬ϕ-unit (x , x∈ϕs)
 ```
 
-If $x$ is a unit clause in $\phi$, and an assignment $\rho$ satisfies
-$\phi$, then $\rho(x)$ must be true.
+We can now piece together the result which justifies unit propagation:
+If we have a satisfying assignment $\rho \vDash \phi$, and a literal $x$
+appears as a unit clause in $\phi$, then we know that $\rho(x)$ must be
+true.
 
 ```agda
 unit-clause-sat
-  : (x : Literal Γ)
-  → (ϕs : CNF Γ)
+  : (x : Literal Γ) (ϕs : CNF Γ)
   → (x ∷ []) ∈ₗ ϕs
   → (ρ : Fin Γ → Bool)
-  → ⟦ ϕs ⟧ ρ ≡ true
-  → ⟦ x ⟧ ρ ≡ true
+  → ⟦ ϕs ⟧ ρ ≡ true → ⟦ x ⟧ ρ ≡ true
 unit-clause-sat x (ϕ ∷ ϕs) (here [x]=ϕ) ρ ϕs-sat =
-  sym (or-falser _)
-  ∙ ap (λ e → (⟦ e ⟧ ρ)) [x]=ϕ
-  ∙ and-reflect-true-l ϕs-sat
+  ⟦ x ⟧ ρ      ≡⟨ sym (or-falser _) ⟩
+  ⟦ x ∷ [] ⟧ ρ ≡⟨ ap (λ e → (⟦ e ⟧ ρ)) [x]=ϕ ⟩
+  ⟦ ϕ ⟧ ρ      ≡⟨ and-reflect-true-l ϕs-sat ⟩
+  true         ∎
 unit-clause-sat x (y ∷ ϕs) (there [x]∈ϕs) ρ ϕs-sat =
   unit-clause-sat x ϕs [x]∈ϕs ρ (and-reflect-true-r ϕs-sat)
 ```
@@ -220,8 +235,8 @@ We also note that it is impossible to find a satisfying assignment to a
 clause with no atoms.
 
 ```agda
-¬empty-clause-sat : ∀ (ϕ : Clause 0) → (ρ : Fin 0 → Bool) → ⟦ ϕ ⟧ ρ ≡ true → ⊥
-¬empty-clause-sat [] ρ sat = true≠false (sym sat)
+¬empty-clause-sat : (ϕ : Clause 0) (ρ : Fin 0 → Bool) → ⟦ ϕ ⟧ ρ ≡ true → ⊥
+¬empty-clause-sat []           ρ sat = true≠false (sym sat)
 ¬empty-clause-sat (lit () ∷ ϕ) ρ sat
 ¬empty-clause-sat (neg () ∷ ϕ) ρ sat
 ```
@@ -233,43 +248,41 @@ expression is unsatisfiable.
 
 ```agda
 unit-propagate-sat
-  : (x : Literal (suc Γ))
-  → (ϕs : CNF (suc Γ))
-  → Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ unit-propagate x ϕs ⟧ ρ ≡ true)
+  : (x : Literal (suc Γ)) (ϕs : CNF (suc Γ))
+  → Σ[ ρ ∈ (Fin Γ → Bool) ]       (⟦ unit-propagate x ϕs ⟧ ρ ≡ true)
   → Σ[ ρ ∈ (Fin (suc Γ) → Bool) ] (⟦ ϕs ⟧ ρ ≡ true)
 unit-propagate-sat x ϕs (ρ , ρ-sat) =
-  (ρ [ lit-var x ≔ lit-val x ]) , unit-propagate-sound x ϕs ρ ∙ ρ-sat
+    ρ [ lit-var x ≔ lit-val x ]
+  , unit-propagate-sound x ϕs ρ ∙ ρ-sat
 
 unit-propagate-unsat
   : (x : Literal (suc Γ))
   → (ϕs : CNF (suc Γ))
-  → ¬ Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ unit-propagate x ϕs ⟧ ρ ≡ true)
+  → ¬ Σ[ ρ ∈ (Fin Γ → Bool) ]       (⟦ unit-propagate x ϕs ⟧ ρ ≡ true)
   → ¬ Σ[ ρ ∈ (Fin (suc Γ) → Bool) ] ((⟦ ϕs ⟧ ρ ≡ true) × (⟦ x ⟧ ρ ≡ true))
-unit-propagate-unsat x ϕs ¬sat (ρ , ρ-sat , x-sat) =
-  ¬sat $
-  delete ρ (lit-var x) ,
-  sym (unit-propagate-complete x ϕs ρ x-sat)
-  ∙ ρ-sat
+unit-propagate-unsat x ϕs ¬sat (ρ , ρ-sat , x-sat) = ¬sat $
+    delete ρ (lit-var x)
+  , sym (unit-propagate-complete x ϕs ρ x-sat) ∙ ρ-sat
 ```
 
 Armed with these lemmas, we can finally write our SAT solver.
 We shall perform induction on the number of atoms in our CNF
-expression $\phi$. If $\phi$ contains no atoms, then we simply
-need to check if it has any clauses.
+expression, $\phi$. If $\phi$ has no atoms, then we know its
+satisfiability by looking at the clauses: having no clauses is the CNF
+representation of $\top$, while having an empty clause is the CNF
+representation of $\bot$.
 
 ```agda
 cnf-sat? : (ϕs : CNF Γ) → Dec (Σ[ ρ ∈ (Fin Γ → Bool) ] (⟦ ϕs ⟧ ρ ≡ true))
-cnf-sat? {Γ = zero} [] =
-  yes (((λ ()) , refl))
-cnf-sat? {Γ = zero} (ϕ ∷ ϕs) =
-  no (λ (ρ , sat) → ¬empty-clause-sat ϕ ρ (and-reflect-true-l sat))
+cnf-sat? {Γ = zero} []       = yes ((λ ()) , refl)
+cnf-sat? {Γ = zero} (ϕ ∷ ϕs) = no λ where
+  (ρ , sat) → ¬empty-clause-sat ϕ ρ (and-reflect-true-l sat)
 ```
 
-If $\phi$ contains at least one atom, we first check to see if there
-are any unit clauses. If there are, we perform unit propagation, and
-recurse. If there aren't, then we perform backtracking search, first
-trying to see if the first atom is true, and then checking to see if
-it is false.
+The interesting case is when $\phi$ contains at least one atom. Ideally,
+$\phi$ has a unit clause, in which case we can perform unit propagation,
+and recursively and check satisfiability of the (hopefully much
+smaller!) resulting formula.
 
 ```agda
 cnf-sat? {Γ = suc Γ} ϕs with has-unit-clause? ϕs
@@ -278,20 +291,48 @@ cnf-sat? {Γ = suc Γ} ϕs with has-unit-clause? ϕs
 ...   | no ¬sat = no λ (ρ , ρ-sat) →
         unit-propagate-unsat x ϕs ¬sat
           (ρ , ρ-sat , unit-clause-sat x ϕs [x]∈ϕs ρ ρ-sat)
-cnf-sat? {Γ = suc Γ} ϕs | no ¬ϕs-unit with (cnf-sat? (unit-propagate (lit fzero) ϕs))
-... | yes sat-true = yes (unit-propagate-sat (lit fzero) ϕs sat-true)
-... | no ¬sat-true with cnf-sat? (unit-propagate (neg fzero) ϕs)
-...   | yes sat-false = yes (unit-propagate-sat (neg fzero) ϕs sat-false)
-...   | no ¬sat-false = no λ (ρ , ρ-sat) →
-        Bool-elim (λ b → ρ fzero ≡ b → ⊥)
-          (λ ρ₀-true → unit-propagate-unsat (lit fzero) ϕs ¬sat-true (ρ , ρ-sat , ρ₀-true))
-          (λ ρ₀-false → unit-propagate-unsat (neg fzero) ϕs ¬sat-false (ρ , ρ-sat , ap not ρ₀-false))
-          (ρ fzero) refl
+```
+
+If there aren't, then we're slightly out of luck. We'll have to guess:
+We pick the first atom in $\phi$ and arbitrarily decide that it must be
+true. We can then propagate this choice, using the same unit-propagation
+procedure, to obtain a formula $\phi[\rm{true}/0]$. _If_ this formula is
+satisfiable, we know that $\phi$ is, too.
+
+```agda
+cnf-sat? {Γ = suc Γ} ϕs
+    | no ¬ϕs-unit with cnf-sat? (unit-propagate (lit fzero) ϕs)
+...   | yes sat-true = yes (unit-propagate-sat (lit fzero) ϕs sat-true)
+```
+
+But choosing $\rm{true}$ was a guess, and it might have been wrong! If
+it was, then we'll try again: we'll check satisfiability of
+$\phi[\rm{false}/0]$. Once again, satisfiability of this new formula
+implies satisfiability of the original.
+
+```agda
+...   | no ¬sat-true with cnf-sat? (unit-propagate (neg fzero) ϕs)
+...     | yes sat-false = yes (unit-propagate-sat (neg fzero) ϕs sat-false)
+```
+
+However, we might have been wrong again! It might be the case that the
+expression is *un*satisfiable. In this case we can return "UNSAT": if
+anyone claims to have a satisfying assignment $\rho \vDash \phi$, they
+must have chosen one of two values for $\rho(0)$, and we know that
+neither can work.
+
+```agda
+...     | no ¬sat-false = no λ (ρ , ρ-sat) → Bool-elim (λ b → ρ fzero ≡ b → ⊥)
+  (λ ρ₀-true  → unit-propagate-unsat (lit fzero) ϕs ¬sat-true
+    (ρ , ρ-sat , ρ₀-true))
+  (λ ρ₀-false → unit-propagate-unsat (neg fzero) ϕs ¬sat-false
+    (ρ , ρ-sat , ap not ρ₀-false))
+  (ρ fzero) refl
 ```
 
 And that's it! Note that "classic" DPLL also includes a second rule
-known as "pure literal elimination". The idea here is that if a literal
-only shows up as negated or not negated, then we can delete all occurrences
-of that literal. However, this operation is somewhat expensive to perform,
-and also rather annoying to program in Agda. Therefore, it has been omitted
-from this implementation.
+known as _pure literal elimination_. The idea here is that if a literal
+only shows up as negated or not negated, then we can delete all
+occurrences of that literal. However, this operation is somewhat
+expensive to perform, and also rather annoying to program in Agda.
+Therefore, it has been omitted from this implementation.

--- a/src/Logic/Propositional/Classical/SAT.lagda.md
+++ b/src/Logic/Propositional/Classical/SAT.lagda.md
@@ -31,7 +31,7 @@ private variable
 ```
 -->
 
-# SAT Solving
+# SAT Solving {defines="SAT-solving SAT"}
 
 SAT solving is the process of determining if we can find some assignment
 of variables $\rho$ that makes a given formula $\phi$ in classical propositional

--- a/src/Meta/Brackets.lagda.md
+++ b/src/Meta/Brackets.lagda.md
@@ -1,0 +1,21 @@
+<!--
+```agda
+open import 1Lab.Type
+```
+-->
+
+```agda
+module Meta.Brackets where
+```
+
+```agda
+record ⟦⟧-notation {ℓ} (A : Type ℓ) : Typeω where
+  constructor brackets
+  field
+    {lvl} : Level
+    Sem : Type lvl
+    ⟦_⟧ : A → Sem
+
+open ⟦⟧-notation ⦃...⦄ public
+{-# DISPLAY ⟦⟧-notation.⟦_⟧ f x = ⟦ x ⟧ #-}
+```

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -972,6 +972,16 @@ open import Order.DCPO.Pointed -- Pointed directed-complete partial orders
 open import Order.DCPO.Free -- Free DCPOs and free pointed DCPOs
 ```
 
+# Logic
+
+```
+open import Logic.Propositional.Classical
+-- Classical logic, soundness, completeness
+open import Logic.Propositional.Classical.CNF
+-- Conjunctive normal forms
+open import Logic.Propositional.Classical.SAT
+-- DPLL SAT solver
+```
 
 # Algebra
 

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -974,7 +974,7 @@ open import Order.DCPO.Free -- Free DCPOs and free pointed DCPOs
 
 # Logic
 
-```
+```agda
 open import Logic.Propositional.Classical
 -- Classical logic, soundness, completeness
 open import Logic.Propositional.Classical.CNF


### PR DESCRIPTION
Reopen #286:

> # Description
>
> This PR defines classical propositional logic, proves completeness and soundness, defines conjunctive normal forms, and also includes a simple DPLL SAT solver. It also includes a bunch of misc. additions to modules involving `Fin`, `List`, and `Bool`.
