### PR TITLE
chore: bump to agda/agda#7077

### DIFF
--- a/1lab.agda-lib
+++ b/1lab.agda-lib
@@ -11,4 +11,5 @@ flags:
   --rewriting
   --guardedness
   --two-level
+  --lossy-instance-fields
   -W noUnsupportedIndexedMatch

--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -4,6 +4,7 @@ open import 1Lab.Function.Embedding
 open import 1Lab.Reflection.HLevel
 open import 1Lab.Reflection.Subst
 open import 1Lab.HLevel.Retracts
+open import 1Lab.HIT.Truncation
 open import 1Lab.Reflection
 open import 1Lab.Type.Sigma
 open import 1Lab.Type.Pi
@@ -337,3 +338,20 @@ injection→extensional!
   → Extensional B ℓr
   → Extensional A ℓr
 injection→extensional! {sb = b-set} = injection→extensional b-set
+
+Extensional-tr-map
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : Type ℓ'}
+  → ⦃ sf : Extensional (A → B) ℓr ⦄ {@(tactic hlevel-tactic-worker) b-set : is-set B}
+  → Extensional (∥ A ∥ → B) ℓr
+Extensional-tr-map ⦃ sf ⦄ .Pathᵉ f g = sf .Pathᵉ (f ∘ inc) (g ∘ inc)
+Extensional-tr-map ⦃ sf ⦄ .reflᵉ f = sf .reflᵉ (f ∘ inc)
+Extensional-tr-map ⦃ sf ⦄ {c-set} .idsᵉ .to-path h = funext $
+  ∥-∥-elim (λ x → c-set _ _) (happly (sf .idsᵉ .to-path h))
+Extensional-tr-map ⦃ sf ⦄ {c-set} .idsᵉ .to-path-over p =
+  is-prop→pathp (λ i → Pathᵉ-is-hlevel 1 sf (fun-is-hlevel 2 c-set)) _ _
+
+instance
+  extensionality-tr-map
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+    → Extensionality (∥ A ∥ → B)
+  extensionality-tr-map = record { lemma = quote Extensional-tr-map }

--- a/src/1Lab/Extensionality.agda
+++ b/src/1Lab/Extensionality.agda
@@ -350,7 +350,19 @@ Extensional-tr-map ⦃ sf ⦄ {c-set} .idsᵉ .to-path h = funext $
 Extensional-tr-map ⦃ sf ⦄ {c-set} .idsᵉ .to-path-over p =
   is-prop→pathp (λ i → Pathᵉ-is-hlevel 1 sf (fun-is-hlevel 2 c-set)) _ _
 
+Extensional-Σ-∥∥
+  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : A → Type ℓ'} ⦃ ext : Extensional A ℓr ⦄
+  → Extensional (Σ[ a ∈ A ] ∥ B a ∥) ℓr
+Extensional-Σ-∥∥ ⦃ sa ⦄ .Pathᵉ (x , _) (y , _) = sa .Pathᵉ x y
+Extensional-Σ-∥∥ ⦃ sa ⦄ .reflᵉ (x , _) = sa .reflᵉ x
+Extensional-Σ-∥∥ ⦃ sa ⦄ .idsᵉ .to-path p = Σ-prop-path! (sa .idsᵉ .to-path p)
+Extensional-Σ-∥∥ ⦃ sa ⦄ .idsᵉ .to-path-over p = sa .idsᵉ .to-path-over p
+
 instance
+  extensionality-Σ-∥∥
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} → Extensionality (Σ[ a ∈ A ] ∥ B a ∥)
+  extensionality-Σ-∥∥ = record { lemma = quote Extensional-Σ-∥∥ }
+
   extensionality-tr-map
     : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
     → Extensionality (∥ A ∥ → B)

--- a/src/1Lab/HIT/Truncation.lagda.md
+++ b/src/1Lab/HIT/Truncation.lagda.md
@@ -215,8 +215,9 @@ definition of image, or more properly of $(-1)$-image:
 [1Lab.Counterexamples.Sigma]: 1Lab.Counterexamples.Sigma.html
 
 ```agda
-image : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → (A → B) → Type _
-image {A = A} {B = B} f = Σ[ b ∈ B ] ∃[ a ∈ A ] (f a ≡ b)
+private
+  image : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → (A → B) → Type _
+  image {A = A} {B = B} f = Σ[ b ∈ B ] ∃[ a ∈ A ] (f a ≡ b)
 ```
 
 To see that the `image`{.Agda} indeed implements the concept of image,

--- a/src/Algebra/Group.lagda.md
+++ b/src/Algebra/Group.lagda.md
@@ -184,6 +184,8 @@ record
   is-group-hom
     {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
     (G : Group-on A) (G' : Group-on B) (e : A → B) : Type (ℓ ⊔ ℓ') where
+  no-eta-equality
+
   private
     module A = Group-on G
     module B = Group-on G'

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -63,18 +63,14 @@ Zero-group = to-group zg where
   zg .make-group.idl x = refl
 
 Zero-group-is-initial : is-initial Zero-group
-Zero-group-is-initial (_ , G) .centre = total-hom (λ x → G.unit) gh where
-  module G = Group-on G
-  gh : is-group-hom _ _ (λ x → G.unit)
-  gh .pres-⋆ x y =
-    G.unit            ≡˘⟨ G.idl ⟩
-    G.unit G.⋆ G.unit ∎
+Zero-group-is-initial (_ , G) .centre .hom _ = Group-on.unit G
+Zero-group-is-initial (_ , G) .centre .preserves .pres-⋆ _ _ = sym (Group-on.idl G)
 Zero-group-is-initial (_ , G) .paths x =
   ext λ _ → sym (is-group-hom.pres-id (x .preserves))
 
 Zero-group-is-terminal : is-terminal Zero-group
-Zero-group-is-terminal _ .centre =
-  total-hom (λ _ → lift tt) record { pres-⋆ = λ _ _ _ → lift tt }
+Zero-group-is-terminal _ .centre .hom _ = lift tt
+Zero-group-is-terminal _ .centre .preserves .pres-⋆ x y = refl
 Zero-group-is-terminal _ .paths x = trivial!
 
 Zero-group-is-zero : is-zero Zero-group
@@ -234,7 +230,8 @@ $g$.
 ```agda
   Groups-equalisers : Equaliser (Groups ℓ) f g
   Groups-equalisers .apex = Equaliser-group
-  Groups-equalisers .equ = total-hom fst record { pres-⋆ = λ x y → refl }
+  Groups-equalisers .equ .hom (x , _) = x
+  Groups-equalisers .equ .preserves .pres-⋆ _ _ = refl
   Groups-equalisers .has-is-eq .equal = Forget-is-faithful seq.equal
   Groups-equalisers .has-is-eq .universal {F = F} {e'} p = total-hom go lim-gh where
     go = seq.universal {F = underlying-set (F .snd)} (ap hom p)

--- a/src/Algebra/Group/Subgroup.lagda.md
+++ b/src/Algebra/Group/Subgroup.lagda.md
@@ -126,19 +126,6 @@ giving the element $xy$ in the fibre over $ab$.
 
 <!--
 ```agda
-Extensional-Σ-∥∥
-  : ∀ {ℓ ℓ' ℓr} {A : Type ℓ} {B : A → Type ℓ'} ⦃ ext : Extensional A ℓr ⦄
-  → Extensional (Σ[ a ∈ A ] ∥ B a ∥) ℓr
-Extensional-Σ-∥∥ ⦃ sa ⦄ .Pathᵉ (x , _) (y , _) = sa .Pathᵉ x y
-Extensional-Σ-∥∥ ⦃ sa ⦄ .reflᵉ (x , _) = sa .reflᵉ x
-Extensional-Σ-∥∥ ⦃ sa ⦄ .idsᵉ .to-path p = Σ-prop-path! (sa .idsᵉ .to-path p)
-Extensional-Σ-∥∥ ⦃ sa ⦄ .idsᵉ .to-path-over p = sa .idsᵉ .to-path-over p
-
-instance
-  Extensionality-Σ-∥∥
-    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} → Extensionality (Σ[ a ∈ A ] ∥ B a ∥)
-  Extensionality-Σ-∥∥ = record { lemma = quote Extensional-Σ-∥∥ }
-
 module _ {ℓ} {A B : Group ℓ} (f : Groups.Hom A B) where
   private
     module A = Group-on (A .snd)

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -612,5 +612,10 @@ instance
 
   Funlike-Functor : ∀ {o ℓ o' ℓ'} → Funlike (Functor {o} {ℓ} {o'} {ℓ'})
   Funlike-Functor = record { _#_ = Functor.F₀ }
+
+  Membership-Functor
+    : ∀ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} ⦃ ud : Underlying ⌞ D ⌟ ⦄
+    → Membership ⌞ C ⌟ (Functor C D) _
+  Membership-Functor = Funlike→membership
 ```
 -->

--- a/src/Cat/Diagram/Sieve.lagda.md
+++ b/src/Cat/Diagram/Sieve.lagda.md
@@ -12,17 +12,16 @@ import Cat.Reasoning
 -->
 
 ```agda
-module Cat.Diagram.Sieve {o κ : _} (C : Precategory o κ) (c : Precategory.Ob C) where
+module Cat.Diagram.Sieve where
 ```
 
 <!--
 ```agda
-private
-  module C = Cat.Reasoning C
-  module PSh = Cat.Reasoning (PSh κ C)
-open PSh._↪_
 open _=>_
 open Functor
