### PR TITLE
chore: add CITATION.bib

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,6 @@
+@online{1lab,
+  author = {{The 1Lab Development Team}},
+  title = {{The 1Lab}},
+  url = {https://1lab.dev},
+  year = 2023,
+}


### PR DESCRIPTION
People keep asking for this.

Following https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#other-citation-files, but we could also have a `CITATION.cff` with more information if desired.