### PR TITLE
Generalize Pointwise to indexed posets

### DIFF
--- a/src/Order/Instances/Pointwise.lagda.md
+++ b/src/Order/Instances/Pointwise.lagda.md
@@ -16,19 +16,22 @@ module Order.Instances.Pointwise where
 
 # The pointwise ordering
 
-If $(B, \le)$ is a [[partially ordered set]], then so is $A \to B$, for
-any type $A$ which we might choose! There might be other ways of making
-$A \to B$ into a poset, of course, but the canonical way we're talking
-about here is the **pointwise ordering** on $A \to B$, where $f \le g$
-iff $f(x) \le g(x)$ for all $x$.
+The product of a family of [[partially ordered sets]] $\prod_{i : I} P_i$ is a
+poset, for any index type $I$ which we might choose! There might be other ways
+of making $\prod_{i : I} P_i$ into a poset, of course, but the canonical way
+we're talking about here is the **pointwise ordering** on $\prod_{i : I} P_i$,
+where $f \le g$ iff $f(x) \le g(x)$ for all $x$.
+
+[partially ordered sets]: Order.Base.html
 
 ```agda
-Pointwise : ∀ {ℓ ℓₐ ℓᵣ} → Type ℓ → Poset ℓₐ ℓᵣ → Poset (ℓ ⊔ ℓₐ) (ℓ ⊔ ℓᵣ)
-Pointwise A B = po where
-  open Pr B
+Pointwise : ∀ {ℓ ℓₐ ℓᵣ} (I : Type ℓ) (P : I → Poset ℓₐ ℓᵣ)
+  → Poset (ℓ ⊔ ℓₐ) (ℓ ⊔ ℓᵣ)
+Pointwise I P = po where
+  open module PrP {i : I} = Pr (P i)
 
   po : Poset _ _
-  po .Poset.Ob = A → ⌞ B ⌟
+  po .Poset.Ob = (i : I) → ⌞ P i ⌟
   po .Poset._≤_ f g = ∀ x → f x ≤ g x
   po .Poset.≤-thin = hlevel!
   po .Poset.≤-refl x = ≤-refl
@@ -41,7 +44,7 @@ of subsets of a fixed type, which has underlying set $A \to \Omega$.
 
 ```agda
 Subsets : ∀ {ℓ} → Type ℓ → Poset ℓ ℓ
-Subsets A = Pointwise A Props
+Subsets A = Pointwise A (λ _ → Props)
 ```
 
 Another important case: when your domain is not an arbitrary type but

--- a/src/Order/Instances/Pointwise/Diagrams.lagda.md
+++ b/src/Order/Instances/Pointwise/Diagrams.lagda.md
@@ -27,12 +27,12 @@ notation for clarity.], then $h = f \land g$ when $I \to P$ is given the
 
 ```agda
 module
-  _ {ℓₒ ℓᵣ ℓᵢ} {I : Type ℓᵢ} (P : Poset ℓₒ ℓᵣ)
-    (f g h : I → ⌞ P ⌟)
+  _ {ℓₒ ℓᵣ ℓᵢ} {I : Type ℓᵢ} (P : I → Poset ℓₒ ℓᵣ)
+    (f g h : (i : I) → ⌞ P i ⌟)
   where
 
   is-meet-pointwise
-    : (∀ i → is-meet P (f i) (g i) (h i))
+    : (∀ i → is-meet (P i) (f i) (g i) (h i))
     → is-meet (Pointwise I P) f g h
   is-meet-pointwise pwise .is-meet.meet≤l i = pwise i .is-meet.meet≤l
   is-meet-pointwise pwise .is-meet.meet≤r i = pwise i .is-meet.meet≤r
@@ -40,7 +40,7 @@ module
     pwise i .is-meet.greatest (lb' i) (lb'<f i) (lb'<g i)
 
   is-join-pointwise
-    : (∀ i → is-join P (f i) (g i) (h i))
+    : (∀ i → is-join (P i) (f i) (g i) (h i))
     → is-join (Pointwise I P) f g h
   is-join-pointwise pwise .is-join.l≤join i = pwise i .is-join.l≤join
   is-join-pointwise pwise .is-join.r≤join i = pwise i .is-join.r≤join
@@ -54,20 +54,20 @@ special case of both arbitrary lubs and glbs being pointwise:
 ```agda
 module
   _ {ℓₒ ℓᵣ ℓᵢ ℓⱼ} {I : Type ℓᵢ} {J : Type ℓⱼ}
-    (P : Poset ℓₒ ℓᵣ)
-    (F : I → J → ⌞ P ⌟)
-    (m : J → ⌞ P ⌟)
+    (P : J → Poset ℓₒ ℓᵣ)
+    (F : I → (j : J) → ⌞ P j ⌟)
+    (m : (j : J) → ⌞ P j ⌟)
   where
 
   is-lub-pointwise
-    : (∀ j → is-lub P (λ i → F i j) (m j))
+    : (∀ j → is-lub (P j) (λ i → F i j) (m j))
     → is-lub (Pointwise J P) F m
   is-lub-pointwise pwise .is-lub.fam≤lub i j = pwise j .is-lub.fam≤lub i
   is-lub-pointwise pwise .is-lub.least ub' fi<ub' j =
     pwise j .is-lub.least (ub' j) λ i → fi<ub' i j
 
   is-glb-pointwise
-    : (∀ j → is-glb P (λ i → F i j) (m j))
+    : (∀ j → is-glb (P j) (λ i → F i j) (m j))
     → is-glb (Pointwise J P) F m
   is-glb-pointwise pwise .is-glb.glb≤fam i j = pwise j .is-glb.glb≤fam i
   is-glb-pointwise pwise .is-glb.greatest ub' fi<ub' j =


### PR DESCRIPTION
# Description

Generalize [Pointwise](https://1lab.dev/Order.Instances.Pointwise.html#569) to dependent/indexed posets, because why not. Binary products are a special case.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [x] All new code blocks have "agda" as their language.