### PR TITLE
reflection: η-expand implicit arguments

### DIFF
--- a/src/1Lab/Reflection/Induction/Examples.agda
+++ b/src/1Lab/Reflection/Induction/Examples.agda
@@ -57,3 +57,12 @@ _ : {ℓ : Level} {A : Type ℓ} {ℓ₁ : Level} {P : (z : ∥ A ∥₀) → Ty
     (Pinc : (z : A) → P (inc z))
     (x : ∥ A ∥₀) → P x
 _ = ∥-∥₀-elim
+
+-- Test case: this should not generate unsolved metavariables.
+unquoteDecl Nat-rec = make-elim-with (record default-rec { hide-cons-args = true }) Nat-rec (quote Nat)
+
+_ : {ℓ : Level} {P : Type ℓ}
+  → P
+  → ({n : Nat} → P → P)
+  → Nat → P
+_ = Nat-rec


### PR DESCRIPTION
# Description

Fix the bug alluded to [here](https://github.com/plt-amy/1lab/pull/291#issue-2011184971) in the way suggested there, for lack of a better mechanism. See also https://github.com/agda/agda/issues/7056.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