+
+module _ {o κ : _} (C : Precategory o κ) (c : Precategory.Ob C)  where
+  private module C = Precategory C
 ```
 -->
 
@@ -38,14 +37,24 @@ given an arrow $f : a \to c$ (and its domain), yields a proposition
 representing inclusion in the subset.
 
 ```agda
-record Sieve : Type (o ⊔ lsuc κ) where
-  field
-    arrows : {y : C.Ob} → ℙ (C.Hom y c)
-    closed : {y z : _} {f : _} (g : C.Hom y z)
-           → f ∈ arrows
-           → (f C.∘ g) ∈ arrows
-open Sieve
+  record Sieve : Type (o ⊔ lsuc κ) where
+    field
+      arrows : {y : C.Ob} → ℙ (C.Hom y c)
+      closed : {y z : _} {f : _} (g : C.Hom y z)
+            → f ∈ arrows
+            → (f C.∘ g) ∈ arrows
+  open Sieve
 ```
+
+<!--
+```agda
+instance
+  Membership-Sieve
+    : ∀ {o ℓ} {C : Precategory o ℓ} {x y : Precategory.Ob C}
+    → Membership ⌞ Precategory.Hom C x y ⌟ (Sieve C y) _
+  Membership-Sieve = record { _∈_ = λ x S → x ∈ Sieve.arrows S }
+```
+-->
 
 The `maximal`{.agda} sieve on an object is the collection of _all_ maps
 $a \to c$; It represents the identity map $\yo(c) \to \yo(c)$ as a
@@ -56,14 +65,26 @@ subobjects.
 
 [$\kappa$-small]: 1Lab.intro.html#universes-and-size-issues
 
+<!--
 ```agda
-maximal' : Sieve
-maximal' .arrows x = ⊤Ω
-maximal' .closed g x = tt
+module _ {o κ : _} (C : Precategory o κ) (c : Precategory.Ob C)  where
+  private
+    module C = Cat.Reasoning C
+    module PSh = Cat.Reasoning (PSh κ C)
 
-intersect : ∀ {I : Type κ} (F : I → Sieve) → Sieve
-intersect {I = I} F .arrows h = elΩ ((x : I) → h ∈ F x .arrows)
-intersect {I = I} F .closed g x = inc λ i → F i .closed g (out! x i)
+  open Sieve
+  open PSh._↪_
+```
+-->
+
+```agda
+  maximal' : Sieve C c
+  maximal' .arrows x = ⊤Ω
+  maximal' .closed g x = tt
+
+  intersect : ∀ {I : Type κ} (F : I → Sieve C c) → Sieve C c
+  intersect {I = I} F .arrows h = elΩ ((x : I) → h ∈ F x)
+  intersect {I = I} F .closed g x = inc λ i → F i .closed g (out! x i)
 ```
 
 ## Representing subfunctors
@@ -75,18 +96,18 @@ $d$ to the set of arrows $d \xto{f} c$ s.t. $f \in S$; The functorial
 action is given by composition, as with the $\hom$ functor.
 
 ```agda
-to-presheaf : Sieve → PSh.Ob
-to-presheaf sieve .F₀ d .∣_∣   = Σ[ f ∈ C.Hom d c ] (f ∈ sieve .arrows)
-to-presheaf sieve .F₀ d .is-tr = hlevel!
-to-presheaf sieve .F₁ f (g , s) = g C.∘ f , sieve .closed _ s
+  to-presheaf : Sieve C c → PSh.Ob
+  to-presheaf sieve .F₀ d .∣_∣   = ∫ₚ sieve
+  to-presheaf sieve .F₀ d .is-tr = hlevel!
+  to-presheaf sieve .F₁ f (g , s) = g C.∘ f , sieve .closed _ s
 ```
 
 <!--
 ```agda
-to-presheaf sieve .F-id = funext λ _ →
-  Σ-prop-path (λ _ → hlevel!) (C.idr _)
-to-presheaf sieve .F-∘ f g = funext λ _ →
-  Σ-prop-path (λ _ → hlevel!) (C.assoc _ _ _)
+  to-presheaf sieve .F-id = funext λ _ →
+    Σ-prop-path (λ _ → hlevel!) (C.idr _)
+  to-presheaf sieve .F-∘ f g = funext λ _ →
+    Σ-prop-path (λ _ → hlevel!) (C.assoc _ _ _)
 ```
 -->
 
@@ -97,10 +118,10 @@ proposition). Since natural transformations are monic if they are
 componentwise monic, and embeddings are monic, the result follows.
 
 ```agda
-to-presheaf↪よ : {S : Sieve} → to-presheaf S PSh.↪ よ₀ C c
-to-presheaf↪よ {S} .mor .η x (f , _) = f
-to-presheaf↪よ {S} .mor .is-natural x y f = refl
-to-presheaf↪よ {S} .monic g h path = Nat-path λ x →
-  embedding→monic (Subset-proj-embedding (λ _ → S .arrows _ .is-tr))
-    (g .η x) (h .η x) (path ηₚ x)
+  to-presheaf↪よ : {S : Sieve C c} → to-presheaf S PSh.↪ よ₀ C c
+  to-presheaf↪よ {S} .mor .η x (f , _) = f
+  to-presheaf↪よ {S} .mor .is-natural x y f = refl
+  to-presheaf↪よ {S} .monic g h path = Nat-path λ x →
+    embedding→monic (Subset-proj-embedding (λ _ → S .arrows _ .is-tr))
+      (g .η x) (h .η x) (path ηₚ x)
 ```

--- a/src/Cat/Diagram/Sieve.lagda.md
+++ b/src/Cat/Diagram/Sieve.lagda.md
@@ -76,7 +76,8 @@ action is given by composition, as with the $\hom$ functor.
 
 ```agda
 to-presheaf : Sieve → PSh.Ob
-to-presheaf sieve .F₀ d = el! (Σ[ f ∈ C.Hom d c ] (f ∈ sieve .arrows))
+to-presheaf sieve .F₀ d .∣_∣   = Σ[ f ∈ C.Hom d c ] (f ∈ sieve .arrows)
+to-presheaf sieve .F₀ d .is-tr = hlevel!
 to-presheaf sieve .F₁ f (g , s) = g C.∘ f , sieve .closed _ s
 ```
 

--- a/src/Cat/Functor/WideSubcategory.lagda.md
+++ b/src/Cat/Functor/WideSubcategory.lagda.md
@@ -8,15 +8,16 @@ import Cat.Reasoning
 -->
 
 ```agda
-module Cat.Functor.WideSubcategory {o h} {C : Precategory o h} where
+module Cat.Functor.WideSubcategory where
 ```
 
 <!--
 ```agda
-private module C = Cat.Reasoning C
-open Precategory
-private variable
-  ℓ : Level
+module _ {o h} (C : Precategory o h) where
+  private module C = Cat.Reasoning C
+  open Precategory
+  private variable
+    ℓ : Level
 ```
 -->
 
@@ -33,84 +34,103 @@ To start, we package up all the data required to define a wide
 subcategory up into a record.
 
 ```agda
-record Wide-subcat (ℓ : Level) : Type (o ⊔ h ⊔ lsuc ℓ) where
-  no-eta-equality
-  field
-    P      : ∀ {x y} → C.Hom x y → Type ℓ
-    P-prop : ∀ {x y} (f : C.Hom x y) → is-prop (P f)
+  record Wide-subcat (ℓ : Level) : Type (o ⊔ h ⊔ lsuc ℓ) where
+    no-eta-equality
+    field
+      P      : ∀ {x y} → C.Hom x y → Type ℓ
+      P-prop : ∀ {x y} (f : C.Hom x y) → is-prop (P f)
 
-    P-id : ∀ {x} → P (C.id {x})
-    P-∘  : ∀ {x y z} {f : C.Hom y z} {g : C.Hom x y}
-         → P f → P g → P (f C.∘ g)
-
-open Wide-subcat
+      P-id : ∀ {x} → P (C.id {x})
+      P-∘  : ∀ {x y z} {f : C.Hom y z} {g : C.Hom x y}
+          → P f → P g → P (f C.∘ g)
 ```
 
 Morphisms of wide subcategories are defined as morphisms in $\cC$ where
 $P$ holds.
 
+<!--
 ```agda
-record Wide-hom (sub : Wide-subcat ℓ) (x y : C.Ob) : Type (h ⊔ ℓ) where
-  no-eta-equality
-  constructor wide
-  field
-    hom : C.Hom x y
-    witness : sub .P hom
+instance
+  Membership-Wide-subcat
+    : ∀ {o ℓ w} {C : Precategory o ℓ} {a b}
+    → Membership (Precategory.Hom C a b) (Wide-subcat C w) w
+  Membership-Wide-subcat = record { _∈_ = λ f W → Wide-subcat.P W f }
+
+module _ {o h} {C : Precategory o h} where
+  private
+    module C = Precategory C
+    variable ℓ : Level
+  open Wide-subcat
+```
+-->
+
+```agda
+  record Wide-hom (W : Wide-subcat C ℓ) (x y : C.Ob) : Type (h ⊔ ℓ) where
+    no-eta-equality
+    constructor wide
+    field
+      hom     : C.Hom x y
+      witness : hom ∈ W
 ```
 
 <!--
 ```agda
-open Wide-hom public
+  open Wide-hom public
 
