### PR TITLE
chore: remove useless hlevel bumping

### DIFF
--- a/src/Data/List.lagda.md
+++ b/src/Data/List.lagda.md
@@ -100,9 +100,9 @@ We use this to prove that lists preserve h-levels for $n \ge 2$, i.e. if
     Code-is-hlevel {x ∷ x₁} {x₂ ∷ y} = ×-is-hlevel (suc n) (ahl _ _) Code-is-hlevel
 
   instance
-    H-Level-List : ∀ {n} {k} → ⦃ H-Level A (2 + n) ⦄ → H-Level (List A) (2 + n + k)
+    H-Level-List : ∀ {n} → ⦃ H-Level A (2 + n) ⦄ → H-Level (List A) (2 + n)
     H-Level-List {n = n} ⦃ x ⦄ =
-      basic-instance (2 + n) (List-is-hlevel n (H-Level.has-hlevel x))
+      record { has-hlevel = List-is-hlevel n (H-Level.has-hlevel x) }
 
   is-set→List-is-set : is-set A → is-set (List A)
   is-set→List-is-set = List-is-hlevel zero


### PR DESCRIPTION
# Description

Remove useless hlevel bumping in `H-Level-List`

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [x] All new code blocks have "agda" as their language.