### PR TITLE
typo: antitone is defined incorrectly

### DIFF
--- a/src/Order/Morphism.lagda.md
+++ b/src/Order/Morphism.lagda.md
@@ -46,7 +46,7 @@ module _ {o ℓ o' ℓ'} (P : Poset o ℓ) (Q : Poset o' ℓ') (f : ⌞ P ⌟ �
 
   ```agda
   is-antitone : Type _
-  is-antitone = ∀ {x y} → x P.≤ y → f x Q.≤ f y
+  is-antitone = ∀ {x y} → x P.≤ y → f y Q.≤ f x
   ```
 
 - :::{.definition #order-reflection}


### PR DESCRIPTION
# Description

Currently `is-antitone` has the same definition as `is-montone`

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
