### PR TITLE
feat: Search context for `is-hlevel` proofs in `hlevel!`, define generalized `Disc!`

### DIFF
--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -348,13 +348,13 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ' n) w works.
   -- Entry point for calling the tactic.
   search : List Nat → Nat → Bool → Term → Nat → Term → TC ⊤
   -- Give up if we're out of fuel:
-  search ctx-prfs under has-alts _     zero    goal = unify goal unknown
+  search ctx-prfs depth has-alts _     zero    goal = unify goal unknown
 
   -- Actual main loop: try using the hints database, try treating the
   -- goal as an n-type, fall back to instance search.
-  search ctx-prfs under has-alts level (suc n) goal =
-      use-context
-      <|> use-projections
+  search ctx-prfs depth has-alts level (suc n) goal =
+      use-projections
+      <|> use-context
       <|> use-hints
       <|> use-instance-search has-alts goal
       <|> typeError "Search failed!!"
@@ -366,7 +366,7 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ' n) w works.
         (wanted-ty , wanted-lv) ← decompose-is-hlevel goal
         debugPrint "tactic.hlevel" 20 $ "Attempting to use context for goal\n  " ∷ termErr wanted-ty ∷ []
         nondet (eff List) ctx-prfs λ idx → do
-          let idx = idx + under
+          let idx = idx + depth
           -- debugPrint "tactic.hlevel" 20 $
             -- "Considering context entry " ∷ termErr prf ∷ " with type is-hlevel " ∷ termErr have-ty ∷ " " ∷ termErr have-level ∷ []
           (have-ty , have-lv) ← decompose-is-hlevel (var₀ idx)
@@ -514,7 +514,7 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ' n) w works.
           cont
           -- go back under the new scope to recursively search for
           -- levels.
-          gounder ⊤ $ search ctx-prfs under has-alts unknown n mv
+          gounder ⊤ $ search ctx-prfs (depth + under) has-alts unknown n mv
 
       -- Try all the candidate hints in order. This is a version of
       -- 'nondet' which additionally threads whether we're looking at

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -155,13 +155,6 @@ private
     quote is-set ∷
     quote is-groupoid ∷
     []