-Wide-hom-path
-  : {sub : Wide-subcat ℓ}
-  → {x y : C.Ob}
-  → {f g : Wide-hom sub x y}
-  → f .hom ≡ g .hom
-  → f ≡ g
-Wide-hom-path {f = f} {g = g} p i .hom = p i
-Wide-hom-path {sub = sub} {f = f} {g = g} p i .witness =
-  is-prop→pathp (λ i → sub .P-prop (p i)) (f .witness) (g .witness) i
+  Wide-hom-path
+    : {sub : Wide-subcat C ℓ}
+    → {x y : C.Ob}
+    → {f g : Wide-hom sub x y}
+    → f .hom ≡ g .hom
+    → f ≡ g
+  Wide-hom-path {f = f} {g = g} p i .hom = p i
+  Wide-hom-path {sub = sub} {f = f} {g = g} p i .witness =
+    is-prop→pathp (λ i → sub .P-prop (p i)) (f .witness) (g .witness) i
 
-Extensional-wide-hom
-  : ∀ {ℓ ℓr} {sub : Wide-subcat ℓ} {x y : C.Ob}
-  → ⦃ sa : Extensional (C.Hom x y) ℓr ⦄
-  → Extensional (Wide-hom sub x y) ℓr
-Extensional-wide-hom ⦃ sa ⦄ = injection→extensional!
-  Wide-hom-path sa
+  Extensional-wide-hom
+    : ∀ {ℓ ℓr} {sub : Wide-subcat C ℓ} {x y : ⌞ C ⌟}
+    → ⦃ sa : Extensional (C.Hom x y) ℓr ⦄
+    → Extensional (Wide-hom sub x y) ℓr
+  Extensional-wide-hom ⦃ sa ⦄ = injection→extensional!
+    Wide-hom-path sa
 
-instance
-  extensionality-wide-hom
-    : ∀ {ℓ} {sub : Wide-subcat ℓ} {x y : C.Ob} → Extensionality (Wide-hom sub x y)
-  extensionality-wide-hom = record { lemma = quote Extensional-wide-hom }
+  instance
+    extensionality-wide-hom
+      : ∀ {ℓ} {sub : Wide-subcat C ℓ} {x y : C.Ob} → Extensionality (Wide-hom sub x y)
+    extensionality-wide-hom = record { lemma = quote Extensional-wide-hom }
 
-Wide-hom-is-set
-  : {sub : Wide-subcat ℓ}
-  → {x y : C.Ob}
-  → is-set (Wide-hom sub x y)
-Wide-hom-is-set {sub = sub} = Iso→is-hlevel 2 eqv $
-  Σ-is-hlevel 2 (C.Hom-set _ _) λ f → is-hlevel-suc 1 (sub .P-prop f)
-  where unquoteDecl eqv = declare-record-iso eqv (quote Wide-hom)
+    H-Level-Wide-Hom
+      : ∀ {ℓ} {sub : Wide-subcat C ℓ} {x y : C.Ob} {n}
+      → H-Level (Wide-hom sub x y) (2 + n)
+    H-Level-Wide-Hom {sub = sub} = basic-instance 2 $ Iso→is-hlevel 2 eqv $
+      Σ-is-hlevel 2 (C.Hom-set _ _) λ f → is-hlevel-suc 1 (sub .P-prop f)
+      where unquoteDecl eqv = declare-record-iso eqv (quote Wide-hom)
+
+module _ {o h} (C : Precategory o h) where
+  private module C = Cat.Reasoning C
+
+  open Precategory
+  open Wide-subcat
 ```
 -->
 
 We can then use this data to construct a category.
 
 ```agda
-Wide : Wide-subcat ℓ → Precategory o (h ⊔ ℓ)
-Wide sub .Ob = C.Ob
-Wide sub .Hom         = Wide-hom sub
-Wide sub .Hom-set _ _ = Wide-hom-is-set
+  Wide : ∀ {ℓ} → Wide-subcat C ℓ → Precategory o (h ⊔ ℓ)
+  Wide sub .Ob = C.Ob
+  Wide sub .Hom         = Wide-hom sub
+  Wide sub .Hom-set _ _ = hlevel 2
 
-Wide sub .id .hom     = C.id
-Wide sub .id .witness = sub .P-id
+  Wide sub .id .hom     = C.id
+  Wide sub .id .witness = sub .P-id
 
-Wide sub ._∘_ f g .hom     = f .hom C.∘ g .hom
-Wide sub ._∘_ f g .witness = sub .P-∘ (f .witness) (g .witness)
+  Wide sub ._∘_ f g .hom     = f .hom C.∘ g .hom
+  Wide sub ._∘_ f g .witness = sub .P-∘ (f .witness) (g .witness)
 
-Wide sub .idr _ = ext $ C.idr _
-Wide sub .idl _ = ext $ C.idl _
-Wide sub .assoc _ _ _ = ext $ C.assoc _ _ _
+  Wide sub .idr _ = ext $ C.idr _
+  Wide sub .idl _ = ext $ C.idl _
+  Wide sub .assoc _ _ _ = ext $ C.assoc _ _ _
 ```
 
 ## From split essentially surjective inclusions
@@ -120,14 +140,14 @@ There is another way of representing wide subcategories: By giving a
 
 <!--
 ```agda
-module _ {o' h'} {D : Precategory o' h'} {F : Functor D C}
-  (pseudomonic : is-pseudomonic F)
-  (eso : is-split-eso F)
-  where
-  open Functor F
-  private
-    module D = Cat.Reasoning D
-    module eso x =  C._≅_ (eso x .snd)
+  module _ {o' h'} {D : Precategory o' h'} {F : Functor D C}
+    (pseudomonic : is-pseudomonic F)
+    (eso : is-split-eso F)
+    where
+    open Functor F
+    private
+      module D = Cat.Reasoning D
+      module eso x = C._≅_ (eso x .snd)
 ```
 -->
 
@@ -136,45 +156,45 @@ $\cC$ that lie in the image of $F$. Since $F$ is a [[faithful functor]],
 this is indeed a proposition.
 
 ```agda
