### PR TITLE
chore: rename universality of min and max

### DIFF
--- a/src/Data/Nat/Properties.lagda.md
+++ b/src/Data/Nat/Properties.lagda.md
@@ -289,11 +289,11 @@ max-≤r zero (suc y) = ≤-refl
 max-≤r (suc x) zero = 0≤x
 max-≤r (suc x) (suc y) = s≤s (max-≤r x y)
 
-max-is-lub : (x y z : Nat) → x ≤ z → y ≤ z → max x y ≤ z
-max-is-lub zero zero z 0≤x 0≤x = 0≤x
-max-is-lub zero (suc y) (suc z) 0≤x (s≤s q) = s≤s q
-max-is-lub (suc x) zero (suc z) (s≤s p) 0≤x = s≤s p
-max-is-lub (suc x) (suc y) (suc z) (s≤s p) (s≤s q) = s≤s (max-is-lub x y z p q)
+max-univ : (x y z : Nat) → x ≤ z → y ≤ z → max x y ≤ z
+max-univ zero zero z 0≤x 0≤x = 0≤x
+max-univ zero (suc y) (suc z) 0≤x (s≤s q) = s≤s q
+max-univ (suc x) zero (suc z) (s≤s p) 0≤x = s≤s p
+max-univ (suc x) (suc y) (suc z) (s≤s p) (s≤s q) = s≤s (max-univ x y z p q)
 
 max-zerol : (x : Nat) → max 0 x ≡ x
 max-zerol zero = refl
@@ -329,9 +329,9 @@ min-≤r zero (suc y) = 0≤x
 min-≤r (suc x) zero = 0≤x
 min-≤r (suc x) (suc y) = s≤s (min-≤r x y)
 
-min-is-glb : (x y z : Nat) → z ≤ x → z ≤ y → z ≤ min x y
-min-is-glb x y zero 0≤x 0≤x = 0≤x
-min-is-glb (suc x) (suc y) (suc z) (s≤s p) (s≤s q) = s≤s (min-is-glb x y z p q)
+min-univ : (x y z : Nat) → z ≤ x → z ≤ y → z ≤ min x y
+min-univ x y zero 0≤x 0≤x = 0≤x
+min-univ (suc x) (suc y) (suc z) (s≤s p) (s≤s q) = s≤s (min-univ x y z p q)
 
 min-zerol : (x : Nat) → min 0 x ≡ 0
 min-zerol zero = refl

--- a/src/Order/Instances/Int.lagda.md
+++ b/src/Order/Instances/Int.lagda.md
@@ -56,12 +56,12 @@ open minmax (Int-is-dec-total .is-decidable-total-order.has-is-total)
     ( min      to minℤ
     ; min-≤l   to minℤ-≤l
     ; min-≤r   to minℤ-≤r
-    ; min-univ to minℤ-is-meet
+    ; min-univ to minℤ-univ
 
     ; max      to maxℤ
     ; max-≤l   to maxℤ-≤l
     ; max-≤r   to maxℤ-≤r
-    ; max-univ to maxℤ-is-join)
+    ; max-univ to maxℤ-univ)
   using () public
 ```
 -->

--- a/src/Order/Instances/Nat.lagda.md
+++ b/src/Order/Instances/Nat.lagda.md
@@ -58,13 +58,13 @@ Nat-meets : ∀ x y → Meet Nat-poset x y
 Nat-meets x y .glb                = min x y
 Nat-meets x y .has-meet .meet≤l   = min-≤l x y
 Nat-meets x y .has-meet .meet≤r   = min-≤r x y
-Nat-meets x y .has-meet .greatest = min-is-glb x y
+Nat-meets x y .has-meet .greatest = min-univ x y
 
 Nat-joins : ∀ x y → Join Nat-poset x y
 Nat-joins x y .lub              = max x y
-Nat-joins x y .has-join .least  = max-is-lub x y
 Nat-joins x y .has-join .l≤join = max-≤l x y
 Nat-joins x y .has-join .r≤join = max-≤r x y
+Nat-joins x y .has-join .least  = max-univ x y
 ```
 
 It's straightforward to show that this order is _bounded below_, since


### PR DESCRIPTION
# Description

Some instances of `max-is-lub` and `min-is-glb` should have been called `max-univ` and `min-univ`.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.