### PR TITLE
chore: add a non-tactic version of injection→extensional!

### DIFF
--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -290,6 +290,16 @@ iso→extensional
 iso→extensional f ext =
   embedding→extensional (Iso→Embedding f) ext
 
+injection→extensional
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
+  → is-set B
+  → {f : A → B}
+  → (∀ {x y} → f x ≡ f y → x ≡ y)
+  → Extensional B ℓr
+  → Extensional A ℓr
+injection→extensional b-set {f} inj ext =
+  embedding→extensional (f , injective→is-embedding b-set f inj) ext
+
 injection→extensional!
   : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
   → {@(tactic hlevel-tactic-worker) sb : is-set B}
@@ -297,5 +307,4 @@ injection→extensional!
   → (∀ {x y} → f x ≡ f y → x ≡ y)
   → Extensional B ℓr
   → Extensional A ℓr
-injection→extensional! {sb = b-set} {f} inj ext =
-  embedding→extensional (f , injective→is-embedding b-set f inj) ext
+injection→extensional! {sb = b-set} = injection→extensional b-set


### PR DESCRIPTION
# Description

I encountered a case where set-ness has to be passed as an (instance or implicit) argument to Extensional because I could not find a clean and usable way to bundle setness with other types. The best solution I found is to use an implicit argument with a tactic to get the set-ness "intelligently", and then pass the set-ness proof to `injection→extensional`. (The tactic in `injection→extensional!`, unfortunately, did not work because it would see `(x y : A) -> is-prop (Path A x y)` instead of `is-set A` at that point.) While I could specify the implicit argument of `injection→extensional!` using `{sb = ...}`, I felt this is a bit fragile and maybe it's cleaner to have a non-tactical version of `injection→extensional`. Thus this PR.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [x] All new code blocks have "agda" as their language.