-  Split-eso-inclusion→Wide-subcat : Precategory _ _
-  Split-eso-inclusion→Wide-subcat = Wide sub where
-    sub : Wide-subcat (h ⊔ h')
-    sub .P {x = x} {y = y} f =
-      Σ[ g ∈ D.Hom (eso x .fst) (eso y .fst) ]
-      (eso.to y C.∘ F₁ g C.∘ eso.from x ≡ f)
-    sub .P-prop {x} {y} f (g , p) (g' , q) =
-      Σ-prop-path (λ _ → C.Hom-set _ _ _ _) $
-      is-pseudomonic.faithful pseudomonic   $
-      C.iso→epic (eso x .snd C.Iso⁻¹) _ _   $
-      C.iso→monic (eso y .snd) _ _ (p ∙ sym q)
-    sub .P-id {x} =
-      (D.id , ap₂ C._∘_ refl (C.eliml F-id) ∙ C.invl (eso x .snd))
-    sub .P-∘ {x} {y} {z} {f} {g} (f' , p) (g' , q) =
-      f' D.∘ g' , (
-        eso.to z C.∘ F₁ (f' D.∘ g') C.∘ eso.from x                                    ≡⟨ C.push-inner (F-∘ f' g') ⟩
-        (eso.to z C.∘ F₁ f') C.∘ (F₁ g' C.∘ eso.from x)                               ≡⟨ C.insert-inner (eso.invr y) ⟩
-        ((eso.to z C.∘ F₁ f') C.∘ eso.from y) C.∘ (eso.to y C.∘ F₁ g' C.∘ eso.from x) ≡⟨ ap₂ C._∘_ (sym (C.assoc _ _ _) ∙ p) q ⟩
-        f C.∘ g ∎)
+    Split-eso-inclusion→Wide-subcat : Precategory _ _
+    Split-eso-inclusion→Wide-subcat = Wide sub where
+      sub : Wide-subcat C (h ⊔ h')
+      sub .P {x = x} {y = y} f =
+        Σ[ g ∈ D.Hom (eso x .fst) (eso y .fst) ]
+        (eso.to y C.∘ F₁ g C.∘ eso.from x ≡ f)
+      sub .P-prop {x} {y} f (g , p) (g' , q) =
+        Σ-prop-path (λ _ → C.Hom-set _ _ _ _) $
+        is-pseudomonic.faithful pseudomonic   $
+        C.iso→epic (eso x .snd C.Iso⁻¹) _ _   $
+        C.iso→monic (eso y .snd) _ _ (p ∙ sym q)
+      sub .P-id {x} =
+        (D.id , ap₂ C._∘_ refl (C.eliml F-id) ∙ C.invl (eso x .snd))
+      sub .P-∘ {x} {y} {z} {f} {g} (f' , p) (g' , q) =
+        f' D.∘ g' , (
+          eso.to z C.∘ F₁ (f' D.∘ g') C.∘ eso.from x                                    ≡⟨ C.push-inner (F-∘ f' g') ⟩
+          (eso.to z C.∘ F₁ f') C.∘ (F₁ g' C.∘ eso.from x)                               ≡⟨ C.insert-inner (eso.invr y) ⟩
+          ((eso.to z C.∘ F₁ f') C.∘ eso.from y) C.∘ (eso.to y C.∘ F₁ g' C.∘ eso.from x) ≡⟨ ap₂ C._∘_ (sym (C.assoc _ _ _) ∙ p) q ⟩
+          f C.∘ g ∎)
 ```
 
 This canonical wide subcategory is equivalent to $\cD$.
 
 ```agda
-  Wide-subcat→Split-eso-domain : Functor (Split-eso-inclusion→Wide-subcat) D
-  Wide-subcat→Split-eso-domain .Functor.F₀ x = eso x .fst
-  Wide-subcat→Split-eso-domain .Functor.F₁ f = f .witness .fst
-  Wide-subcat→Split-eso-domain .Functor.F-id = refl
-  Wide-subcat→Split-eso-domain .Functor.F-∘ _ _ = refl
+    Wide-subcat→Split-eso-domain : Functor (Split-eso-inclusion→Wide-subcat) D
+    Wide-subcat→Split-eso-domain .Functor.F₀ x = eso x .fst
+    Wide-subcat→Split-eso-domain .Functor.F₁ f = f .witness .fst
+    Wide-subcat→Split-eso-domain .Functor.F-id = refl
+    Wide-subcat→Split-eso-domain .Functor.F-∘ _ _ = refl
 
-  is-fully-faithful-Wide-subcat→domain : is-fully-faithful Wide-subcat→Split-eso-domain
-  is-fully-faithful-Wide-subcat→domain = is-iso→is-equiv $ iso
-    (λ f → wide (eso.to _ C.∘ F₁ f C.∘ eso.from _) (f , refl))
-    (λ _ → refl)
-    (λ f → ext (f .witness .snd))
+    is-fully-faithful-Wide-subcat→domain : is-fully-faithful Wide-subcat→Split-eso-domain
+    is-fully-faithful-Wide-subcat→domain = is-iso→is-equiv $ iso
+      (λ f → wide (eso.to _ C.∘ F₁ f C.∘ eso.from _) (f , refl))
+      (λ _ → refl)
+      (λ f → ext (f .witness .snd))
 
-  is-eso-Wide-subcat→domain : is-split-eso Wide-subcat→Split-eso-domain
-  is-eso-Wide-subcat→domain x =
-    F₀ x , pseudomonic→essentially-injective pseudomonic (eso (F₀ x) .snd)
+    is-eso-Wide-subcat→domain : is-split-eso Wide-subcat→Split-eso-domain
+    is-eso-Wide-subcat→domain x =
+      F₀ x , pseudomonic→essentially-injective pseudomonic (eso (F₀ x) .snd)
 ```
 
 We did cheat a bit earlier when defining wide subcategories: our
@@ -191,13 +211,16 @@ should be part of the definition of a wide subcategory, but it isn't
 
 <!--
 ```agda
-module _ {sub : Wide-subcat ℓ} where
-  private module Wide = Cat.Reasoning (Wide sub)
+module _ {o h ℓ} {C : Precategory o h} {sub : Wide-subcat C ℓ} where
+  open Wide-subcat
+  private
+    module Wide = Cat.Reasoning (Wide C sub)
+    module C = Cat.Reasoning C
 ```
 -->
 
 ```agda
-  Forget-wide-subcat : Functor (Wide sub) C
+  Forget-wide-subcat : Functor (Wide C sub) C
   Forget-wide-subcat .Functor.F₀ x = x
   Forget-wide-subcat .Functor.F₁ f = f .hom
   Forget-wide-subcat .Functor.F-id = refl
@@ -207,7 +230,7 @@ module _ {sub : Wide-subcat ℓ} where
   is-faithful-Forget-wide-subcat = Wide-hom-path
 
   is-pseudomonic-Forget-wide-subcat
-    : (P-invert : ∀ {x y} {f : C.Hom x y} → C.is-invertible f → sub .P f)
+    : (P-invert : ∀ {x y} {f : C.Hom x y} → C.is-invertible f → f ∈ sub)
     → is-pseudomonic Forget-wide-subcat
   is-pseudomonic-Forget-wide-subcat P-invert .is-pseudomonic.faithful =
     is-faithful-Forget-wide-subcat

--- a/src/Cat/Instances/Core.lagda.md
+++ b/src/Cat/Instances/Core.lagda.md
@@ -31,10 +31,10 @@ under composition, we can construct this as a [wide subcategory] of $\cC$.
 
 ```agda
 Core : ∀ {o ℓ} → Precategory o ℓ → Precategory o ℓ
-Core C = Wide sub where
+Core C = Wide C sub where
   open Cat.Reasoning C
 
-  sub : Wide-subcat {C = C} _
+  sub : Wide-subcat C _
   sub .Wide-subcat.P = is-invertible
   sub .Wide-subcat.P-prop _ = is-invertible-is-prop
   sub .Wide-subcat.P-id = id-invertible

--- a/src/Cat/Instances/Discrete.lagda.md
+++ b/src/Cat/Instances/Discrete.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS -vtc.instance:15 --no-lossy-instance-fields #-}
 open import Cat.Instances.Product
 open import Cat.Groupoid
 open import Cat.Morphism

--- a/src/Cat/Instances/Localisation.lagda.md
+++ b/src/Cat/Instances/Localisation.lagda.md
@@ -18,9 +18,9 @@ module Cat.Instances.Localisation where
 
 <!--
 ```agda
-module _ {o ℓ w} (C : Precategory o ℓ) (W : Wide-subcat {C = C} w) where
+module _ {o ℓ w} (C : Precategory o ℓ) (W : Wide-subcat C w) where
   open Precategory C
-  open Wide-subcat W renaming (P to W?)
+  open Wide-subcat W
 
   private variable
     a b c d : Ob
@@ -77,7 +77,7 @@ with!
   data Zigzag : Ob → Ob → Type (o ⊔ ℓ ⊔ w) where
     []  : Zigzag a a
     zig : Hom b c → Zigzag a b → Zigzag a c
-    zag : (f : Hom c b) → f ∈ W? → Zigzag a b → Zigzag a c
+    zag : (f : Hom c b) → f ∈ W → Zigzag a b → Zigzag a c
 ```
 
 However, if we treat zigzags as plain *data*, things go wrong. We must
@@ -119,10 +119,10 @@ zag-zig could appear will respect this identity.
 
 ```agda
     zig-zag
-      : (f : Hom c b) (w : f ∈ W?) (h : Zigzag a b)
+      : (f : Hom c b) (w : f ∈ W) (h : Zigzag a b)
       → zig f (zag f w h) ≡ h
     zag-zig
-      : (f : Hom b c) (w : f ∈ W?) (h : Zigzag a b)
+      : (f : Hom b c) (w : f ∈ W) (h : Zigzag a b)
       → zag f w (zig f h) ≡ h
 ```
 
@@ -161,7 +161,7 @@ over them for time.
 
     zag-∘
       : ∀ {a b c d} {f : Hom c d} {g : Hom b c} (hs : Zigzag a d)
-      → (hf : f ∈ W?) (hg : g ∈ W?)
+      → (hf : f ∈ W) (hg : g ∈ W)
       → zag (f ∘ g) (P-∘ hf hg) hs ≡ zag g hg (zag f hf hs)
     zag-∘ {f = f} {g} hs hf hg =
       zag (f ∘ g) (P-∘ hf hg) ⌜ hs ⌝                                      ≡˘⟨ ap¡ (ap (zig f) (zig-zag _ _ _) ∙ zig-zag _ _ _) ⟩
@@ -174,8 +174,8 @@ over them for time.
 
 <!--
 ```agda
-module _ {o ℓ w} {C : Precategory o ℓ} {W : Wide-subcat {C = C} w} where
-  open Wide-subcat W renaming (P to W?)
+module _ {o ℓ w} {C : Precategory o ℓ} {W : Wide-subcat C w} where
+  open Wide-subcat W
   instance
     H-Level-Zigzag : ∀ {a b n} → H-Level (Zigzag C W a b) (2 + n)
     H-Level-Zigzag = basic-instance 2 squash
@@ -187,13 +187,13 @@ module _ {o ℓ w} {C : Precategory o ℓ} {W : Wide-subcat {C = C} w} where
     → (∀ {a b} (h : Zigzag C W a b) → is-set (P h))
     → (hnil : ∀ {a} → P {a} [])
     → (hzig : ∀ {a b c} (f : Hom b c) (h : Zigzag C W a b) → P h → P (zig f h))
-    → (hzag : ∀ {a b c} (f : Hom c b) (hf : f ∈ W?) (h : Zigzag C W a b) → P h → P (zag f hf h))
+    → (hzag : ∀ {a b c} (f : Hom c b) (hf : f ∈ W) (h : Zigzag C W a b) → P h → P (zag f hf h))
     → (∀ {a b} {h : Zigzag C W a b} (ph : P h) → PathP (λ i → P (zig-id h i)) (hzig id h ph) ph)
     → (∀ {a b c d} {f : Hom c d} {g : Hom b c} {h : Zigzag C W a b} (ph : P h)
       → PathP (λ i → P (zig-∘ f g h i)) (hzig f (zig g h) (hzig g h ph)) (hzig (f ∘ g) h ph))
-    → (∀ {a b c} {f : Hom c b} {w : f ∈ W?} {h : Zigzag C W a b} (ph : P h)
+    → (∀ {a b c} {f : Hom c b} {w : f ∈ W} {h : Zigzag C W a b} (ph : P h)
       → PathP (λ i → P (zig-zag f w h i)) (hzig f (zag f w h) (hzag f w h ph)) ph)
-    → (∀ {a b c} {f : Hom b c} {w : f ∈ W?} {h : Zigzag C W a b} (ph : P h)
+    → (∀ {a b c} {f : Hom b c} {w : f ∈ W} {h : Zigzag C W a b} (ph : P h)
       → PathP (λ i → P (zag-zig f w h i)) (hzag f w (zig f h) (hzig f h ph)) ph)
     → ∀ {a b} (h : Zigzag C W a b) → P h
   Zigzag-elim P pset pnil pzig pzag pzid pzo pia pai = go where
@@ -213,7 +213,7 @@ module _ {o ℓ w} {C : Precategory o ℓ} {W : Wide-subcat {C = C} w} where
       → (∀ {a b} (h : Zigzag C W a b) → is-prop (P h))
       → (hnil : ∀ {a} → P {a} [])
       → (hzig : ∀ {a b c} (f : Hom b c) (h : Zigzag C W a b) → P h → P (zig f h))
-      → (hzag : ∀ {a b c} (f : Hom c b) (hf : f ∈ W?) (h : Zigzag C W a b) → P h → P (zag f hf h))
+      → (hzag : ∀ {a b c} (f : Hom c b) (hf : f ∈ W) (h : Zigzag C W a b) → P h → P (zag f hf h))
       → ∀ {a b} (h : Zigzag C W a b) → P h
     Zigzag-elim-prop P pprop hnil hzig hzag =
       Zigzag-elim P
@@ -270,7 +270,7 @@ again mirror precisely the proofs for lists, or simple paths.
 
 <!--
 ```agda
-module _ {o ℓ w} (C : Precategory o ℓ) (W : Wide-subcat {C = C} w) where
+module _ {o ℓ w} (C : Precategory o ℓ) (W : Wide-subcat C w) where
   private module C = Cat.Reasoning C
   open Wide-subcat W renaming (P to W?)
   open Precategory
@@ -424,7 +424,7 @@ localisation back to $\cC$:
 module _ {o ℓ} (C : Precategory o ℓ) where
   open Precategory C
 
-  Total : Wide-subcat {C = C} lzero
+  Total : Wide-subcat C lzero
   Total .Wide-subcat.P      _ = ⊤
   Total .Wide-subcat.P-prop f = hlevel 1
   Total .Wide-subcat.P-id     = _
@@ -563,7 +563,7 @@ to map from $\cC\loc{W}$, instead.
 
 ```agda
 Localisation-univ-groupoid
-  : ∀ {o ℓ w o' ℓ'} {C : Precategory o ℓ} {W : Wide-subcat {C = C} w}
+  : ∀ {o ℓ w o' ℓ'} {C : Precategory o ℓ} {W : Wide-subcat C w}
   → {D : Precategory o' ℓ'} (d-grpd : is-pregroupoid D)
   → Functor C D
   → Functor (Localisation C W) D

--- a/src/Cat/Restriction/Instances/Allegory.lagda.md
+++ b/src/Cat/Restriction/Instances/Allegory.lagda.md
@@ -36,7 +36,7 @@ module _ {o ℓ ℓ'} (A : Allegory o ℓ ℓ') where
 -->
 
 ```agda
-  Partial-maps-subcat : Wide-subcat {C = cat} ℓ'
+  Partial-maps-subcat : Wide-subcat cat ℓ'
   Partial-maps-subcat .Wide-subcat.P = is-functional
   Partial-maps-subcat .Wide-subcat.P-prop f = ≤-thin
   Partial-maps-subcat .Wide-subcat.P-id =
@@ -45,7 +45,7 @@ module _ {o ℓ ℓ'} (A : Allegory o ℓ ℓ') where
     functional-∘ f-partial g-partial
 
   Partial-maps : Precategory o (ℓ ⊔ ℓ')
-  Partial-maps = Wide Partial-maps-subcat
+  Partial-maps = Wide cat Partial-maps-subcat
 ```
 
 This category can be equipped with a restriction structure, defining

--- a/src/Cat/Restriction/Total.lagda.md
+++ b/src/Cat/Restriction/Total.lagda.md
@@ -30,14 +30,14 @@ module _ {o ℓ} {C : Precategory o ℓ} (C↓ : Restriction-category C) where
 -->
 
 ```agda
-  Total-wide-subcat : Wide-subcat {C = C} ℓ
+  Total-wide-subcat : Wide-subcat C ℓ
   Total-wide-subcat .Wide-subcat.P = is-total
   Total-wide-subcat .Wide-subcat.P-prop = is-total-is-prop
   Total-wide-subcat .Wide-subcat.P-id = id-total
   Total-wide-subcat .Wide-subcat.P-∘ = total-∘
 
   Total-maps : Precategory o ℓ
-  Total-maps = Wide Total-wide-subcat
+  Total-maps = Wide C Total-wide-subcat
 ```
 
 <!--
@@ -53,7 +53,6 @@ Furthermore, the injection from $\thecat{Total}(\cC)$ into $\cC$ is
 [pseudomonic]: Cat.Functor.Properties.html#pseudomonic-functors
 
 ```agda
-
   Forget-total : Functor (Total-maps C↓) C
   Forget-total = Forget-wide-subcat
 

--- a/src/Data/List/Membership.lagda.md
+++ b/src/Data/List/Membership.lagda.md
@@ -44,6 +44,14 @@ data _∈ₗ_ {ℓ} {A : Type ℓ} (x : A) : List A → Type ℓ where
   there : (p : x ∈ₗ xs)       → x ∈ₗ (y ∷ xs)
 ```
 
+<!--
+```agda
+instance
+  Membership-List : ∀ {ℓ} {A : Type ℓ} → Membership A (List A) ℓ
+  Membership-List = record { _∈_ = _∈ₗ_ }
+```
+-->
+
 There is a more (homotopically) straightforward characterisation of
 membership in lists: the [[fibres]] of the lookup function `xs !
 i`{.Agda ident=!_}. These are given by an index $i :
@@ -56,14 +64,14 @@ proof that they are _are_ inverses is a straightforward induction in
 both cases, so it's omitted for space.
 
 ```agda
-element→!-fibre : ∀ {x : A} {xs} → x ∈ₗ xs → fibre (xs !_) x
+element→!-fibre : ∀ {x : A} {xs} → x ∈ xs → fibre (xs !_) x
 element→!-fibre (here p) = fzero , sym p
 element→!-fibre (there prf) with element→!-fibre prf
 ... | ix , p = fsuc ix , p
 
-!-fibre→element : ∀ {x : A} {xs} → fibre (xs !_) x → x ∈ₗ xs
+!-fibre→element : ∀ {x : A} {xs} → fibre (xs !_) x → x ∈ xs
 !-fibre→element {A = A} {x = x} = λ (ix , p) → go ix p module !-fibre→element where
-  go : ∀ {xs} (ix : Fin (length xs)) → xs ! ix ≡ x → x ∈ₗ xs
+  go : ∀ {xs} (ix : Fin (length xs)) → xs ! ix ≡ x → x ∈ xs
   go {xs = x ∷ xs} fzero p     = here  (sym p)
   go {xs = x ∷ xs} (fsuc ix) p = there (go ix p)
 ```
@@ -86,7 +94,7 @@ element→!-fibre→element : ∀ {x : A} {xs} (p : x ∈ₗ xs) → p ≡ !-fib
 element→!-fibre→element (here p)  = refl
 element→!-fibre→element (there p) = ap there (element→!-fibre→element p)
 
-element≃!-fibre : ∀ {x : A} {xs} → (x ∈ₗ xs) ≃ fibre (xs !_) x
+element≃!-fibre : ∀ {x : A} {xs} → (x ∈ xs) ≃ fibre (xs !_) x
 element≃!-fibre .fst = element→!-fibre
 element≃!-fibre .snd = is-iso→is-equiv λ where
   .is-iso.inv  p → !-fibre→element p
@@ -100,7 +108,7 @@ is a [[set]], then all that matters is the index; If $A$ is moreover
 [[discrete]], then $a \in_l as$ is [[decidable]].
 
 ```agda
-elem? : ⦃ _ : Discrete A ⦄ (x : A) (xs : List A) → Dec (x ∈ₗ xs)
+elem? : ⦃ _ : Discrete A ⦄ (x : A) (xs : List A) → Dec (x ∈ xs)
 elem? x [] = no λ ()
 elem? x (y ∷ xs) with x ≡ᵢ? y
 ... | yes reflᵢ = yes (here refl)
@@ -112,7 +120,7 @@ elem? x (y ∷ xs) with x ≡ᵢ? y
 <!--
 ```agda
 instance
-  Dec-∈ₗ : ⦃ _ : Discrete A ⦄ {x : A} {xs : List A} → Dec (x ∈ₗ xs)
+  Dec-∈ₗ : ⦃ _ : Discrete A ⦄ {x : A} {xs : List A} → Dec (x ∈ xs)
   Dec-∈ₗ {x = x} {xs} = elem? x xs
 ```
 -->
@@ -127,7 +135,7 @@ the terrible time complexity $O(n^2)$, but it works for an arbitrary
 discrete type, which is the best possible generality.
 
 ```agda
-nub-cons : (x : A) (xs : List A) → Dec (x ∈ₗ xs) → List A
+nub-cons : (x : A) (xs : List A) → Dec (x ∈ xs) → List A
 nub-cons x xs (yes _) = xs
 nub-cons x xs (no _)  = x ∷ xs
 
@@ -145,9 +153,9 @@ will be mapped to the same (first) occurrence in the deduplicated list.
 
 ```agda
 member-nub-is-prop
-  : ∀ ⦃ _ : Discrete A ⦄ {x : A} (xs : List A) → is-prop (x ∈ₗ nub xs)
+  : ∀ ⦃ _ : Discrete A ⦄ {x : A} xs → is-prop (x ∈ nub xs)
 member→member-nub
-  : ∀ ⦃ _ : Discrete A ⦄ {x : A} {xs : List A} → x ∈ₗ xs → x ∈ₗ nub xs
+  : ∀ ⦃ _ : Discrete A ⦄ {x : A} {xs} → x ∈ xs → x ∈ nub xs
 ```
 
 <details>
@@ -181,7 +189,7 @@ member→member-nub {xs = x ∷ xs} (there α) with elem? x (nub xs)
 !-tabulate-fibre f x = Σ-ap (cast (length-tabulate f) , cast-is-equiv _) λ i →
   path→equiv (ap (_≡ x) (!-tabulate f i))
 
-member-tabulate : ∀ {n} (f : Fin n → A) x → (x ∈ₗ tabulate f) ≃ fibre f x
+member-tabulate : ∀ {n} (f : Fin n → A) x → (x ∈ tabulate f) ≃ fibre f x
 member-tabulate f x = element≃!-fibre ∙e !-tabulate-fibre f x
 ```
 -->
@@ -190,15 +198,15 @@ member-tabulate f x = element≃!-fibre ∙e !-tabulate-fibre f x
 ```agda
 map-member
   : ∀ {A : Type ℓ} {B : Type ℓ'} (f : A → B) {x : A} {xs : List A}
-  → x ∈ₗ xs → f x ∈ₗ map f xs
+  → x ∈ xs → f x ∈ map f xs
 map-member f (here p)  = here (ap f p)
 map-member f (there x) = there (map-member f x)
 
-++-memberₗ : x ∈ₗ xs → x ∈ₗ (xs ++ ys)
+++-memberₗ : x ∈ xs → x ∈ (xs ++ ys)
 ++-memberₗ (here p)  = here p
 ++-memberₗ (there p) = there (++-memberₗ p)
 
-++-memberᵣ : x ∈ₗ ys → x ∈ₗ (xs ++ ys)
+++-memberᵣ : x ∈ ys → x ∈ (xs ++ ys)
 ++-memberᵣ {xs = []}     p = p
 ++-memberᵣ {xs = x ∷ xs} p = there (++-memberᵣ p)
 ```
@@ -210,7 +218,7 @@ any-one-of
   : ∀ {ℓ} {A : Type ℓ}
   → (f : A → Bool)
   → (x : A) (xs : List A)
-  → x ∈ₗ xs → f x ≡ true
+  → x ∈ xs → f x ≡ true
   → any-of f xs ≡ true
 any-one-of f x (y ∷ xs) (here x=y) x-true =
   ap₂ or (subst (λ e → f e ≡ true) x=y x-true) refl

--- a/src/Data/List/Quantifiers.lagda.md
+++ b/src/Data/List/Quantifiers.lagda.md
@@ -155,7 +155,7 @@ instance
 
 
 ```agda
-all-∈ : All P xs → x ∈ₗ xs → P x
+all-∈ : All P xs → x ∈ xs → P x
 all-∈ {P = P} (px ∷ pxs) (here p) = subst P (sym p) px
 all-∈ (px ∷ pxs) (there x∈xs) = all-∈ pxs x∈xs
 ```

--- a/src/Data/Power.lagda.md
+++ b/src/Data/Power.lagda.md
@@ -49,8 +49,8 @@ The **subset** relation is defined as is done traditionally: If $x \in
 X$ implies $x \in Y$, for $X, Y : \bb{P}(T)$, then $X \subseteq Y$.
 
 ```agda
-_⊆_ : ℙ X → ℙ X → Type _
-X ⊆ Y = ∀ x → x ∈ X → x ∈ Y
+_ : ∀ {X : Type ℓ} {x : X} {P Q : ℙ X} → (P ⊆ Q) ≡ (∀ x → x ∈ P → x ∈ Q)
+_ = refl
 ```
 
 By function and propositional extensionality, two subsets of $X$ are
@@ -67,7 +67,7 @@ propositions to each inhabitant of $X$.
 ## Lattice structure
 
 The type $\bb{P}(X)$ has a lattice structure, with the order given
-by `subset inclusion`{.Agda ident=_⊆_}. We call the meets
+by `subset inclusion`{.Agda ident=⊆}. We call the meets
 **`intersections`{.Agda ident=_∩_}** and the joins **`unions`{.Agda
 ident=_∪_}**.
 
@@ -102,8 +102,8 @@ is nothing which guarantees that A and B are disjoint subsets.
 _∪_ : ℙ X → ℙ X → ℙ X
 (A ∪ B) x = A x ∨Ω B x
 
-infixr 22 _∩_
-infixr 21 _∪_
+infixr 27 _∩_
+infixr 26 _∪_
 ```
 
 ## Images

--- a/src/Data/Power/Complemented.lagda.md
+++ b/src/Data/Power/Complemented.lagda.md
@@ -53,7 +53,7 @@ is-decidable p = ∀ a → Dec (a ∈ p)
 is-decidable→is-complemented : (p : ℙ A) → is-decidable p → is-complemented p
 is-decidable→is-complemented {A = A} p dec = inv , intersection , union where
   inv : ℙ A
-  inv x = el (¬ (x ∈ p)) hlevel!
+  inv x = el (x ∉ p) hlevel!
 
   intersection : (p ∩ inv) ⊆ minimal
   intersection x (x∈p , x∉p) = x∉p x∈p

--- a/src/Data/Set/Material.lagda.md
+++ b/src/Data/Set/Material.lagda.md
@@ -159,22 +159,16 @@ is-member e (squash x y p q i j) =
 ```
 -->
 
-As a type, we will write the membership relation as `_∈ₛ_`{.Agda}, since
+As a type, we will write the membership relation as `_∈_`{.Agda}, since
 `_∈_`{.Agda} already stands for the fibres of families of propositions.
 There's nothing surprising about the subset relation $s \sube t$: it
 means every element of $s$ is an element of $t$.
 
-```agda
-_∈ₛ_ : ∀ {ℓ} → V ℓ → V ℓ → Type (lsuc ℓ)
-x ∈ₛ y = ∣ is-member x y ∣
-
-_⊆_ : ∀ {ℓ} → V ℓ → V ℓ → Type (lsuc ℓ)
-s ⊆ t = ∀ a → a ∈ₛ s → a ∈ₛ t
-```
-
 <!--
 ```agda
-infix 30 _∈ₛ_ _⊆_
+instance
+  Membership-V : ∀ {ℓ} → Membership (V ℓ) (V ℓ) (lsuc ℓ)
+  Membership-V = record { _∈_ = λ x y → ⌞ is-member x y ⌟ }
 ```
 -->
 
@@ -197,8 +191,8 @@ condition on $f$.
 ```agda
   worker
     : ∀ {A B} (f : A → V _) (g : B → V _)
-    → ((a : V _) → a ∈ₛ set A f → a ∈ₛ set B g)
-    → ((a : V _) → a ∈ₛ set B g → a ∈ₛ set A f)
+    → ((a : V _) → a ∈ set A f → a ∈ set B g)
+    → ((a : V _) → a ∈ set B g → a ∈ set A f)
     → set A f ≡ set B g
   worker f g f<g g<f = ext f g
     (λ a → f<g (f a) (inc (a , refl)))
@@ -380,18 +374,18 @@ of $X$'s presentation.
 module Members {ℓ} (X : V ℓ) where
   open Presentation (presentation X) public
 
-  memb : ∀ {x} → x ∈ₛ X ≃ fibre elem x
+  memb : ∀ {x} → x ∈ X ≃ fibre elem x
   memb {x = x} = prop-ext (is-member _ X .is-tr) (embeds _)
-    (λ a → ∥-∥-proj (embeds _) (subst (x ∈ₛ_) presents a))
-    (λ a → subst (x ∈ₛ_) (sym presents) (inc a))
+    (λ a → ∥-∥-proj (embeds _) (subst (x ∈_) presents a))
+    (λ a → subst (x ∈_) (sym presents) (inc a))
 
   module memb {x} = Equiv (memb {x})
 
-  contains : ∀ {i} → elem i ∈ₛ X
+  contains : ∀ {i} → elem i ∈ X
   contains = memb.from (_ , refl)
 
-  contains' : ∀ {i x} → x ≡ elem i → x ∈ₛ X
-  contains' p = subst (_∈ₛ X) (sym p) contains
+  contains' : ∀ {i x} → x ≡ elem i → x ∈ X
+  contains' p = subst (_∈ X) (sym p) contains
 ```
 
 # Modelling IZF
@@ -419,7 +413,7 @@ module _ {ℓ} where
   ∅V : V ℓ
   ∅V = set (Lift ℓ ⊥) (λ ())
 
-  empty-set : ∀ x → ¬ (x ∈ₛ ∅V)
+  empty-set : ∀ x → x ∉ ∅V
   empty-set x = ∥-∥-rec (hlevel 1) (λ ())
 ```
 
@@ -439,7 +433,7 @@ The proof that $x \in \{A, B\} \simeq (x = A \lor x = B)$ is essentially
 the implementation of binary coproducts in terms of arbitrary sum types.
 
 ```agda
-  pairing : ∀ {a b x} → x ∈ₛ pair a b ≃ ∥ (x ≡ a) ⊎ (x ≡ b) ∥
+  pairing : ∀ {a b x} → x ∈ pair a b ≃ ∥ (x ≡ a) ⊎ (x ≡ b) ∥
   pairing = prop-ext squash squash
     (∥-∥-rec squash λ where
       (lift true , p) → inc (inl (sym p))
@@ -471,7 +465,7 @@ of $u$. This is essentially reassociation modulo the equivalence $x \in
 F \simeq m_F^*(x)$.
 
 ```agda
-  union : ∀ {x F} → x ∈ₛ ⋃V F ≃ ∃ (V ℓ) λ u → x ∈ₛ u × u ∈ₛ F
+  union : ∀ {x F} → x ∈ ⋃V F ≃ ∃ (V ℓ) λ u → x ∈ u × u ∈ F
   union {x} {F} = prop-ext hlevel! squash
     (∥-∥-map λ { ((i , j) , p) →
         Members.elem F i
@@ -532,7 +526,7 @@ constructor to the successor set.
     go zero    = ∅V
     go (suc x) = suc-V (go x)
 
-  zero∈ℕ : ∅V ∈ₛ ℕV
+  zero∈ℕ : ∅V ∈ ℕV
   zero∈ℕ = inc (lift zero , refl)
 ```
 
@@ -542,7 +536,7 @@ contains the empty set and is closed under successor, for if $x \in
 $\rm{suc}^{i + 1}(\varnothing) = \rm{suc}_V(x)$.
 
 ```agda
-  suc∈ℕ : ∀ {X} → X ∈ₛ ℕV → suc-V X ∈ₛ ℕV
+  suc∈ℕ : ∀ {X} → X ∈ ℕV → suc-V X ∈ ℕV
   suc∈ℕ = ∥-∥-map λ (lift i , x) → lift (suc i) , ap₂ _∪V_ x (ap singleton x)
 ```
 
@@ -555,7 +549,7 @@ set.
 
 ```agda
   ℕ-induction
-    : ∀ x → x ∈ₛ ℕV ≃ ∥ (x ≡ ∅V) ⊎ (∃ (V ℓ) λ y → y ∈ₛ ℕV × (x ≡ suc-V y)) ∥
+    : ∀ x → x ∈ ℕV ≃ ∥ (x ≡ ∅V) ⊎ (∃ (V ℓ) λ y → y ∈ ℕV × (x ≡ suc-V y)) ∥
   ℕ-induction x = prop-ext squash squash
     (∥-∥-map λ where
       (lift zero , w)    → inl (sym w)
@@ -589,8 +583,8 @@ This is a straightforward computation.
 ```agda
   replacement
     : ∀ (r : V ℓ → V ℓ) x i
-    → i ∈ₛ V-image r x
-    ≃ ∃ (V ℓ) λ z → z ∈ₛ x × (i ≡ r z)
+    → i ∈ V-image r x
+    ≃ ∃ (V ℓ) λ z → z ∈ x × (i ≡ r z)
   replacement r x i = prop-ext squash squash
     (∥-∥-map λ { (i , p) → _ , Members.contains x , sym p })
     (∥-∥-map λ { (z , z∈x , i=rz) →
@@ -624,7 +618,7 @@ corresponds to a proof of $x \in a$, and transporting the latter along
 $p$, a proof that $C$ holds of $x$.
 
 ```agda
-  separation : ∀ a C x → (x ∈ₛ subset a C) ≃ (x ∈ₛ a × x ∈ C)
+  separation : ∀ a C x → (x ∈ subset a C) ≃ (x ∈ a × x ∈ C)
   separation a C x = prop-ext squash hlevel!
     (∥-∥-rec hlevel! λ { ((j , w) , p) →
       Members.contains' a (sym p) , subst (λ e → ∣ C e ∣) p w })
@@ -661,21 +655,21 @@ construction of power set.
 
   subset-separation
     : ∀ {a} (p : Members.members a → Ω) x
-    → x ∈ₛ subset a (predicate→class p)
+    → x ∈ subset a (predicate→class p)
     ≃ (Σ (fibre (Members.elem a) x) λ f → f .fst ∈ p)
 ```
 
 <!--
 ```agda
   subset-separation {a} p x =
-    x ∈ₛ subset a (predicate→class p)               ≃⟨ separation _ (predicate→class p) x ⟩
-    x ∈ₛ a × (x ∈ predicate→class p)                ≃⟨ deduplicate ⟩
+    x ∈ subset a (predicate→class p)               ≃⟨ separation _ (predicate→class p) x ⟩
+    x ∈ a × (x ∈ predicate→class p)                ≃⟨ deduplicate ⟩
     Σ (fibre (Members.elem a) x) (λ f → f .fst ∈ p) ≃∎
     where
       hp = Σ-is-hlevel 1 (Members.embeds a x) λ f → p (f .fst) .is-tr
 
       deduplicate
-        : (x ∈ₛ a × (x ∈ predicate→class p))
+        : (x ∈ a × (x ∈ predicate→class p))
         ≃ Σ (fibre (Members.elem a) x) (λ f → f .fst ∈ p)
       deduplicate = prop-ext
         (×-is-hlevel 1 (is-member x a .is-tr) (predicate→class p x .is-tr))
@@ -689,7 +683,7 @@ construction of power set.
   power : V ℓ → V ℓ
   power a = set (Members.members a → Ω) λ p → subset a (predicate→class p)
 
-  power-set : ∀ a i → i ∈ₛ power a ≃ (i ⊆ a)
+  power-set : ∀ a i → i ∈ power a ≃ (i ⊆ a)
   power-set a i = done where
 ```
 
@@ -718,7 +712,7 @@ $(x \in B) \simeq (\sum_{(k, _)} : m_a^*(x)) m_a(k) \in i$.
     p2 : i ⊆ a → ∥ fibre (subset a ∘ predicate→class) i ∥
     p2 i⊆a = inc (belongs , extensionality _ _ to fro) where
       belongs : Members.members a → Ω
-      belongs m = elΩ (Members.elem a m ∈ₛ i)
+      belongs m = elΩ (Members.elem a m ∈ i)
 ```
 
 Given $x \in B$, split it into $k : [a]$, $m_a(i) = x$, $m_a(k) \in i$.
@@ -727,7 +721,7 @@ By transporting this last proof along the middle path, we conclude $x
 
 ```agda
       to : subset a (predicate→class belongs) ⊆ i
-      to e e∈sub = subst (_∈ₛ i)
+      to e e∈sub = subst (_∈ i)
         (Equiv.to (subset-separation belongs e) e∈sub .fst .snd)
         (out! {pa = is-member _ i .is-tr}
           (Equiv.to (subset-separation belongs e) e∈sub .snd))
@@ -742,7 +736,7 @@ m_a^*(x)$. It remains to show $m_a(k) \in i$; but this is equal to $x
       fro : i ⊆ subset a (predicate→class belongs)
       fro e e∈i = Equiv.from (subset-separation belongs _)
         ( Members.memb.to a (i⊆a _ e∈i)
-        , inc (subst (_∈ₛ i) (sym (Members.memb.to a (i⊆a _ e∈i) .snd)) e∈i))
+        , inc (subst (_∈ i) (sym (Members.memb.to a (i⊆a _ e∈i) .snd)) e∈i))
 
     done = prop-ext squash hlevel! (∥-∥-rec hlevel! p1) p2
 ```
@@ -757,7 +751,7 @@ as it holds for every $x \in a$, then $P$ holds of any material set.
 ```agda
   ∈-induction
     : ∀ {ℓ'} (P : V ℓ → Prop ℓ')
-    → (∀ {a} → (∀ {x} → x ∈ₛ a → ∣ P x ∣) → ∣ P a ∣)
+    → (∀ {a} → (∀ {x} → x ∈ a → ∣ P x ∣) → ∣ P a ∣)
     → ∀ x → ∣ P x ∣
   ∈-induction P ps = V-elim-prop (λ z → ∣ P z ∣) (λ _ → P _ .is-tr) $ λ f i →
     ps λ {x} → ∥-∥-rec (P _ .is-tr) λ (a , p) →

--- a/src/Data/Set/Material.lagda.md
+++ b/src/Data/Set/Material.lagda.md
@@ -159,18 +159,17 @@ is-member e (squash x y p q i j) =
 ```
 -->
 
-As a type, we will write the membership relation as `_∈_`{.Agda}, since
-`_∈_`{.Agda} already stands for the fibres of families of propositions.
-There's nothing surprising about the subset relation $s \sube t$: it
-means every element of $s$ is an element of $t$.
+Having constructed the membership proposition, we can declare an
+instance of the `Membership`{.Agda} for `V`{.Agda}. This will allow us
+to use not only the notation `x ∈ X`{.Agda ident=_∈_}, with the meaning
+above, but also the subset notation, `X ⊆ Y`{.Agda ident=⊆}, with its
+usual meaning.
 
-<!--
 ```agda
 instance
   Membership-V : ∀ {ℓ} → Membership (V ℓ) (V ℓ) (lsuc ℓ)
   Membership-V = record { _∈_ = λ x y → ⌞ is-member x y ⌟ }
 ```
--->
 
 ## Extensionality
 

--- a/src/HoTT.lagda.md
+++ b/src/HoTT.lagda.md
@@ -544,7 +544,7 @@ _ = Ωⁿ≃Sⁿ-map
 -->
 
 * Remark 6.2.3: `to-pathp`{.Agda}, `from-pathp`{.Agda}
-* _Induction principle for $\bb{S}^1$: by pattern matching.
+* _Induction principle for $\bb{S}^1$_: by pattern matching.
 * Lemma 6.2.5: `S¹-rec`{.Agda}
 * Lemma 6.2.9: `Ωⁿ≃Sⁿ-map`{.Agda} for `n = 1`{.Agda}
 

--- a/src/Logic/Propositional/Classical.lagda.md
+++ b/src/Logic/Propositional/Classical.lagda.md
@@ -59,6 +59,10 @@ data _∈ᶜ_ {Γ : Nat} (P : Proposition Γ) : Ctx Γ → Type where
 
 <!--
 ```agda
+instance
+  Membership-Ctx : ∀ {Γ} → Membership (Proposition Γ) (Ctx Γ) lzero
+  Membership-Ctx = record { _∈_ = _∈ᶜ_ }
+
 infixr 12 _“⇒”_
 infixr 11 _“∧”_
 infixr 10 _“∨”_
@@ -80,7 +84,7 @@ Our first rule is pretty intuitive: If `P` is in our hypotheses `ψ`,
 then we can deduce `P` from `ψ`.
 
 ```agda
-  hyp : ∀ {P} → P ∈ᶜ ψ → ψ ⊢ P
+  hyp : ∀ {P} → P ∈ ψ → ψ ⊢ P
 ```
 
 Next, we give an introduction rule for "true" and an elimination rule
@@ -170,7 +174,7 @@ inc-ctx : Ctx Γ → Ctx (suc Γ)
 inc-ctx []      = []
 inc-ctx (ψ ⨾ P) = inc-ctx ψ ⨾ inc-prop P
 
-inc-atom : P ∈ᶜ ψ → inc-prop P ∈ᶜ inc-ctx ψ
+inc-atom : P ∈ ψ → inc-prop P ∈ inc-ctx ψ
 inc-atom here      = here
 inc-atom (there x) = there (inc-atom x)
 
@@ -200,7 +204,7 @@ bump-ctx : Ctx Γ → Ctx (suc Γ)
 bump-ctx []      = []
 bump-ctx (ψ ⨾ P) = bump-ctx ψ ⨾ bump-prop P
 
-bump-atom : P ∈ᶜ ψ → bump-prop P ∈ᶜ bump-ctx ψ
+bump-atom : P ∈ ψ → bump-prop P ∈ bump-ctx ψ
 bump-atom here      = here
 bump-atom (there p) = there (bump-atom p)
 
@@ -323,7 +327,7 @@ In categorical terms, this induces a presheaf on the category of
 contexts.
 
 ```agda
-rename-hyp : Rename ψ θ → P ∈ᶜ θ → P ∈ᶜ ψ
+rename-hyp : Rename ψ θ → P ∈ θ → P ∈ ψ
 rename-hyp (drop rn) mem         = there (rename-hyp rn mem)
 rename-hyp (keep rn) here        = here
 rename-hyp (keep rn) (there mem) = there (rename-hyp rn mem)
@@ -431,11 +435,11 @@ propositions.
 “⋀” []      = “⊤”
 “⋀” (ψ ⨾ P) = “⋀” ψ “∧” P
 
-⋀-intro : (∀ {P} → P ∈ᶜ ψ → θ ⊢ P) → θ ⊢ “⋀” ψ
+⋀-intro : (∀ {P} → P ∈ ψ → θ ⊢ P) → θ ⊢ “⋀” ψ
 ⋀-intro {ψ = []}    pfs = ⊤-intro
 ⋀-intro {ψ = ψ ⨾ P} pfs = ∧-intro (⋀-intro (pfs ∘ there)) (pfs here)
 
-⋀-elim : P ∈ᶜ ψ → θ ⊢ “⋀” ψ → θ ⊢ P
+⋀-elim : P ∈ ψ → θ ⊢ “⋀” ψ → θ ⊢ P
 ⋀-elim here      p = ∧-elim-r p
 ⋀-elim (there x) p = ⋀-elim x (∧-elim-l p)
 ```
@@ -529,7 +533,7 @@ following: if `ψ ⊢ P` is provable, then we have the semantic entailment
 mechanical.
 
 ```agda
-hyp-sound : ∀ {Γ} {ψ : Ctx Γ} {P : Proposition Γ} → P ∈ᶜ ψ → ψ ⊨ P
+hyp-sound : ∀ {Γ} {ψ : Ctx Γ} {P : Proposition Γ} → P ∈ ψ → ψ ⊨ P
 hyp-sound here      ρ hyps-true = and-reflect-true-r hyps-true
 hyp-sound (there m) ρ hyps-true = hyp-sound m ρ (and-reflect-true-l hyps-true)
 

--- a/src/Logic/Propositional/Classical/SAT.lagda.md
+++ b/src/Logic/Propositional/Classical/SAT.lagda.md
@@ -136,7 +136,7 @@ This is not hard to show, just tedious.
 ```agda
 delete-literal-sound
   : (x : Literal (suc Γ)) (ϕ : Clause (suc Γ))
-  → ¬ (x ∈ₗ ϕ)
+  → x ∉ ϕ
   → (ρ : Fin Γ → Bool)
   → ⟦ ϕ ⟧ (ρ [ lit-var x ≔ lit-val x ]) ≡ ⟦ delete-literal (lit-var x) ϕ ⟧ ρ
 

--- a/src/Order/Base.lagda.md
+++ b/src/Order/Base.lagda.md
@@ -219,6 +219,11 @@ instance
   Funlike-Monotone : ∀ {o o' ℓ ℓ'} → Funlike (Monotone {o} {o'} {ℓ} {ℓ'})
   Funlike-Monotone = record { _#_ = hom }
 
+  Membership-Monotone
+    : ∀ {o ℓ o' ℓ'} {P : Poset o ℓ} {Q : Poset o' ℓ'} ⦃ u : Underlying ⌞ Q ⌟ ⦄
+    → Membership ⌞ P ⌟ (Monotone P Q) _
+  Membership-Monotone = Funlike→membership
+
 Monotone-pathp
   : ∀ {o ℓ o' ℓ'} {P : I → Poset o ℓ} {Q : I → Poset o' ℓ'}
   → {f : Monotone (P i0) (Q i0)} {g : Monotone (P i1) (Q i1)}

--- a/src/Order/Frame/Free.lagda.md
+++ b/src/Order/Frame/Free.lagda.md
@@ -161,8 +161,8 @@ binary meets.
       B.⋃ (λ i → f # fst i)                             B.≤∎
       where
         meet-section
-          : Σ[ x ∈ A.Ob ] (x ∈↓ S) × Σ[ y ∈ A.Ob ] (y ∈↓ T)
-          → Σ[ x ∈ A.Ob ] ((x ∈↓ S) × (x ∈↓ T))
+          : ∫ₚ S × ∫ₚ T
+          → Σ[ x ∈ A.Ob ] (x ∈ S × x ∈ T)
         meet-section ((x , p) , (y , q)) =
           (x A.∩ y) , (S .pres-≤ A.∩≤l p , T .pres-≤ A.∩≤r q)
 ```

--- a/src/Order/Instances/Lower.lagda.md
+++ b/src/Order/Instances/Lower.lagda.md
@@ -47,9 +47,6 @@ Lower-set P = ⌞ Lower-sets P ⌟
 ```agda
 module _ {ℓₒ ℓᵣ} {P : Poset ℓₒ ℓᵣ} where
   private module P = Pr P
-
-  _∈↓_ : P.Ob → Lower-set P → Type _
-  a ∈↓ S = a ∈ apply S
 ```
 -->
 
@@ -87,7 +84,7 @@ by arbitrarily large types:
   Lower-sets-complete
     : ∀ {ℓ'} {I : Type ℓ'} (F : I → Lower-set P) → Glb (Lower-sets P) F
   Lower-sets-complete F .Glb.glb .hom i =
-    elΩ (∀ j → i ∈ apply (F j))
+    elΩ (∀ j → i ∈ F j)
   Lower-sets-complete F .Glb.glb .pres-≤ j≤i =
     □-map λ x∈Fj j → F j .pres-≤ j≤i (x∈Fj j)
   Lower-sets-complete F .Glb.has-glb .is-glb.glb≤fam i x x∈Fj = (out! x∈Fj) i
@@ -103,7 +100,7 @@ operator automatically propositionally truncates.
   Lower-sets-cocomplete
     : ∀ {ℓ'} {I : Type ℓ'} (F : I → Lower-set P) → Lub (Lower-sets P) F
   Lower-sets-cocomplete F .Lub.lub .hom i =
-    elΩ (Σ _ λ j → i ∈ apply (F j))
+    elΩ (Σ _ λ j → i ∈ F j)
   Lower-sets-cocomplete F .Lub.lub .pres-≤ j≤i =
     □-map λ { (i , x∈Fi) → i , F i .pres-≤ j≤i x∈Fi }
   Lower-sets-cocomplete F .Lub.has-lub .is-lub.fam≤lub i x x∈Fi =

--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "agda",
   "repo": "agda",
-  "branch": "master",
+  "branch": "aliao/lossy-instance-fields",
   "private": false,
-  "rev": "8ede3561ae32257eb7a102b8301c61fae1debb23",
-  "sha256": "0iwif4ix47974j5mnq24a2afhgc03y0gp977bn0vsb3ics8dg6bz"
+  "rev": "ba971387549aab39b287620d087132f9ac604e72",
+  "sha256": "0q5ydsnjg2agrgrky0mk80b9fdgkyl1111h1hl98npxa8jys3ira"
 }


### PR DESCRIPTION
I wrote an Agda feature so we could have nice `_∈_` so here's my implementation of a nice `_∈_`. The only file that broke with the change to instance selection was `Cat.Instances.Discrete`, where a (non-confluent) rewrite rule no longer fired for one of the `F-id` proofs.

The diff is large mostly because I went around making some things prettier also. Remarkably *every single use-site* of both `ext` and `hlevel!` survived as is. We're pretty good at writing tactics that block properly :relieved: