### PR TITLE
chore: bump Agda

### DIFF
--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -3,6 +3,6 @@
   "repo": "agda",
   "branch": "master",
   "private": false,
-  "rev": "5c8116227e2d9120267aed43f0e545a65d9c2fe2",
-  "sha256": "11q0fa087wik8k0badpvifan70n8x666z8mvvxwb1vb0cbzz3av3"
+  "rev": "8ede3561ae32257eb7a102b8301c61fae1debb23",
+  "sha256": "0iwif4ix47974j5mnq24a2afhgc03y0gp977bn0vsb3ics8dg6bz"
 }

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -16,7 +16,7 @@ in
     # somehow depends on mime-types
     labHaskellPackages = super.haskell.packages.ghc946.override (old: {
       overrides = self: super: {
-        Agda = noProfile (noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily -f debug" {}));
+        Agda = noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily -f debug" {});
       };
     });
   }

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -16,7 +16,7 @@ in
     # somehow depends on mime-types
     labHaskellPackages = super.haskell.packages.ghc946.override (old: {
       overrides = self: super: {
-        Agda = noProfile (noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily" {}));
+        Agda = noProfile (noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily -f debug" {}));
       };
     });
   }


### PR DESCRIPTION
The changes to instance ordering did actually reveal some less-than-defined behaviour in the hlevel tactic: if the goal type was blocked on a meta, it might commit to a solution too early, blocking another tactic (or instance search) from making progress. 

This came to head in the `Abelianisation` module, where `hlevel`, `extensionality`, and a `Funlike` instance all had to cooperate to solve the funlike instance.