### PR TITLE
A macro for generating induction principles

### DIFF
--- a/src/1Lab/HIT/Truncation.lagda.md
+++ b/src/1Lab/HIT/Truncation.lagda.md
@@ -5,6 +5,7 @@ definition: |
 ---
 <!--
 ```agda
+open import 1Lab.Reflection.Induction
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Retracts
 open import 1Lab.Path.Reasoning
@@ -339,31 +340,19 @@ principles.
 <!--
 ```agda
 ∥-∥³-elim-set
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : ∥ A ∥³ → Type ℓ'}
+  : ∀ {ℓ} {A : Type ℓ} {ℓ'} {P : ∥ A ∥³ → Type ℓ'}
   → (∀ a → is-set (P a))
   → (f : (a : A) → P (inc a))
   → (∀ a b → PathP (λ i → P (iconst a b i)) (f a) (f b))
   → ∀ a → P a
-∥-∥³-elim-set {P = P} sets f fconst = go where
-  go : ∀ a → P a
-  go (inc x) = f x
-  go (iconst a b i) = fconst a b i
-  go (icoh a b c i j) = is-set→squarep (λ i j → sets (icoh a b c i j))
-    refl (λ i → go (iconst a b i)) (λ i → go (iconst a c i)) (λ i → go (iconst b c i))
-    i j
-  go (squash x y a b p q i j k) = is-hlevel→is-hlevel-dep 2 (λ _ → is-hlevel-suc 2 (sets _))
-    (go x) (go y)
-    (λ k → go (a k)) (λ k → go (b k))
-    (λ j k → go (p j k)) (λ j k → go (q j k))
-    (squash x y a b p q) i j k
+unquoteDef ∥-∥³-elim-set = make-elim-n 2 ∥-∥³-elim-set (quote ∥_∥³)
 
 ∥-∥³-elim-prop
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : ∥ A ∥³ → Type ℓ'}
+  : ∀ {ℓ} {A : Type ℓ} {ℓ'} {P : ∥ A ∥³ → Type ℓ'}
   → (∀ a → is-prop (P a))
   → (f : (a : A) → P (inc a))
   → ∀ a → P a
-∥-∥³-elim-prop props f = ∥-∥³-elim-set (λ _ → is-hlevel-suc 1 (props _)) f
-  (λ _ _ → is-prop→pathp (λ _ → props _) _ _)
+unquoteDef ∥-∥³-elim-prop = make-elim-n 1 ∥-∥³-elim-prop (quote ∥_∥³)
 ```
 -->
 
@@ -434,7 +423,7 @@ data ∥_∥⁴ {ℓ} (A : Type ℓ) : Type ℓ where
   squash : is-hlevel ∥ A ∥⁴ 4
 
 ∥-∥⁴-rec
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  : ∀ {ℓ} {A : Type ℓ} {ℓ'} {B : Type ℓ'}
   → is-hlevel B 4
   → (f : A → B)
   → (fconst : ∀ a b → f a ≡ f b)
@@ -443,18 +432,7 @@ data ∥_∥⁴ {ℓ} (A : Type ℓ) : Type ℓ where
                                     (fconst a b) (fcoh a c d i))
                        (fcoh a b c) (fcoh a b d))
   → ∥ A ∥⁴ → B
-∥-∥⁴-rec {A = A} {B} b4 f fconst fcoh fassoc = go where
-  go : ∥ A ∥⁴ → B
-  go (inc x) = f x
-  go (iconst a b i) = fconst a b i
-  go (icoh a b c i j) = fcoh a b c i j
-  go (iassoc a b c d i j k) = fassoc a b c d i j k
-  go (squash x y a b p q r s i j k l) = b4
-    (go x) (go y)
-    (λ i → go (a i)) (λ i → go (b i))
-    (λ i j → go (p i j)) (λ i j → go (q i j))
-    (λ i j k → go (r i j k)) (λ i j k → go (s i j k))
-    i j k l
+unquoteDef ∥-∥⁴-rec = make-rec-n 4 ∥-∥⁴-rec (quote ∥_∥⁴)
 ```
 </details>
 

--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import 1Lab.Type.Sigma
 open import 1Lab.Path
 open import 1Lab.Type hiding (absurd)
 
@@ -186,6 +187,9 @@ instance
 # Reflection helpers
 
 ```agda
+Args : Type
+Args = List (Arg Term)
+
 Fun : ∀ {ℓ ℓ'} → Type ℓ → Type ℓ' → Type (ℓ ⊔ ℓ')
 Fun A B = A → B
 
@@ -218,9 +222,12 @@ block-on-meta m = blockTC (blocker-meta m)
 vlam : String → Term → Term
 vlam nam body = lam visible (abs nam body)
 
-infer-hidden : Nat → List (Arg Term) → List (Arg Term)
+infer-hidden : Nat → Args → Args
 infer-hidden zero    xs = xs
 infer-hidden (suc n) xs = unknown h∷ infer-hidden n xs
+
+infer-tel : Telescope → Args
+infer-tel tel = (λ (_ , arg ai _) → arg ai unknown) <$> tel
 
 “refl” : Term
 “refl” = def (quote refl) []
@@ -296,6 +303,10 @@ get-boundary : Term → TC (Maybe (Term × Term))
 get-boundary tm = unapply-path tm >>= λ where
   (just (_ , x , y)) → pure (just (x , y))
   nothing            → pure nothing
+
+instance
+  Has-visibility-Telescope : Has-visibility Telescope
+  Has-visibility-Telescope .set-visibility v tel = ×-map₂ (set-visibility v) <$> tel
 ```
 
 ## Debugging tools

