### PR TITLE
chore: use GHC2021 as default-language

### DIFF
--- a/support/shake/1lab-shake.cabal
+++ b/support/shake/1lab-shake.cabal
@@ -52,7 +52,7 @@ common common
     Macros,
     Timer,
     Definitions
-  default-language: Haskell2010
+  default-language: GHC2021
   ghc-options: -Wextra -Wall -Wno-name-shadowing -Wno-implicit-prelude
   default-extensions: BlockArguments, LambdaCase
 


### PR DESCRIPTION
Fixes an error about GeneralisedNewtypeDeriving not being enabled when building via cabal.