-  
-  hlevel-lift-types : List Name 
-  hlevel-lift-types =
-    quote is-contr→is-prop ∷ 
-    quote is-prop→is-set ∷
-    quote is-hlevel-suc ∷
-    []
 
   pattern nat-lit n =
     def (quote Number.fromNat) (_ ∷ _ ∷ _ ∷ lit (nat n) v∷ _)

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -369,7 +369,6 @@ from the wanted level (k + n) until is-hlevel-+ n (sucᵏ' n) w works.
       use-context : TC ⊤
       use-context = do
         (wanted-ty , wanted-lv) ← decompose-is-hlevel goal
-        -- wait-principal-arg wanted-ty
         wait-principal-arg wanted-ty
         debugPrint "tactic.hlevel" 10 $ "Attempting to use context for goal\n  " ∷ termErr wanted-ty ∷ []
         nondet (eff List) ctx-prfs λ idx → do

--- a/src/Cat/Bi/Instances/Discrete.lagda.md
+++ b/src/Cat/Bi/Instances/Discrete.lagda.md
@@ -34,7 +34,7 @@ the Hom-sets of $\cC$.
 {-# TERMINATING #-}
 Locally-discrete : Prebicategory o ℓ ℓ
 Locally-discrete .Ob = C.Ob
-Locally-discrete .Hom x y = Disc' (el (C.Hom x y) (C.Hom-set x y))
+Locally-discrete .Hom x y = Disc! $ C.Hom x y
 Locally-discrete .id = C.id
 Locally-discrete .compose .F₀ (f , g) = f C.∘ g
 Locally-discrete .compose .F₁ (p , q) = ap₂ C._∘_ p q

--- a/src/Cat/Diagram/Colimit/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Colimit/Coproduct.lagda.md
@@ -40,7 +40,7 @@ module _ {I : Type ℓ'} (i-is-grpd : is-groupoid I) (F : I → Ob) where
   open _=>_
 
   Inj→Cocone : ∀ {x} → (∀ i → Hom (F i) x)
-             → Disc-adjunct {C = C} {iss = i-is-grpd} F => Const x
+             → Disc-adjunct {C = C} F => Const x
   Inj→Cocone inj .η i = inj i
   Inj→Cocone inj .is-natural i j p =
     J (λ j p → inj j ∘ subst (Hom (F i) ⊙ F) p id ≡ id ∘ inj i)
@@ -68,7 +68,7 @@ module _ {I : Type ℓ'} (i-is-grpd : is-groupoid I) (F : I → Ob) where
 
   is-colimit→is-indexed-coprduct
     : ∀ {K : Functor ⊤Cat C}
-    → {eps : Disc-adjunct {iss = i-is-grpd} F => K F∘ !F}
+    → {eps : Disc-adjunct F => K F∘ !F}
     → is-lan !F (Disc-adjunct F) K eps
     → is-indexed-coproduct C F (eps .η)
   is-colimit→is-indexed-coprduct {K = K} {eps} colim = ic where
@@ -87,13 +87,13 @@ module _ {I : Type ℓ'} (i-is-grpd : is-groupoid I) (F : I → Ob) where
 
   IC→Colimit
     : Indexed-coproduct C F
-    → Colimit {C = C} (Disc-adjunct {iss = i-is-grpd} F)
+    → Colimit {C = C} (Disc-adjunct F)
   IC→Colimit ic =
     to-colimit (is-indexed-coproduct→is-colimit has-is-ic)
     where open Indexed-coproduct ic
 
   Colimit→IC
-    : Colimit {C = C} (Disc-adjunct {iss = i-is-grpd} F)
+    : Colimit {C = C} (Disc-adjunct F)
     → Indexed-coproduct C F
   Colimit→IC colim .Indexed-coproduct.ΣF = _
   Colimit→IC colim .Indexed-coproduct.ι = _

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -6,6 +6,7 @@ description: |
 
 <!--
 ```agda
+{-# OPTIONS -vtactic.hlevel:10 #-}
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Product.Indexed
 open import Cat.Diagram.Limit.Base
@@ -34,7 +35,7 @@ open _=>_
 ```
 -->
 
-# Products are limits
+# Products are limits 
 
 We establish the correspondence between binary products $A \times B$ and
 limits over the functor out of $\rm{Disc}(\{0,1\})$ which maps $0$
@@ -43,7 +44,7 @@ existing infrastructure):
 
 ```agda
 2-object-category : Precategory _ _
-2-object-category = Disc' (el Bool Bool-is-set)
+2-object-category = Disc! Bool
 
 2-object-diagram : Ob → Ob → Functor 2-object-category C
 2-object-diagram a b = Disc-diagram λ where
@@ -142,7 +143,7 @@ defined above.
 
 ```agda
 canonical-functors
-  : ∀ (F : Functor 2-object-category C)
+  : ∀ (F : Functor (Disc! Bool) C)
   → F ≡ 2-object-diagram (F₀ F true) (F₀ F false)
 canonical-functors F = Functor-path p q where
   p : ∀ x → _
@@ -176,7 +177,7 @@ module _ {ℓ} {I : Type ℓ} (i-is-grpd : is-groupoid I) (F : I → Ob) where
   open _=>_
 
   Proj→Cone : ∀ {x} → (∀ i → Hom x (F i))
-            → Const x => Disc-adjunct {C = C} {iss = i-is-grpd} F
+            → Const x => Disc-adjunct {C = C} F
   Proj→Cone π .η i = π i
   Proj→Cone π .is-natural i j p =
     J (λ j p →  π j ∘ id ≡ subst (Hom (F i) ⊙ F) p id ∘ π i)
@@ -205,7 +206,7 @@ module _ {ℓ} {I : Type ℓ} (i-is-grpd : is-groupoid I) (F : I → Ob) where
 
   is-limit→is-indexed-product
     : ∀ {K : Functor ⊤Cat C}
-    → {eta : K F∘ !F => Disc-adjunct {iss = i-is-grpd} F}
+    → {eta : K F∘ !F => Disc-adjunct F}
     → is-ran !F (Disc-adjunct F) K eta
     → is-indexed-product C F (eta .η)
   is-limit→is-indexed-product {K = K} {eta} lim = ip where
@@ -222,12 +223,12 @@ module _ {ℓ} {I : Type ℓ} (i-is-grpd : is-groupoid I) (F : I → Ob) where
     ip .unique k comm =
       lim.unique _ _ _ comm
 
-  IP→Limit : Indexed-product C F → Limit {C = C} (Disc-adjunct {iss = i-is-grpd} F)
+  IP→Limit : Indexed-product C F → Limit {C = C} (Disc-adjunct F)
   IP→Limit ip =
     to-limit (is-indexed-product→is-limit has-is-ip)
     where open Indexed-product ip
 
-  Limit→IP : Limit {C = C} (Disc-adjunct {iss = i-is-grpd} F) → Indexed-product C F
+  Limit→IP : Limit {C = C} (Disc-adjunct F) → Indexed-product C F
   Limit→IP lim .Indexed-product.ΠF = _
   Limit→IP lim .Indexed-product.π = _
   Limit→IP lim .Indexed-product.has-is-ip =

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -34,7 +34,7 @@ open _=>_
 ```
 -->
 
-# Products are limits 
+# Products are limits
 
 We establish the correspondence between binary products $A \times B$ and
 limits over the functor out of $\rm{Disc}(\{0,1\})$ which maps $0$

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -142,7 +142,7 @@ defined above.
 
 ```agda
 canonical-functors
-  : ∀ (F : Functor (Disc! Bool) C)
+  : ∀ (F : Functor 2-object-category C)
   → F ≡ 2-object-diagram (F₀ F true) (F₀ F false)
 canonical-functors F = Functor-path p q where
   p : ∀ x → _

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -6,7 +6,6 @@ description: |
 
 <!--
 ```agda
-{-# OPTIONS -vtactic.hlevel:10 #-}
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Product.Indexed
 open import Cat.Diagram.Limit.Base

--- a/src/Cat/Displayed/Instances/Family.lagda.md
+++ b/src/Cat/Displayed/Instances/Family.lagda.md
@@ -153,10 +153,10 @@ the family fibration is fibrewise univalent whenever $\cC$ is.
 ```agda
 module _ {ℓ} (X : Set ℓ) where
   private
-    lift-f = Disc-adjunct {C = C} {iss = is-hlevel-suc 2 (X .is-tr)}
+    lift-f = Disc-adjunct {C = C} {X = ⌞ X ⌟}
     module F = Cat.Reasoning (Fibre Family X)
 
-  Families→functors : Functor (Fibre Family X) Cat[ Disc' X , C ]
+  Families→functors : Functor (Fibre Family X) Cat[ Disc! X , C ]
   Families→functors .F₀ = Disc-adjunct
   Families→functors .F₁ f .η = f
   Families→functors .F₁ {X} {Y} f .is-natural x y =

--- a/src/Cat/Instances/Discrete.lagda.md
+++ b/src/Cat/Instances/Discrete.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS -vtactic.hlevel:10 -vtactic:50 #-}
 open import Cat.Prelude
 
 open import Data.Id.Base

--- a/src/Cat/Instances/Discrete.lagda.md
+++ b/src/Cat/Instances/Discrete.lagda.md
@@ -43,16 +43,8 @@ Disc A A-grpd .idr _ = ∙-idl _
 Disc A A-grpd .idl _ = ∙-idr _
 Disc A A-grpd .assoc _ _ _ = sym (∙-assoc _ _ _)
 
--- Disc' : Set ℓ → Precategory ℓ ℓ
--- Disc' A = Disc ∣ A ∣ h where abstract
---   h : is-groupoid ∣ A ∣
---   h = is-hlevel-suc 2 (A .is-tr)
-
 Disc! : {T : Type ℓ} ⦃ u : Underlying T ⦄ (A : T) {@(tactic hlevel-tactic-worker) is-grpd : is-groupoid ⌞ A ⌟} → Precategory (u .Underlying.ℓ-underlying) (u .Underlying.ℓ-underlying)
 Disc! A {is-grpd} = Disc ⌞ A ⌟ is-grpd
-  -- where abstract
-    -- h : is-groupoid ⌞ A ⌟
-    -- h = is-grpd
 ```
 
 We can lift any function between the underlying types to a functor

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -521,7 +521,7 @@ Let's begin. The `Total-space`{.Agda} functor gets out of our way very
 fast:
 
 ```agda
-  Total-space : Functor Cat[ Disc' I , Sets ℓ ] (Slice (Sets ℓ) I)
+  Total-space : Functor Cat[ Disc! I , Sets ℓ ] (Slice (Sets ℓ) I)
   Total-space .F₀ F .domain = el (Σ _ (∣_∣ ⊙ F₀ F)) hlevel!
   Total-space .F₀ F .map    = fst
 

--- a/src/Cat/Instances/StrictCat/Cohesive.lagda.md
+++ b/src/Cat/Instances/StrictCat/Cohesive.lagda.md
@@ -70,14 +70,14 @@ We begin by defining the object set functor.
 Γ .F-∘ _ _ = refl
 ```
 
-We must then prove that the assignment `Disc'`{.Agda} extends to a
+We must then prove that the assignment `Disc!`{.Agda} extends to a
 functor from `Sets`{.Agda}, and prove that it's left adjoint to the
 functor `Γ`{.Agda} we defined above. Then we define the adjunction
 `Disc⊣Γ`{.Agda}.
 
 ```agda
 Disc : Functor (Sets ℓ) (Strict-cats ℓ ℓ)
-Disc .F₀ S = Disc' S , S .is-tr
+Disc .F₀ S = Disc! S , S .is-tr
 Disc .F₁ = lift-disc
 Disc .F-id = Functor-path (λ x → refl) λ f → refl
 Disc .F-∘ _ _ = Functor-path (λ x → refl) λ f → refl
@@ -123,7 +123,7 @@ identity map suffices.
 ```agda
   adj .counit = NT (λ x → F x) nat where
     F : (x : Precategory.Ob (Strict-cats ℓ ℓ))
-      → Functor (Disc' (el _ (x .snd))) _
+      → Functor (Disc! (x .fst .Ob) {is-grpd = is-hlevel-suc 2 (x .snd)}) _
     F X .F₀ x = x
     F X .F₁ p = subst (X .fst .Hom _) p (X .fst .id) {- 1 -}
     F X .F-id = transport-refl _

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -297,5 +297,12 @@ lookup x [] = nothing
 lookup x ((k , v) ∷ xs) with x ≡? k
 ... | yes _ = just v
 ... | no  _ = lookup x xs
+
+
+filter-map : (A → Maybe B) → List A → List B
+filter-map f [] = []
+filter-map f (x ∷ xs) with f x
+... | nothing = filter-map f xs
+... | just y  = y ∷ filter-map f xs
 ```
 -->


### PR DESCRIPTION
# Description

The `hlevel!` tactic now computes a list of all local variables for which `decompose-is-hlevel` succeeds (before searching starts), and on each search it loops through these to check if any have a type which matches the goal.

Using this, we define `Disc!`, which accepts any structure with an underlying type which can be decided to be a groupoid by `hlevel!`, and use it to remove `Disc'`

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs`.
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