--- a/src/1Lab/Reflection/Induction.agda
+++ b/src/1Lab/Reflection/Induction.agda
@@ -1,0 +1,290 @@
+open import 1Lab.Reflection.Subst
+open import 1Lab.HLevel.Retracts
+open import 1Lab.Reflection
+open import 1Lab.Type.Sigma
+open import 1Lab.Type.Pi
+open import 1Lab.HLevel
+open import 1Lab.Path
+open import 1Lab.Type
+
+open import Data.String.Show
+open import Data.Nat.Base
+
+open import Meta.Append
+
+module 1Lab.Reflection.Induction where
+
+open import Data.Maybe.Base public
+
+{-
+A macro for generating induction principles for (higher, indexed) inductive types.
+
+We support inductive types in the form presented in "Pattern Matching Without K"
+by Cockx et al, section 3.1, with the addition of higher inductive types.
+Reusing the terminology from that paper, the idea is to translate the constructors
+of a data type into corresponding *methods* along with spines that tell us how to
+apply them to build the eliminator's clauses.
+
+When generating an eliminator into (n-2)-types, we automatically omit the methods that
+follow from h-level (i.e. those corresponding to constructors with at least n
+nested `PathP`s).
+
+See 1Lab.Reflection.Induction.Examples for examples.
+-}
+
+pi-view-path : Term → Telescope
+pi-view-path (pi x (abs n y)) = (n , x) ∷ pi-view-path y
+pi-view-path (def (quote PathP) (_ h∷ lam _ (abs n y) v∷ _ v∷ _ v∷ [])) =
+  (n , argN (quoteTerm I)) ∷ pi-view-path y
+pi-view-path _ = []
+
+Replacements = List (Term × Term)
+
+subst-replacements : Subst → Replacements → Replacements
+subst-replacements s = map (×-map (applyS s) (applyS s))
+
+instance
+  Has-subst-Replacements : Has-subst Replacements
+  Has-subst-Replacements = record { applyS = subst-replacements }
+
+private
+ module Induction
+  (D : Name) (pars : Nat) (ixTel : Telescope) (cs : List Name)
+  (ind? : Bool)
+  (hlevel? : Maybe Nat)
+  (hide-method-args? hide-indices? : Bool)
+  where
+
+  -- Given a term c : T, produce a replacement c↑ : T↑ (see below).
+  -- The Replacements argument maps constructors and variables to their
+  -- lifted version.
+  {-# TERMINATING #-}
+  replace : Replacements → Term → Maybe Term
+  replace* : Replacements → Args → Args
+
+  lookupR : Term → Replacements → Maybe Term
+  lookupR t [] = nothing
+  lookupR t@(con c _) ((con c' _ , r) ∷ rs) with c ≡? c'
+  ... | yes _ = just r
+  ... | no  _ = lookupR t rs
+  lookupR t@(var i _) ((var i' _ , r) ∷ rs) with i ≡? i'
+  ... | yes _ = just r
+  ... | no  _ = lookupR t rs
+  lookupR t (_ ∷ rs) = lookupR t rs
+
+  replace rs (lam v (abs n t)) = lam v ∘ abs n <$> replace (raise 1 rs) t
+  replace rs t@(con c args) = lookupR t rs <&> λ r →
+    apply-tm* r (replace* rs (drop pars args))
+  replace rs t@(var i args) = lookupR t rs <&> λ r →
+    apply-tm* r (replace* rs args)
+  replace rs _ = nothing
+
+  replace* rs [] = []
+  replace* rs (arg ai t ∷ as) with replace rs t
+  ... | just t' = hide-if hide-method-args? (arg ai t) ∷ arg ai t' ∷ replace* rs as
+  ... | nothing = arg ai t ∷ replace* rs as
+
+  {-
+  The main part of the algorithm: computes the method associated to a constructor.
+
+  In detail, given
+    a motive `P : (is : Ξ) → D ps is → Type ℓ`
+    a term `c : T = Δ → D ps is`
+  produces
+    the "lifted" type `T↑ = Δ↑ → P is (c ρ)`
+      where `Δ↑ ⊢ ρ : Δ` is an embedding
+      where types of the form `S = Φ → D ps is` in Δ are replaced recursively with `{S}, S↑` in Δ↑
+      (this only occurs with a recursion depth of 1 due to strict positivity)
+    and a spine α such that
+      rec : Π P, Δ ⊢ α : Δ↑
+      where Π P = (is : Ξ) → (d : D ps is) → P is d
+  or nothing if T doesn't end in `D ps`.
+
+  Example: W A B
+    sup : (a : A) (f : B a → W A B) → W A B
+      f : B a → W A B
+      display f = ((b : B a) → P (f b))
+                , (_ : Π P, b : B a ⊢ b : B a)
+    display sup = ((a : A) {f : B a → W A B} (pf : ∀ b → P (f b)) → P (sup a f))
+                , (rec : Π P, a : A, f : B a → W A B ⊢ a, {f}, (λ b → rec (f b)))
+  -}
+  {-# TERMINATING #-}
+  display
+    : (depth : Nat)
+    → (ps : Args) -- D's parameters
+    → (P : Term)
+    → (rs : Replacements) -- a list of replacements from terms to their lifted version,
+                          -- used for correcting path boundaries
+    → (rec : Term) -- a variable for explicit recursion
+    → (α : Args) -- accumulator for the spine
+    → (c : Term) (T : Term)
+    → Maybe (Term × Args) -- (T↑ , α)
+  display depth ps P rs rec α c (pi (arg ai x) (abs n y)) = do
+    let ps = raise 1 ps
+        P = raise 1 P
+        rs = raise 1 rs
+        rec = raise 1 rec
+        α = raise 1 α
+        c = raise 1 c
+        base =
+          let c = c <#> arg ai (var 0 [])
+              α = α ∷r arg ai (var 0 [])
+          in display depth ps P rs rec α c y <&> ×-map₁ λ y →
+            pi (arg ai x) (abs n y)
+    suc depth-1 ← pure depth
+      where _ → base
+    just (h , α') ← pure (display depth-1 ps P rs unknown [] (var 0 []) (raise 1 x))
+      where _ → base
+    let ps = raise 1 ps
+        P = raise 1 P
+        rs = (var 1 [] , var 0 []) ∷ raise 1 rs
+        c = raise 1 c <#> arg ai (var 1 [])
+        hTel = pi-view-path h
+        l = tel→lam hTel (apply-tm* (raise (length hTel) rec)
+          (infer-tel ixTel ∷r argN (var (length hTel) α')))
+        α = α ++ [ hide-if hide-method-args? (arg ai (var 0 [])) , argN l ]
+        y = raise 1 y
+    display depth ps P rs rec α c y <&> ×-map₁ λ y →
+      pi (hide-if hide-method-args? (arg ai x)) (abs n (pi (argN h) (abs ("p" <> n) y)))
+  display depth ps P rs rec α c (def (quote PathP) (_ h∷ lam v (abs n y) v∷ l v∷ r v∷ [])) = do
+    l ← replace rs l
+    r ← replace rs r
+    let ps = raise 1 ps
+        P = raise 1 P
+        rs = raise 1 rs
+        rec = raise 1 rec
+        α = raise 1 α ∷r argN (var 0 [])
+        c = raise 1 c <#> argN (var 0 [])
+    display depth ps P rs rec α c y <&> ×-map₁ λ y →
+      def (quote PathP) (unknown h∷ lam v (abs n y) v∷ l v∷ r v∷ [])
+  display depth ps P rs rec α c (def D' args) = do
+    yes _ ← pure (D ≡? D')
+      where _ → nothing
+    let ps' , is = split-at pars args
+    yes _ ← pure (ps ≡? ps')
+      where _ → nothing
+    let Pc = apply-tm* P (if ind? then hide-if hide-indices? is ++ c v∷ [] else [])
+    pure (Pc , α)
+  display depth ps P rs rec α c _ = nothing
+
+  try-hlevel : Term → TC (Maybe Term)
+  try-hlevel T =
+    (do
+      maybe→alt hlevel?
+      m ← new-meta T
+      unify m $ def (quote centre) $
+        def (quote hlevel) (unknown h∷ T h∷ lit (nat 0) v∷ []) v∷ []
+      pure (just m))
+    <|> pure nothing
+
+  ×-map₁₂ : ∀ {A B C : Type} → (A → A) → (B → B) → A × B × C → A × B × C
+  ×-map₁₂ f g (a , b , c) = (f a , g b , c)
+
+  -- Loop over D's constructors and build the method telescope, constructor
+  -- replacements and spines to apply them to.
+  methods : Args → Term → TC (Telescope × List Args × Replacements)
+  methods ps P = go ps P [] (enumerate cs) where
+    go : Args → Term → Replacements → List (Nat × Name) → TC _
+    go ps P rs [] = pure ([] , [] , rs)
+    go ps P rs ((i , c) ∷ cs) = do
+      let c' = con c (hide ps)
+      cT ← flip pi-applyTC ps =<< normalise =<< get-type c
+      just (methodT , α) ← pure (display 1 ps P rs (var 0 []) [] c' cT)
+        where _ → typeError [ "the type of constructor " , nameErr c , " somehow does not end in " , termErr (def D ps) ]
+      try-hlevel methodT >>= λ where
+        (just m) → do
+          -- The type of the method is solvable by hlevel (i.e. contractible):
+          -- we can omit that type from the telescope and replace the method with
+          -- a call to `hlevel 0 .centre`.
+          let rs = (c' , m) ∷ rs
+          go ps P rs cs <&> ×-map₁₂ id (α ∷_)
+        nothing → do
+          -- Otherwise, add m : T to the telescope and replace the corresponding
+          -- constructor with m henceforth.
+          let method = "m" <> show i
+              ps = raise 1 ps
+              P = raise 1 P
+              rs = (c' , var 0 []) ∷ raise 1 rs
+          extend-context method (argN methodT) (go ps P rs cs) <&>
+            ×-map₁₂ ((method , argN methodT) ∷_) (α ∷_)
+
+-- The entry point of the macro: declares or defines the induction principle for D as `elim`.
+-- If `ind?` is true, an induction principle is generated; otherwise, a recursion principle.
+-- If `hlevel?` is `just n`, generate an induction principle into n-types by omitting
+-- the methods that can be solved by hlevel.
+-- `hide-*?` provide some control over which arguments are implicit in the eliminator's type.
+make-elim-with : Bool → Maybe Nat → Bool → Bool → Bool → Name → Name → TC ⊤
+make-elim-with ind? hlevel? hide-motive? hide-indices? hide-method-args? elim D =
+  withNormalisation true do
+  DT ← get-type D >>= normalise -- D : (ps : Γ) (is : Ξ) → Type _
+  data-type pars cs ← get-definition D
+    where _ → typeError [ "not a data type: " , nameErr D ]
+  let DTTel , _ = pi-view DT
+      parTel , ixTel = split-at pars DTTel
+      parTelH = hide parTel
+      ixTel = hide-if hide-indices? ixTel
+      DTel = ixTel ∷r ("" , argN (def D (tel→args 0 DTTel))) -- (is : Ξ) (_ : D ps is)
+      DTel = raise 1 DTel
+      PTel = if ind? then id else λ _ → []
+      argP = if hide-motive? then argH else argN
+      motiveTel = ("ℓ" , argH (quoteTerm Level))
+                -- P : DTel → Type ℓ
+                ∷ ("P" , argP (unpi-view (PTel DTel) (agda-sort (set (var (length (PTel DTel)) [])))))
+                ∷ []
+      DTel = raise 1 DTel
+      -- We want to take is-hlevel as an argument, but we need to work in a context
+      -- with an H-Level instance in scope.
+      -- (d : DTel) → is-hlevel (P d) n
+      hlevelTel = maybe→alt hlevel? <&> λ n → "h" , argN
+        (unpi-view (PTel DTel)
+          (def (quote is-hlevel) (var (length (PTel DTel)) (tel→args 0 (PTel DTel))
+            v∷ lit (nat n) v∷ [])))
+      -- {d : DTel} {k : Nat} → H-Level (P d) (n + k)
+      H-LevelTel = maybe→alt hlevel? <&> λ n → "h" , argI
+        (unpi-view (hide (PTel DTel)) (pi (argH (quoteTerm Nat)) (abs "k"
+          (def (quote H-Level) (var (length (PTel DTel) + 1) (tel→args 1 (PTel DTel)) v∷
+            def (quote _+_) (lit (nat n) v∷ var 0 [] v∷ []) v∷ [])))))
+      ps = tel→args (length motiveTel + length hlevelTel) parTel
+      P = var (length hlevelTel) []
+      module I = Induction D pars ixTel cs ind? hlevel? hide-method-args? hide-indices?
+  methodTel , αs , rs ← in-context (reverse (parTelH ++ motiveTel ++ H-LevelTel)) (I.methods ps P)
+  let baseTel = parTelH ++ motiveTel ++ hlevelTel ++ methodTel
+      DTel = raise (length hlevelTel + length methodTel) DTel
+      P = raise (length methodTel + length DTel) P
+      Pd = apply-tm* P (tel→args 0 (PTel DTel))
+      -- ∀ (ps : Γ) {ℓ} {P} (h : ∀ d → is-hlevel (P d) n)? (ms : methodTel) (d : DTel) → P d
+      elimT = unpi-view (baseTel ++ DTel) Pd
+  elimT' ← just <$> get-type elim <|> nothing <$ declare (argN elim) elimT
+  for elimT' (unify elimT) -- Give a nicer error if the types don't match
+  let ixTel = raise (length motiveTel + length hlevelTel + length methodTel) ixTel
+      ps = raise (length methodTel + length ixTel) ps
+      rs = raise (length ixTel) rs
+  -- The replacements are in the H-Level context, so we substitute them back into
+  -- our context using basic-instance.
+  let rs = Maybe-rec (λ n → applyS (inplaceS (length methodTel + length ixTel)
+        (tel→lam (hide (PTel DTel))
+          (def (quote basic-instance) (lit (nat n) v∷
+            var (length methodTel + length ixTel + length (PTel DTel)) (tel→args 0 (PTel DTel)) v∷ []))
+        )) rs)
+        rs hlevel?
+  clauses ← in-context (reverse (baseTel ++ ixTel)) do
+    let getClause = λ (c , α) → do
+      cT ← flip pi-applyTC ps =<< normalise =<< get-type c
+      let cTel = pi-view-path cT
+          pats = tel→pats (length cTel) (baseTel ++ ixTel) ∷r argN (con c (tel→pats 0 cTel))
+          rec = def elim (tel→args (length ixTel + length cTel) baseTel)
+          α = applyS (singletonS (length cTel) rec) α
+      just m ← pure (I.replace rs (con c (hide ps)))
+        where _ → typeError []
+      let m = apply-tm* (raise (length cTel) m) α
+      pure (clause (baseTel ++ ixTel ++ cTel) pats m)
+    traverse getClause (zip cs αs)
+  define-function elim clauses
+
+make-elim make-rec : Name → Name → TC ⊤
+make-elim = make-elim-with true nothing true true true
+make-rec = make-elim-with false nothing true true true
+
+make-elim-n make-rec-n : Nat → Name → Name → TC ⊤
+make-elim-n n = make-elim-with true (just n) true true true
+make-rec-n n = make-elim-with false (just n) true true true

--- a/src/1Lab/Reflection/Induction.agda
+++ b/src/1Lab/Reflection/Induction.agda
@@ -29,6 +29,9 @@ When generating an eliminator into (n-2)-types, we automatically omit the method
 follow from h-level (i.e. those corresponding to constructors with at least n
 nested `PathP`s).
 
+Due to limitations of the reflection interface, path constructors between composites
+are not supported.
+
 See 1Lab.Reflection.Induction.Examples for examples.
 -}
 
@@ -190,7 +193,7 @@ private
       let c' = con c (hide ps)
       cT ← flip pi-applyTC ps =<< normalise =<< get-type c
       just (methodT , α) ← pure (display 1 ps P rs (var 0 []) [] c' cT)
-        where _ → typeError [ "the type of constructor " , nameErr c , " somehow does not end in " , termErr (def D ps) ]
+        where _ → typeError [ "The type of constructor " , nameErr c , " is not supported" ]
       try-hlevel methodT >>= λ where
         (just m) → do
           -- The type of the method is solvable by hlevel (i.e. contractible):

--- a/src/1Lab/Reflection/Induction.agda
+++ b/src/1Lab/Reflection/Induction.agda
@@ -1,5 +1,5 @@
+open import 1Lab.Reflection.Signature
 open import 1Lab.Reflection.Subst
-open import 1Lab.HLevel.Retracts
 open import 1Lab.Reflection
 open import 1Lab.Type.Sigma
 open import 1Lab.Type.Pi
@@ -7,14 +7,16 @@ open import 1Lab.HLevel
 open import 1Lab.Path
 open import 1Lab.Type
 
-open import Data.String.Show
 open import Data.Nat.Base
 
 open import Meta.Append
 
 module 1Lab.Reflection.Induction where
 
-open import Data.Maybe.Base public
+-- H-Level instances must be in scope for the macro to work properly
+open import 1Lab.HLevel.Retracts public
+
+open import Data.Maybe.Base using (nothing; just) public
 
 {-
 A macro for generating induction principles for (higher, indexed) inductive types.
@@ -50,13 +52,37 @@ instance
   Has-subst-Replacements : Has-subst Replacements
   Has-subst-Replacements = record { applyS = subst-replacements }
 
+record Elim-options : Type where
+  field
+    -- Whether to generate an induction principle or a recursion principle.
+    -- (P : D → Type ℓ) vs (P : Type ℓ)
+    induction : Bool
+
+    -- If `just n`, assume the motive has hlevel n and omit methods accordingly.
+    into-hlevel : Maybe Nat
+
+    -- Hide the motive argument in the eliminator's type?
+    -- (P : D → Type ℓ) vs. {P : D → Type ℓ}
+    hide-motive : Bool
+
+    -- Hide the indices in the motive's type?
+    -- (P : (is : Ξ) → D is → Type ℓ) vs. (P : {is : Ξ} → D is → Type ℓ)
+    hide-indices : Bool
+
+    -- Hide non-inductive hypotheses in method types?
+    -- (Psup : (x : A) (f : B x → W A B) (Pf : ∀ b → P (f b)) → P (sup x f))
+    -- vs.
+    -- (Psup : {x : A} {f : B x → W A B} (Pf : ∀ b → P (f b)) → P (sup x f))
+    -- Arguments hidden in the constructor's type are always hidden.
+    hide-cons-args : Bool
+
 private
  module Induction
+  (opts : Elim-options)
   (D : Name) (pars : Nat) (ixTel : Telescope) (cs : List Name)
-  (ind? : Bool)
-  (hlevel? : Maybe Nat)
-  (hide-method-args? hide-indices? : Bool)
   where
+
+  open Elim-options opts
 
   -- Given a term c : T, produce a replacement c↑ : T↑ (see below).
   -- The Replacements argument maps constructors and variables to their
@@ -84,7 +110,7 @@ private
 
   replace* rs [] = []
   replace* rs (arg ai t ∷ as) with replace rs t
-  ... | just t' = hide-if hide-method-args? (arg ai t) ∷ arg ai t' ∷ replace* rs as
+  ... | just t' = hide-if hide-cons-args (arg ai t) ∷ arg ai t' ∷ replace* rs as
   ... | nothing = arg ai t ∷ replace* rs as
 
   {-
@@ -123,41 +149,45 @@ private
     → (c : Term) (T : Term)
     → Maybe (Term × Args) -- (T↑ , α)
   display depth ps P rs rec α c (pi (arg ai x) (abs n y)) = do
-    let ps = raise 1 ps
-        P = raise 1 P
-        rs = raise 1 rs
-        rec = raise 1 rec
-        α = raise 1 α
-        c = raise 1 c
-        base =
-          let c = c <#> arg ai (var 0 [])
-              α = α ∷r arg ai (var 0 [])
-          in display depth ps P rs rec α c y <&> ×-map₁ λ y →
-            pi (arg ai x) (abs n y)
+    let
+      ps = raise 1 ps
+      P = raise 1 P
+      rs = raise 1 rs
+      rec = raise 1 rec
+      α = raise 1 α
+      c = raise 1 c
+      base =
+        let
+          c = c <#> arg ai (var 0 [])
+          α = α ∷r hide-if hide-cons-args (arg ai (var 0 []))
+        in display depth ps P rs rec α c y <&> ×-map₁ λ y →
+          pi (hide-if hide-cons-args (arg ai x)) (abs n y)
     suc depth-1 ← pure depth
       where _ → base
     just (h , α') ← pure (display depth-1 ps P rs unknown [] (var 0 []) (raise 1 x))
       where _ → base
-    let ps = raise 1 ps
-        P = raise 1 P
-        rs = (var 1 [] , var 0 []) ∷ raise 1 rs
-        c = raise 1 c <#> arg ai (var 1 [])
-        hTel = pi-view-path h
-        l = tel→lam hTel (apply-tm* (raise (length hTel) rec)
-          (infer-tel ixTel ∷r argN (var (length hTel) α')))
-        α = α ++ [ hide-if hide-method-args? (arg ai (var 0 [])) , argN l ]
-        y = raise 1 y
+    let
+      ps = raise 1 ps
+      P = raise 1 P
+      rs = (var 1 [] , var 0 []) ∷ raise 1 rs
+      c = raise 1 c <#> arg ai (var 1 [])
+      hTel = pi-view-path h
+      l = tel→lam hTel (apply-tm* (raise (length hTel) rec)
+        (infer-tel ixTel ∷r argN (var (length hTel) α')))
+      α = α ++ [ hide-if hide-cons-args (arg ai (var 0 [])) , argN l ]
+      y = raise 1 y
     display depth ps P rs rec α c y <&> ×-map₁ λ y →
-      pi (hide-if hide-method-args? (arg ai x)) (abs n (pi (argN h) (abs ("p" <> n) y)))
+      pi (hide-if hide-cons-args (arg ai x)) (abs n (pi (argN h) (abs ("P" <> n) y)))
   display depth ps P rs rec α c (def (quote PathP) (_ h∷ lam v (abs n y) v∷ l v∷ r v∷ [])) = do
     l ← replace rs l
     r ← replace rs r
-    let ps = raise 1 ps
-        P = raise 1 P
-        rs = raise 1 rs
-        rec = raise 1 rec
-        α = raise 1 α ∷r argN (var 0 [])
-        c = raise 1 c <#> argN (var 0 [])
+    let
+      ps = raise 1 ps
+      P = raise 1 P
+      rs = raise 1 rs
+      rec = raise 1 rec
+      α = raise 1 α ∷r argN (var 0 [])
+      c = raise 1 c <#> argN (var 0 [])
     display depth ps P rs rec α c y <&> ×-map₁ λ y →
       def (quote PathP) (unknown h∷ lam v (abs n y) v∷ l v∷ r v∷ [])
   display depth ps P rs rec α c (def D' args) = do
@@ -166,14 +196,14 @@ private
     let ps' , is = split-at pars args
     yes _ ← pure (ps ≡? ps')
       where _ → nothing
-    let Pc = apply-tm* P (if ind? then hide-if hide-indices? is ++ c v∷ [] else [])
+    let Pc = apply-tm* P (if induction then hide-if hide-indices is ++ c v∷ [] else [])
     pure (Pc , α)
   display depth ps P rs rec α c _ = nothing
 
   try-hlevel : Term → TC (Maybe Term)
   try-hlevel T =
     (do
-      maybe→alt hlevel?
+      maybe→alt into-hlevel
       m ← new-meta T
       unify m $ def (quote centre) $
         def (quote hlevel) (unknown h∷ T h∷ lit (nat 0) v∷ []) v∷ []
@@ -186,10 +216,10 @@ private
   -- Loop over D's constructors and build the method telescope, constructor
   -- replacements and spines to apply them to.
   methods : Args → Term → TC (Telescope × List Args × Replacements)
-  methods ps P = go ps P [] (enumerate cs) where
-    go : Args → Term → Replacements → List (Nat × Name) → TC _
+  methods ps P = go ps P [] cs where
+    go : Args → Term → Replacements → List Name → TC _
     go ps P rs [] = pure ([] , [] , rs)
-    go ps P rs ((i , c) ∷ cs) = do
+    go ps P rs (c ∷ cs) = do
       let c' = con c (hide ps)
       cT ← flip pi-applyTC ps =<< normalise =<< get-type c
       just (methodT , α) ← pure (display 1 ps P rs (var 0 []) [] c' cT)
@@ -204,79 +234,80 @@ private
         nothing → do
           -- Otherwise, add m : T to the telescope and replace the corresponding
           -- constructor with m henceforth.
-          let method = "m" <> show i
-              ps = raise 1 ps
-              P = raise 1 P
-              rs = (c' , var 0 []) ∷ raise 1 rs
+          method ← ("P" <>_) <$> render-name c
+          let
+            ps = raise 1 ps
+            P = raise 1 P
+            rs = (c' , var 0 []) ∷ raise 1 rs
           extend-context method (argN methodT) (go ps P rs cs) <&>
             ×-map₁₂ ((method , argN methodT) ∷_) (α ∷_)
 
--- The entry point of the macro: declares or defines the induction principle for D as `elim`.
--- If `ind?` is true, an induction principle is generated; otherwise, a recursion principle.
--- If `hlevel?` is `just n`, generate an induction principle into n-types by omitting
--- the methods that can be solved by hlevel.
--- `hide-*?` provide some control over which arguments are implicit in the eliminator's type.
-make-elim-with : Bool → Maybe Nat → Bool → Bool → Bool → Name → Name → TC ⊤
-make-elim-with ind? hlevel? hide-motive? hide-indices? hide-method-args? elim D =
-  withNormalisation true do
+make-elim-with : Elim-options → Name → Name → TC ⊤
+make-elim-with opts elim D = withNormalisation true do
   DT ← get-type D >>= normalise -- D : (ps : Γ) (is : Ξ) → Type _
   data-type pars cs ← get-definition D
     where _ → typeError [ "not a data type: " , nameErr D ]
-  let DTTel , _ = pi-view DT
-      parTel , ixTel = split-at pars DTTel
-      parTelH = hide parTel
-      ixTel = hide-if hide-indices? ixTel
-      DTel = ixTel ∷r ("" , argN (def D (tel→args 0 DTTel))) -- (is : Ξ) (_ : D ps is)
-      DTel = raise 1 DTel
-      PTel = if ind? then id else λ _ → []
-      argP = if hide-motive? then argH else argN
-      motiveTel = ("ℓ" , argH (quoteTerm Level))
-                -- P : DTel → Type ℓ
-                ∷ ("P" , argP (unpi-view (PTel DTel) (agda-sort (set (var (length (PTel DTel)) [])))))
-                ∷ []
-      DTel = raise 1 DTel
-      -- We want to take is-hlevel as an argument, but we need to work in a context
-      -- with an H-Level instance in scope.
-      -- (d : DTel) → is-hlevel (P d) n
-      hlevelTel = maybe→alt hlevel? <&> λ n → "h" , argN
-        (unpi-view (PTel DTel)
-          (def (quote is-hlevel) (var (length (PTel DTel)) (tel→args 0 (PTel DTel))
-            v∷ lit (nat n) v∷ [])))
-      -- {d : DTel} {k : Nat} → H-Level (P d) (n + k)
-      H-LevelTel = maybe→alt hlevel? <&> λ n → "h" , argI
-        (unpi-view (hide (PTel DTel)) (pi (argH (quoteTerm Nat)) (abs "k"
-          (def (quote H-Level) (var (length (PTel DTel) + 1) (tel→args 1 (PTel DTel)) v∷
-            def (quote _+_) (lit (nat n) v∷ var 0 [] v∷ []) v∷ [])))))
-      ps = tel→args (length motiveTel + length hlevelTel) parTel
-      P = var (length hlevelTel) []
-      module I = Induction D pars ixTel cs ind? hlevel? hide-method-args? hide-indices?
+  let
+    open Elim-options opts
+    DTTel , _ = pi-view DT
+    parTel , ixTel = split-at pars DTTel
+    parTelH = hide parTel
+    ixTel = hide-if hide-indices ixTel
+    DTel = ixTel ∷r ("" , argN (def D (tel→args 0 DTTel))) -- (is : Ξ) (_ : D ps is)
+    DTel = raise 1 DTel
+    PTel = if induction then id else λ _ → []
+    argP = if hide-motive then argH else argN
+    motiveTel = ("ℓ" , argH (quoteTerm Level))
+              -- P : DTel → Type ℓ
+              ∷ ("P" , argP (unpi-view (PTel DTel) (agda-sort (set (var (length (PTel DTel)) [])))))
+              ∷ []
+    DTel = raise 1 DTel
+    -- We want to take is-hlevel as an argument, but we need to work in a context
+    -- with an H-Level instance in scope.
+    -- (d : DTel) → is-hlevel (P d) n
+    hlevelTel = maybe→alt into-hlevel <&> λ n → "h" , argN
+      (unpi-view (PTel DTel)
+        (def (quote is-hlevel) (var (length (PTel DTel)) (tel→args 0 (PTel DTel))
+          v∷ lit (nat n) v∷ [])))
+    -- {d : DTel} {k : Nat} → H-Level (P d) (n + k)
+    H-LevelTel = maybe→alt into-hlevel <&> λ n → "h" , argI
+      (unpi-view (hide (PTel DTel)) (pi (argH (quoteTerm Nat)) (abs "k"
+        (def (quote H-Level) (var (length (PTel DTel) + 1) (tel→args 1 (PTel DTel)) v∷
+          def (quote _+_) (lit (nat n) v∷ var 0 [] v∷ []) v∷ [])))))
+    ps = tel→args (length motiveTel + length hlevelTel) parTel
+    P = var (length hlevelTel) []
+    module I = Induction opts D pars ixTel cs
   methodTel , αs , rs ← in-context (reverse (parTelH ++ motiveTel ++ H-LevelTel)) (I.methods ps P)
-  let baseTel = parTelH ++ motiveTel ++ hlevelTel ++ methodTel
-      DTel = raise (length hlevelTel + length methodTel) DTel
-      P = raise (length methodTel + length DTel) P
-      Pd = apply-tm* P (tel→args 0 (PTel DTel))
-      -- ∀ (ps : Γ) {ℓ} {P} (h : ∀ d → is-hlevel (P d) n)? (ms : methodTel) (d : DTel) → P d
-      elimT = unpi-view (baseTel ++ DTel) Pd
+  let
+    baseTel = parTelH ++ motiveTel ++ hlevelTel ++ methodTel
+    DTel = raise (length hlevelTel + length methodTel) DTel
+    P = raise (length methodTel + length DTel) P
+    Pd = apply-tm* P (tel→args 0 (PTel DTel))
+    -- ∀ (ps : Γ) {ℓ} {P} (h : ∀ d → is-hlevel (P d) n)? (ms : methodTel) (d : DTel) → P d
+    elimT = unpi-view (baseTel ++ DTel) Pd
   elimT' ← just <$> get-type elim <|> nothing <$ declare (argN elim) elimT
   for elimT' (unify elimT) -- Give a nicer error if the types don't match
-  let ixTel = raise (length motiveTel + length hlevelTel + length methodTel) ixTel
-      ps = raise (length methodTel + length ixTel) ps
-      rs = raise (length ixTel) rs
+  let
+    ixTel = raise (length motiveTel + length hlevelTel + length methodTel) ixTel
+    ps = raise (length methodTel + length ixTel) ps
+    rs = raise (length ixTel) rs
   -- The replacements are in the H-Level context, so we substitute them back into
   -- our context using basic-instance.
-  let rs = Maybe-rec (λ n → applyS (inplaceS (length methodTel + length ixTel)
-        (tel→lam (hide (PTel DTel))
-          (def (quote basic-instance) (lit (nat n) v∷
-            var (length methodTel + length ixTel + length (PTel DTel)) (tel→args 0 (PTel DTel)) v∷ []))
-        )) rs)
-        rs hlevel?
+  let
+    h = length methodTel + length ixTel
+    rs = Maybe-rec (λ n → applyS (inplaceS h
+      (tel→lam (hide (PTel DTel))
+        (def (quote basic-instance) (lit (nat n) v∷
+          var (h + length (PTel DTel)) (tel→args 0 (PTel DTel)) v∷ [])))))
+      id into-hlevel rs
   clauses ← in-context (reverse (baseTel ++ ixTel)) do
     let getClause = λ (c , α) → do
       cT ← flip pi-applyTC ps =<< normalise =<< get-type c
-      let cTel = pi-view-path cT
-          pats = tel→pats (length cTel) (baseTel ++ ixTel) ∷r argN (con c (tel→pats 0 cTel))
-          rec = def elim (tel→args (length ixTel + length cTel) baseTel)
-          α = applyS (singletonS (length cTel) rec) α
+      let
+        cTel = pi-view-path cT
+        pats = tel→pats (length cTel) (baseTel ++ ixTel) ∷r argN (con c (tel→pats 0 cTel))
+        rec = def elim (tel→args (length ixTel + length cTel) baseTel)
+        α = applyS (singletonS (length cTel) rec) α
       just m ← pure (I.replace rs (con c (hide ps)))
         where _ → typeError []
       let m = apply-tm* (raise (length cTel) m) α
@@ -284,10 +315,32 @@ make-elim-with ind? hlevel? hide-motive? hide-indices? hide-method-args? elim D 
     traverse getClause (zip cs αs)
   define-function elim clauses
 
+default-elim = record
+  { induction = true
+  ; into-hlevel = nothing
+  ; hide-motive = true
+  ; hide-indices = true
+  ; hide-cons-args = false
+  }
+
+default-elim-visible = record
+  { induction = true
+  ; into-hlevel = nothing
+  ; hide-motive = false
+  ; hide-indices = false
+  ; hide-cons-args = false
+  }
+
+default-rec = record default-elim { induction = false }
+default-rec-visible = record default-elim-visible { induction = false }
+
+_into_ : Elim-options → Nat → Elim-options
+opts into n = record opts { into-hlevel = just n }
+
 make-elim make-rec : Name → Name → TC ⊤
-make-elim = make-elim-with true nothing true true true
-make-rec = make-elim-with false nothing true true true
+make-elim = make-elim-with default-elim
+make-rec = make-elim-with default-rec
 
 make-elim-n make-rec-n : Nat → Name → Name → TC ⊤
-make-elim-n n = make-elim-with true (just n) true true true
-make-rec-n n = make-elim-with false (just n) true true true
+make-elim-n n = make-elim-with (default-elim into n)
+make-rec-n n = make-elim-with (default-rec into n)

--- a/src/1Lab/Reflection/Induction/Examples.agda
+++ b/src/1Lab/Reflection/Induction/Examples.agda
@@ -1,9 +1,10 @@
 open import 1Lab.Reflection.Induction
-open import 1Lab.Prelude hiding (J)
+open import 1Lab.HLevel
+open import 1Lab.Path hiding (J)
+open import 1Lab.Type
 
 open import Data.Set.Truncation hiding (∥-∥₀-elim)
 open import Data.Wellfounded.W hiding (W-elim; P)
-open import Data.Maybe.Base
 open import Data.Fin.Base hiding (Fin-elim)
 open import Data.Id.Base
 
@@ -15,14 +16,14 @@ unquoteDecl Fin-elim = make-elim Fin-elim (quote Fin)
 
 _ : {ℓ : Level} {P : {n : Nat} (f : Fin n) → Type ℓ}
     (P0 : {n : Nat} → P fzero)
-    (Psuc : {n : Nat} {f : Fin n} (pf : P f) → P (fsuc f))
+    (Psuc : {n : Nat} (f : Fin n) (Pf : P f) → P (fsuc f))
     {n : Nat} (f : Fin n) → P f
 _ = Fin-elim
 
-unquoteDecl J = make-elim-with true nothing true false true J (quote _≡ᵢ_)
+unquoteDecl J = make-elim-with default-elim-visible J (quote _≡ᵢ_)
 
 _ : {ℓ : Level} {A : Type ℓ} {x : A} {ℓ₁ : Level}
-    {P : (z : A) (z₁ : x ≡ᵢ z) → Type ℓ₁}
+    (P : (z : A) (z₁ : x ≡ᵢ z) → Type ℓ₁)
     (Prefl : P x reflᵢ)
     (y : A) (p : x ≡ᵢ y) → P y p
 _ = J
@@ -31,7 +32,7 @@ unquoteDecl W-elim = make-elim W-elim (quote W)
 
 _ : {ℓ ℓ' : Level} {A : Type ℓ} {B : (z : A) → Type ℓ'}
     {ℓ₁ : Level} {P : (w : W A B) → Type ℓ₁}
-    (Psup : (x : A) {f : (z : B x) → W A B} (pf : (z : B x) → P (f z)) → P (sup x f))
+    (Psup : (x : A) (f : (z : B x) → W A B) (Pf : (z : B x) → P (f z)) → P (sup x f))
     (w : W A B) → P w
 _ = W-elim
 

--- a/src/1Lab/Reflection/Induction/Examples.agda
+++ b/src/1Lab/Reflection/Induction/Examples.agda
@@ -1,0 +1,58 @@
+open import 1Lab.Reflection.Induction
+open import 1Lab.Prelude hiding (J)
+
+open import Data.Set.Truncation hiding (∥-∥₀-elim)
+open import Data.Wellfounded.W hiding (W-elim; P)
+open import Data.Maybe.Base
+open import Data.Fin.Base hiding (Fin-elim)
+open import Data.Id.Base
+
+open import Homotopy.Space.Circle hiding (S¹-elim)
+
+module 1Lab.Reflection.Induction.Examples where
+
+unquoteDecl Fin-elim = make-elim Fin-elim (quote Fin)
+
+_ : {ℓ : Level} {P : {n : Nat} (f : Fin n) → Type ℓ}
+    (P0 : {n : Nat} → P fzero)
+    (Psuc : {n : Nat} {f : Fin n} (pf : P f) → P (fsuc f))
+    {n : Nat} (f : Fin n) → P f
+_ = Fin-elim
+
+unquoteDecl J = make-elim-with true nothing true false true J (quote _≡ᵢ_)
+
+_ : {ℓ : Level} {A : Type ℓ} {x : A} {ℓ₁ : Level}
+    {P : (z : A) (z₁ : x ≡ᵢ z) → Type ℓ₁}
+    (Prefl : P x reflᵢ)
+    (y : A) (p : x ≡ᵢ y) → P y p
+_ = J
+
+unquoteDecl W-elim = make-elim W-elim (quote W)
+
+_ : {ℓ ℓ' : Level} {A : Type ℓ} {B : (z : A) → Type ℓ'}
+    {ℓ₁ : Level} {P : (w : W A B) → Type ℓ₁}
+    (Psup : (x : A) {f : (z : B x) → W A B} (pf : (z : B x) → P (f z)) → P (sup x f))
+    (w : W A B) → P w
+_ = W-elim
+
+unquoteDecl S¹-elim = make-elim S¹-elim (quote S¹)
+unquoteDecl S¹-elim-prop = make-elim-n 1 S¹-elim-prop (quote S¹)
+
+_ : {ℓ : Level} {P : (s : S¹) → Type ℓ}
+    (Pbase : P base)
+    (Ploop : PathP (λ i → P (loop i)) Pbase Pbase)
+    (s : S¹) → P s
+_ = S¹-elim
+
+_ : {ℓ : Level} {P : (s : S¹) → Type ℓ}
+  → (∀ s → is-prop (P s))
+  → P base → ∀ s → P s
+_ = S¹-elim-prop
+
+unquoteDecl ∥-∥₀-elim = make-elim-n 2 ∥-∥₀-elim (quote ∥_∥₀)
+
+_ : {ℓ : Level} {A : Type ℓ} {ℓ₁ : Level} {P : (z : ∥ A ∥₀) → Type ℓ₁}
+    (h : (z : ∥ A ∥₀) → is-hlevel (P z) 2)
+    (Pinc : (z : A) → P (inc z))
+    (x : ∥ A ∥₀) → P x
+_ = ∥-∥₀-elim

--- a/src/1Lab/Reflection/Signature.agda
+++ b/src/1Lab/Reflection/Signature.agda
@@ -80,12 +80,6 @@ get-record tm = reduce tm >>= λ where
   (def qn _) → get-record-type qn
   _          → typeError [ "get-record: " , termErr tm , " is not a record type." ]
 
-telescope→patterns : Telescope → List (Arg Pattern)
-telescope→patterns tel = go (length tel - 1) tel where
-  go : Nat → Telescope → List (Arg Pattern)
-  go n []                  = []
-  go n ((_ , arg i _) ∷ t) = arg i (var n) ∷ go (n - 1) t
-
 -- Get the argument telescope of something in the signature. NOTE: If
 -- the Name refers to a Constructor, the returned telescope *will*
 -- include the data/record parameters!

--- a/src/1Lab/Reflection/Subst.agda
+++ b/src/1Lab/Reflection/Subst.agda
@@ -149,3 +149,16 @@ _<#>_ : Term → Arg Term → Term
 f <#> x = apply-tm f x
 
 infixl 7 _<#>_
+
+pi-apply : Term → List (Arg Term) → Maybe Term
+pi-apply ty as = go ty as ids where
+  go : Term → List (Arg Term) → Subst → Maybe Term
+  go (pi (arg _ x) (abs n y)) (arg _ a ∷ as) s = go y as (a ∷ s)
+  go _ (_ ∷ as) s = nothing
+  go t [] s = just (subst-tm s t)
+
+pi-applyTC : Term → List (Arg Term) → TC Term
+pi-applyTC f x with pi-apply f x
+pi-applyTC f x | just r  = pure r
+pi-applyTC f _ | nothing =
+  typeError [ "Failed to apply type " , termErr f ]

--- a/src/1Lab/Type/Pi.lagda.md
+++ b/src/1Lab/Type/Pi.lagda.md
@@ -215,5 +215,10 @@ funext-square p i j a = p a i j
   .is-iso.inv b a → subst B (c .paths a) b
   .is-iso.rinv b → ap (λ e → subst B e b) (is-contr→is-set c _ _ _ _) ∙ transport-refl b
   .is-iso.linv b → funext λ a → from-pathp (ap b (c .paths a))
+
+flip
+  : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : A → B → Type ℓ''}
+  → (∀ a b → C a b) → (∀ b a → C a b)
+flip f b a = f a b
 ```
 -->

--- a/src/Algebra/Group/Cat/Monadic.lagda.md
+++ b/src/Algebra/Group/Cat/Monadic.lagda.md
@@ -179,7 +179,7 @@ but the other direction is by induction on "words".
     go : rec .hom ≡ x .snd .ν
     go = funext $ Free-elim-prop _ (λ _ → hlevel 1)
       (λ x → sym (happly (alg .ν-unit) x))
-      (λ x y p q → rec .preserves .is-group-hom.pres-⋆ x y
+      (λ x p y q → rec .preserves .is-group-hom.pres-⋆ x y
                 ·· ap₂ G._⋆_ p q
                 ·· happly (alg .ν-mult) (inc _ ◆ inc _))
       (λ x p → is-group-hom.pres-inv (rec .preserves) {x = x}

--- a/src/Algebra/Group/Free.lagda.md
+++ b/src/Algebra/Group/Free.lagda.md
@@ -1,5 +1,7 @@
 <!--
 ```agda
+open import 1Lab.Reflection.Induction
+
 open import Algebra.Group.Cat.Base
 open import Algebra.Group
 
@@ -90,36 +92,18 @@ Free-elim-prop
   : ∀ {ℓ} (B : Free-group A → Type ℓ)
   → (∀ x → is-prop (B x))
   → (∀ x → B (inc x))
-  → (∀ x y → B x → B y → B (x ◆ y))
+  → (∀ x → B x → ∀ y → B y → B (x ◆ y))
   → (∀ x → B x → B (inv x))
   → B nil
   → ∀ x → B x
 ```
 
-<details>
-<summary>
 The proof of it is a direct (by which I mean repetitive) case analysis,
-so I've put it in a `<details>`{.html} tag.
-</summary>
+so we let our reflection machinery handle it for us.
 
 ```agda
-Free-elim-prop B bp bi bd binv bnil = go where
-  go : ∀ x → B x
-  go (inc x) = bi x
-  go (x ◆ y) = bd x y (go x) (go y)
-  go (inv x) = binv x (go x)
-  go nil = bnil
-  go (f-assoc x y z i) =
-    is-prop→pathp (λ i → bp (f-assoc x y z i))
-      (bd x (y ◆ z) (go x) (bd y z (go y) (go z)))
-      (bd (x ◆ y) z (bd x y (go x) (go y)) (go z))
-      i
-  go (f-invl x i) =
-    is-prop→pathp (λ i → bp (f-invl x i)) (bd (inv x) x (binv x (go x)) (go x)) bnil i
-  go (f-idl x i) = is-prop→pathp (λ i → bp (f-idl x i)) (bd nil x bnil (go x)) (go x) i
-  go (squash x y p q i j) =
-    is-prop→squarep (λ i j → bp (squash x y p q i j))
-      (λ i → go x) (λ i → go (p i)) (λ i → go (q i)) (λ i → go y) i j
+unquoteDef Free-elim-prop = make-elim-with true (just 1) false false false
+  Free-elim-prop (quote Free-group)
 ```
 
 </details>
@@ -193,7 +177,7 @@ make-free-group .Ml.commutes f = refl
 make-free-group .Ml.unique {y = y} {g = g} p =
   ext $ Free-elim-prop _ (λ _ → hlevel!)
     (p $ₚ_)
-    (λ a b p q → ap₂ y._⋆_ p q ∙ sym (g .preserves .is-group-hom.pres-⋆ _ _))
+    (λ a p b q → ap₂ y._⋆_ p q ∙ sym (g .preserves .is-group-hom.pres-⋆ _ _))
     (λ a p → ap y.inverse p ∙ sym (is-group-hom.pres-inv (g .preserves)))
     (sym (is-group-hom.pres-id (g .preserves)))
   where module y = Group-on (y .snd)

--- a/src/Algebra/Group/Free.lagda.md
+++ b/src/Algebra/Group/Free.lagda.md
@@ -102,7 +102,7 @@ The proof of it is a direct (by which I mean repetitive) case analysis,
 so we let our reflection machinery handle it for us.
 
 ```agda
-unquoteDef Free-elim-prop = make-elim-with true (just 1) false false false
+unquoteDef Free-elim-prop = make-elim-with (default-elim-visible into 1)
   Free-elim-prop (quote Free-group)
 ```
 

--- a/src/Algebra/Group/Homotopy.lagda.md
+++ b/src/Algebra/Group/Homotopy.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import 1Lab.Reflection.Induction
 open import 1Lab.Prelude
 
 open import Algebra.Group.Cat.Base
@@ -236,26 +237,16 @@ eliminator into propositions later, so we define that now.
         → SquareP (λ i j → P (path-sq x y i j))
                   (λ _ → p) (ploop x) (ploop (x ⋆ y)) (ploop y))
     → ∀ x → P x
-  Deloop-elim P grpd pp ploop psq base = pp
-  Deloop-elim P grpd pp ploop psq (path x i) = ploop x i
-  Deloop-elim P grpd pp ploop psq (path-sq x y i j) = psq x y i j
-  Deloop-elim P grpd pp ploop psq (squash a b p q r s i j k) =
-    is-hlevel→is-hlevel-dep 2 grpd
-      (g a) (g b) (λ i → g (p i)) (λ i → g (q i))
-      (λ i j → g (r i j)) (λ i j → g (s i j)) (squash a b p q r s) i j k
-    where
-      g = Deloop-elim P grpd pp ploop psq
+  unquoteDef Deloop-elim = make-elim-with true (just 3) false false false
+    Deloop-elim (quote Deloop)
 
   Deloop-elim-prop
     : ∀ {ℓ'} (P : Deloop → Type ℓ')
     → (∀ x → is-prop (P x))
     → P base
     → ∀ x → P x
-  Deloop-elim-prop P pprop p =
-    Deloop-elim P
-      (λ x → is-prop→is-hlevel-suc {n = 2} (pprop x)) p
-      (λ x → is-prop→pathp (λ i → pprop (path x i)) p p)
-      (λ x y → is-prop→squarep (λ i j → pprop (path-sq x y i j)) _ _ _ _)
+  unquoteDef Deloop-elim-prop = make-elim-with true (just 1) false false false
+    Deloop-elim-prop (quote Deloop)
 ```
 
 We can then proceed to characterise the type `point ≡ x` by an

--- a/src/Algebra/Group/Homotopy.lagda.md
+++ b/src/Algebra/Group/Homotopy.lagda.md
@@ -237,7 +237,7 @@ eliminator into propositions later, so we define that now.
         → SquareP (λ i j → P (path-sq x y i j))
                   (λ _ → p) (ploop x) (ploop (x ⋆ y)) (ploop y))
     → ∀ x → P x
-  unquoteDef Deloop-elim = make-elim-with true (just 3) false false false
+  unquoteDef Deloop-elim = make-elim-with (default-elim-visible into 3)
     Deloop-elim (quote Deloop)
 
   Deloop-elim-prop
@@ -245,7 +245,7 @@ eliminator into propositions later, so we define that now.
     → (∀ x → is-prop (P x))
     → P base
     → ∀ x → P x
-  unquoteDef Deloop-elim-prop = make-elim-with true (just 1) false false false
+  unquoteDef Deloop-elim-prop = make-elim-with (default-elim-visible into 1)
     Deloop-elim-prop (quote Deloop)
 ```
 

--- a/src/Data/Image.lagda.md
+++ b/src/Data/Image.lagda.md
@@ -38,7 +38,7 @@ of $A$".
 Can we do better? It turns out that we can! This generally goes by the
 name of **type-theoretic replacement**, after Rijke [@Rijke:2017 §5]; in
 turn, the name _replacement_ comes from the axiom of material set theory
-sayings the image of a set under a function is again set.^[Keep in mind
+saying the image of a set under a function is again set.^[Keep in mind
 that material set theory says "is a set" in a very different way than we
 do; They mean it about size.] Here we implement a slight generalization
 of [Evan Cavallo's construction] in terms of higher induction-recursion.

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -172,6 +172,8 @@ reverse = go [] where
 _∷r_ : List A → A → List A
 xs ∷r x = xs ++ (x ∷ [])
 
+infixl 20 _∷r_
+
 all=? : (A → A → Bool) → List A → List A → Bool
 all=? eq=? [] [] = true
 all=? eq=? [] (x ∷ ys) = false
@@ -215,6 +217,15 @@ intercalate : ∀ {ℓ} {A : Type ℓ} (x : A) (xs : List A) → List A
 intercalate x []           = []
 intercalate x (y ∷ [])     = y ∷ []
 intercalate x (y ∷ z ∷ xs) = y ∷ x ∷ intercalate x (z ∷ xs)
+
+zip : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → List A → List B → List (A × B)
+zip [] _ = []
+zip _ [] = []
+zip (a ∷ as) (b ∷ bs) = (a , b) ∷ zip as bs
+
+unzip : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → List (A × B) → List A × List B
+unzip [] = [] , []
+unzip ((a , b) ∷ xs) = ×-map (a ∷_) (b ∷_) (unzip xs)
 
 instance
   Idiom-List : Idiom (eff List)

--- a/src/Data/Reflection/Argument.agda
+++ b/src/Data/Reflection/Argument.agda
@@ -64,7 +64,7 @@ record Arg {a} (A : Type a) : Type a where
 pattern _v∷_ t xs = arg (arginfo visible (modality relevant quantity-ω)) t ∷ xs
 pattern _h∷_ t xs = arg (arginfo hidden (modality relevant quantity-ω)) t ∷ xs
 pattern _hm∷_ t xs = arg (arginfo hidden (modality relevant _)) t ∷ xs
-infixr 30 _v∷_ _h∷_ _hm∷_
+infixr 20 _v∷_ _h∷_ _hm∷_
 
 argH0 argI argH argN : ∀ {ℓ} {A : Type ℓ} → A → Arg A
 argH  = arg (arginfo hidden (modality relevant quantity-ω))
@@ -125,3 +125,22 @@ instance
 
   Traversable-Arg : Traversable (eff Arg)
   Traversable-Arg .Traversable.traverse f (arg ai x) = arg ai <$> f x
+
+record Has-visibility {ℓ} (A : Type ℓ) : Type ℓ where
+  field set-visibility : Visibility → A → A
+
+open Has-visibility ⦃ ... ⦄ public
+
+instance
+  Has-visibility-Arg : ∀ {ℓ} {A : Type ℓ} → Has-visibility (Arg A)
+  Has-visibility-Arg .set-visibility v (arg (arginfo _ m) x) = arg (arginfo v m) x
+
+  Has-visibility-Args : ∀ {ℓ} {A : Type ℓ} → Has-visibility (List (Arg A))
+  Has-visibility-Args .set-visibility v l = set-visibility v <$> l
+
+hide : ∀ {ℓ} {A : Type ℓ} → ⦃ Has-visibility A ⦄ → A → A
+hide = set-visibility hidden
+
+hide-if : ∀ {ℓ} {A : Type ℓ} → ⦃ Has-visibility A ⦄ → Bool → A → A
+hide-if true a = hide a
+hide-if false a = a

--- a/src/Data/Reflection/Term.agda
+++ b/src/Data/Reflection/Term.agda
@@ -364,6 +364,16 @@ unpi-view : Telescope → Term → Term
 unpi-view []            k = k
 unpi-view ((n , a) ∷ t) k = pi a (abs n (unpi-view t k))
 
+tel→lam : Telescope → Term → Term
+tel→lam []                               t = t
+tel→lam ((n , arg (arginfo v _) _) ∷ ts) t = lam v (abs n (tel→lam ts t))
+
+tel→args : Nat → Telescope → List (Arg Term)
+tel→args skip tel = map-up (λ i (_ , arg ai _) → arg ai (var (skip + length tel - i) [])) 1 tel
+
+tel→pats : Nat → Telescope → List (Arg Pattern)
+tel→pats skip tel = map-up (λ i (_ , arg ai _) → arg ai (var (skip + length tel - i))) 1 tel
+
 list-term : List Term → Term
 list-term []       = con (quote List.[]) []
 list-term (x ∷ xs) = con (quote List._∷_) (argN x ∷ argN (list-term xs) ∷ [])


### PR DESCRIPTION
# Description

A macro for generating induction principles for (higher, indexed) inductive types.

We support inductive types in the form presented in "Pattern Matching Without K" by Cockx et al, section 3.1, with the addition of higher inductive types.

When generating an eliminator into (n-2)-types, we automatically omit the methods that follow from h-level (i.e. those corresponding to constructors with at least n nested `PathP`s).

This still needs polishing; if you find bugs, please report them! Here's one:

Defining *recursion* principles tends to create unsolved metas from the method arguments to the recursive calls that start with implicit Π types, because Agda instantiates them with metavariables. This could be solved by doing `λ {x y z} → mᵢ {x} {y} {z}`, but is there a better way?

Also needs optimisation; ~in particular, many `raiseTC` calls on things that are known to be unapplied variables could be avoided~. I am not very good at determining what hurts performance the most though, so any help is appreciated.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
