### PR TITLE
Fixed typo in Cartesian Lift

### DIFF
--- a/src/Cat/Displayed/Cartesian.lagda.md
+++ b/src/Cat/Displayed/Cartesian.lagda.md
@@ -577,8 +577,8 @@ cartesian→postcompose-equiv cart =
 
 ## Cartesian lifts {defines="cartesian-lift"}
 
-We call an object $a'$ over $a$ together with a Cartesian arrow $f' : a'
-\to b'$ a _Cartesian lift_ of $f$. Cartesian lifts, defined by universal
+We call an object $y'$ over $y$ together with a Cartesian arrow $f' : x'
+\to y'$ a _Cartesian lift_ of $f$. Cartesian lifts, defined by universal
 property as they are, are unique when they exist, so that "having
 Cartesian lifts" is a _property_, not a structure.
 


### PR DESCRIPTION
# Description

Fixed typo in Cartesian Lift page.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
