### PR TITLE
Basic monoidal category theory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ let
       collection-latex
       xcolor
       preview
-      pgf tikz-cd
+      pgf tikz-cd braids
       mathpazo
       varwidth xkeyval standalone;
   };

--- a/src/Cat/Bi/Base.lagda.md
+++ b/src/Cat/Bi/Base.lagda.md
@@ -418,7 +418,7 @@ have components $F_1(f)F_1(g) \To F_1(fg)$ and $\id \To F_1(\id)$.
 ```agda
     compositor
       : ∀ {A B C}
-      → C.compose F∘ Cat⟨ P₁ {B} {C} F∘ Fst , P₁ {A} {B} F∘ Snd ⟩ => P₁ F∘ B.compose
+      → C.compose F∘ (P₁ {B} {C} F× P₁ {A} {B}) => P₁ F∘ B.compose
 
     unitor : ∀ {A} → C.id C.⇒ P₁ .Functor.F₀ (B.id {A = A})
 ```

--- a/src/Cat/Functor/Base.lagda.md
+++ b/src/Cat/Functor/Base.lagda.md
@@ -181,7 +181,7 @@ Functor-path {C = C} {D = D} {F = F} {G = G} p0 p1 i .F-∘ f g =
 
 <!--
 ```agda
-module _ {C : Precategory o ℓ} {D : Precategory o₁ ℓ₁} where
+module F-iso {C : Precategory o ℓ} {D : Precategory o₁ ℓ₁} (F : Functor C D) where
   private module _ where
     module C = Cat.Reasoning C
     module D = Cat.Reasoning D
@@ -195,17 +195,17 @@ We have also to make note of the following fact: absolutely all functors
 preserve isomorphisms, and, more generally, preserve invertibility.
 
 ```agda
-  F-map-iso : ∀ {x y} (F : Functor C D) → x C.≅ y → F # x D.≅ F # y
-  F-map-iso F x .to       = F .F₁ (x .to)
-  F-map-iso F x .from     = F .F₁ (x .from)
-  F-map-iso F x .inverses =
+  F-map-iso : ∀ {x y} → x C.≅ y → F # x D.≅ F # y
+  F-map-iso x .to       = F .F₁ (x .to)
+  F-map-iso x .from     = F .F₁ (x .from)
+  F-map-iso x .inverses =
     record { invl = sym (F .F-∘ _ _) ∙ ap (F .F₁) (x .invl) ∙ F .F-id
            ; invr = sym (F .F-∘ _ _) ∙ ap (F .F₁) (x .invr) ∙ F .F-id
            }
     where module x = C._≅_ x
 
-  F-map-invertible : ∀ {x y} (F : Functor C D) {f : C.Hom x y} → C.is-invertible f → D.is-invertible (F .F₁ f)
-  F-map-invertible F inv =
+  F-map-invertible : ∀ {x y} {f : C.Hom x y} → C.is-invertible f → D.is-invertible (F .F₁ f)
+  F-map-invertible inv =
     D.make-invertible (F .F₁ _)
       (sym (F .F-∘ _ _) ·· ap (F .F₁) x.invl ·· F .F-id)
       (sym (F .F-∘ _ _) ·· ap (F .F₁) x.invr ·· F .F-id)
@@ -222,36 +222,38 @@ already coherent enough to ensure that these actions agree:
 ```agda
   F-map-path
     : (ccat : is-category C) (dcat : is-category D)
-    → ∀ (F : Functor C D) {x y} (i : x C.≅ y)
-    → ap# F (Univalent.iso→path ccat i) ≡ Univalent.iso→path dcat (F-map-iso F i)
-  F-map-path ccat dcat F {x} = Univalent.J-iso ccat P pr where
+    → ∀ {x y} (i : x C.≅ y)
+    → ap# F (Univalent.iso→path ccat i) ≡ Univalent.iso→path dcat (F-map-iso i)
+  F-map-path ccat dcat {x} = Univalent.J-iso ccat P pr where
     P : (b : C.Ob) → C.Isomorphism x b → Type _
     P b im = ap# F (Univalent.iso→path ccat im)
-           ≡ Univalent.iso→path dcat (F-map-iso F im)
+           ≡ Univalent.iso→path dcat (F-map-iso im)
 
     pr : P x C.id-iso
     pr =
       ap# F (Univalent.iso→path ccat C.id-iso) ≡⟨ ap (ap# F) (Univalent.iso→path-id ccat) ⟩
       ap# F refl                               ≡˘⟨ Univalent.iso→path-id dcat ⟩
       dcat .to-path D.id-iso                   ≡⟨ ap (dcat .to-path) (ext (sym (F .F-id))) ⟩
-      dcat .to-path (F-map-iso F C.id-iso)     ∎
+      dcat .to-path (F-map-iso C.id-iso)     ∎
 ```
 
 <!--
 ```agda
   ap-F₀-to-iso
-    : ∀ (F : Functor C D) {y z}
-    → (p : y ≡ z) → path→iso (ap# F p) ≡ F-map-iso F (path→iso p)
-  ap-F₀-to-iso F {y} =
-    J (λ _ p → path→iso (ap# F p) ≡ F-map-iso F (path→iso p))
+    : ∀ {y z}
+    → (p : y ≡ z) → path→iso (ap# F p) ≡ F-map-iso (path→iso p)
+  ap-F₀-to-iso {y} =
+    J (λ _ p → path→iso (ap# F p) ≡ F-map-iso (path→iso p))
       (D.≅-pathp (λ _ → F .F₀ y) (λ _ → F .F₀ y)
         (Regularity.fast! (sym (F .F-id))))
 
   ap-F₀-iso
-    : ∀ (cc : is-category C) (F : Functor C D) {y z : C.Ob}
-    → (p : y C.≅ z) → path→iso (ap# F (cc .to-path p)) ≡ F-map-iso F p
-  ap-F₀-iso cc F p = ap-F₀-to-iso F (cc .to-path p)
-                   ∙ ap (F-map-iso F) (Univalent.iso→path→iso cc p)
+    : ∀ (cc : is-category C) {y z : C.Ob}
+    → (p : y C.≅ z) → path→iso (ap# F (cc .to-path p)) ≡ F-map-iso p
+  ap-F₀-iso cc p = ap-F₀-to-iso (cc .to-path p)
+                 ∙ ap F-map-iso (Univalent.iso→path→iso cc p)
+
+open F-iso public
 ```
 -->
 

--- a/src/Cat/Functor/Equivalence.lagda.md
+++ b/src/Cat/Functor/Equivalence.lagda.md
@@ -462,7 +462,7 @@ indeed the same path:
     abstract
       square : ap# F x≡y ≡ Fx≡Fy
       square =
-        ap# F x≡y                         ≡⟨ F-map-path ccat dcat F x≅y ⟩
+        ap# F x≡y                         ≡⟨ F-map-path F ccat dcat x≅y ⟩
         dcat .to-path ⌜ F-map-iso F x≅y ⌝ ≡⟨ ap! (equiv→counit (is-ff→F-map-iso-is-equiv {F = F} ff) _)  ⟩
         dcat .to-path Fx≅Fy               ∎
 

--- a/src/Cat/Functor/Hom/Representable.lagda.md
+++ b/src/Cat/Functor/Hom/Representable.lagda.md
@@ -118,7 +118,7 @@ Representation-is-prop {F = F} c-cat x y = path where
       (Nat-pathp _ _ λ a → Hom-pathp-reflr (Sets _)
         {A = F .F₀ a} {q = λ i → el! (C.Hom a (objs i))}
         (funext λ x →
-           ap (λ e → e .Sets.to) (ap-F₀-iso c-cat (Hom-from C a) _) $ₚ _
+           ap (λ e → e .Sets.to) (ap-F₀-iso (Hom-from C a) c-cat _) $ₚ _
         ·· sym (Y.rep.to .is-natural _ _ _) $ₚ _
         ·· ap Y.Rep.from (sym (X.rep.from .is-natural _ _ _ $ₚ _)
                        ·· ap X.Rep.to (C.idl _)
@@ -305,7 +305,7 @@ Corepresentation-is-prop {F = F} c-cat X Y = path where
        (Nat-pathp _ _ λ a → Hom-pathp-reflr (Sets _)
          {A = F .F₀ a} {q = λ i → el! (C.Hom (objs i) a)}
          (funext λ x →
-           ap (λ e → e .Sets.to) (ap-F₀-iso (opposite-is-category c-cat) (Hom-into C a) _) $ₚ _
+           ap (λ e → e .Sets.to) (ap-F₀-iso (Hom-into C a) (opposite-is-category c-cat) _) $ₚ _
            ·· sym (corep.to Y .is-natural _ _ _ $ₚ _)
            ·· ap (Corep.from Y) (sym (corep.from X .is-natural _ _ _ $ₚ _)
                                  ·· ap (Corep.to X) (C.idr _)

--- a/src/Cat/Functor/Naturality.lagda.md
+++ b/src/Cat/Functor/Naturality.lagda.md
@@ -200,6 +200,15 @@ to an invertible natural transformation, resp. natural isomorphism.
     ate : _ => _
     ate .η x = D.is-invertible.inv (i x)
     ate .is-natural = inverse-is-natural eta _ (λ x → D.is-invertible.invl (i x)) (λ x → D.is-invertible.invr (i x))
+
+  push-eqⁿ : ∀ {F G} (α : F ≅ⁿ G) {a b} {f g : C.Hom a b} → F .F₁ f ≡ F .F₁ g → G .F₁ f ≡ G .F₁ g
+  push-eqⁿ {F = F} {G = G} α {f = f} {g} p =
+    G .F₁ f                                           ≡⟨ D.insertl (α .Isoⁿ.invl ηₚ _) ⟩
+    α .Isoⁿ.to .η _ D.∘ α .Isoⁿ.from .η _ D.∘ G .F₁ f ≡⟨ D.refl⟩∘⟨ α .Isoⁿ.from .is-natural _ _ _ ⟩
+    α .Isoⁿ.to .η _ D.∘ F .F₁ f D.∘ α .Isoⁿ.from .η _ ≡⟨ D.refl⟩∘⟨ p D.⟩∘⟨refl ⟩
+    α .Isoⁿ.to .η _ D.∘ F .F₁ g D.∘ α .Isoⁿ.from .η _ ≡˘⟨ D.refl⟩∘⟨ α .Isoⁿ.from .is-natural _ _ _ ⟩
+    α .Isoⁿ.to .η _ D.∘ α .Isoⁿ.from .η _ D.∘ G .F₁ g ≡⟨ D.cancell (α .Isoⁿ.invl ηₚ _) ⟩
+    G .F₁ g                                           ∎
 ```
 -->
 

--- a/src/Cat/Functor/Naturality.lagda.md
+++ b/src/Cat/Functor/Naturality.lagda.md
@@ -11,7 +11,7 @@ import Cat.Reasoning
 module Cat.Functor.Naturality where
 ```
 
-# Working with natural transformations
+# Working with natural transformations {defines="natural-isomorphism"}
 
 Working with natural transformations can often be more cumbersome than
 working directly with the underlying families of morphisms; moreover, we
@@ -33,7 +33,8 @@ module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} where
 -->
 
 We'll refer to the natural-transformation versions of predicates on
-morphisms by a superscript `ⁿ`:
+morphisms by a superscript `ⁿ`. A **natural isomorphism** is simply an
+isomorphism in a functor category.
 
 ```agda
   Inversesⁿ : {F G : Functor C D} → F => G → G => F → Type _

--- a/src/Cat/Functor/Properties.lagda.md
+++ b/src/Cat/Functor/Properties.lagda.md
@@ -207,7 +207,7 @@ module _ {C : Precategory o h} {D : Precategory o₁ h₁} where
 
   is-ff→F-map-iso-is-equiv
     : {F : Functor C D} → is-fully-faithful F
-    → ∀ {X Y} → is-equiv (F-map-iso {x = X} {Y} F)
+    → ∀ {X Y} → is-equiv (F-map-iso F {x = X} {Y})
   is-ff→F-map-iso-is-equiv {F = F} ff = is-iso→is-equiv isom where
     isom : is-iso _
     isom .is-iso.inv    = is-ff→essentially-injective {F = F} ff

--- a/src/Cat/Functor/Reasoning.lagda.md
+++ b/src/Cat/Functor/Reasoning.lagda.md
@@ -4,6 +4,7 @@ open import 1Lab.Path
 
 open import Cat.Base
 
+import Cat.Functor.Base
 import Cat.Reasoning
 ```
 -->
@@ -19,13 +20,14 @@ private
   module 𝒞 = Cat.Reasoning 𝒞
   module 𝒟 = Cat.Reasoning 𝒟
 open Functor F public
+open Cat.Functor.Base.F-iso F public
 ```
 
 <!--
 ```agda
 private variable
   A B C : 𝒞.Ob
-  a b c d : 𝒞.Hom A B
+  a a' b b' c c' d : 𝒞.Hom A B
   X Y Z : 𝒟.Ob
   f g h i : 𝒟.Hom X Y
 ```
@@ -75,6 +77,13 @@ module _ (ab≡c : a 𝒞.∘ b ≡ c) where
   pullr : (f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b ≡ f 𝒟.∘ F₁ c
   pullr = 𝒟.pullr collapse
 
+module _ (abc≡d : a 𝒞.∘ b 𝒞.∘ c ≡ d) where
+  collapse3 : F₁ a 𝒟.∘ F₁ b 𝒟.∘ F₁ c ≡ F₁ d
+  collapse3 = ap (F₁ a 𝒟.∘_) (sym (F-∘ b c)) ∙ collapse abc≡d
+
+  pulll3 : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ (F₁ c 𝒟.∘ f)) ≡ F₁ d 𝒟.∘ f
+  pulll3 = 𝒟.pulll3 collapse3
+
 module _ (c≡ab : c ≡ a 𝒞.∘ b) where
   expand : F₁ c ≡ F₁ a 𝒟.∘ F₁ b
   expand = sym (collapse (sym c≡ab))
@@ -98,6 +107,13 @@ module _ (p : a 𝒞.∘ c ≡ b 𝒞.∘ d) where
   extend-inner :
     f 𝒟.∘ F₁ a 𝒟.∘ F₁ c 𝒟.∘ g ≡ f 𝒟.∘ F₁ b 𝒟.∘ F₁ d 𝒟.∘ g
   extend-inner = 𝒟.extend-inner weave
+
+module _ (p : a 𝒞.∘ b 𝒞.∘ c ≡ a' 𝒞.∘ b' 𝒞.∘ c') where
+  weave3 : F₁ a 𝒟.∘ F₁ b 𝒟.∘ F₁ c ≡ F₁ a' 𝒟.∘ F₁ b' 𝒟.∘ F₁ c'
+  weave3 = ap (_ 𝒟.∘_) (sym (F-∘ b c)) ·· weave p ·· ap (_ 𝒟.∘_) (F-∘ b' c')
+
+  extendl3 : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ (F₁ c 𝒟.∘ f)) ≡ F₁ a' 𝒟.∘ (F₁ b' 𝒟.∘ (F₁ c' 𝒟.∘ f))
+  extendl3 = 𝒟.extendl3 weave3
 
 module _ (p : F₁ a 𝒟.∘ F₁ c ≡ F₁ b 𝒟.∘ F₁ d) where
   swap : F₁ (a 𝒞.∘ c) ≡ F₁ (b 𝒞.∘ d)

--- a/src/Cat/Functor/Reasoning/FullyFaithful.lagda.md
+++ b/src/Cat/Functor/Reasoning/FullyFaithful.lagda.md
@@ -1,7 +1,6 @@
 <!--
 ```agda
 open import Cat.Functor.Properties
-open import Cat.Functor.Base
 open import Cat.Prelude hiding (injective)
 
 import Cat.Functor.Reasoning as Fr
@@ -43,10 +42,10 @@ module _ {a} {b} where
   open Equiv (F₁ {a} {b} , ff) public
 
 iso-equiv : ∀ {a b} → (a C.≅ b) ≃ (F₀ a D.≅ F₀ b)
-iso-equiv {a} {b} = (F-map-iso {x = a} {b} F , is-ff→F-map-iso-is-equiv {F = F} ff)
+iso-equiv {a} {b} = (F-map-iso {x = a} {b} , is-ff→F-map-iso-is-equiv {F = F} ff)
 
 module iso {a} {b} =
-  Equiv (F-map-iso {x = a} {b} F , is-ff→F-map-iso-is-equiv {F = F} ff)
+  Equiv (F-map-iso {x = a} {b} , is-ff→F-map-iso-is-equiv {F = F} ff)
 ```
 -->
 

--- a/src/Cat/Instances/Comma/Univalent.lagda.md
+++ b/src/Cat/Instances/Comma/Univalent.lagda.md
@@ -94,8 +94,8 @@ an identification $o \equiv o'$.
       lemma' : PathP (λ i → X.Hom (F.₀ (objs i .x)) (G.₀ (objs i .y)))
                 (ob .map) (ob' .map)
       lemma' = transport
-        (λ i → PathP (λ j → X.Hom (F-map-path yuniv xuniv F x-is-x (~ i) j)
-                                  (F-map-path zuniv xuniv G y-is-y (~ i) j))
+        (λ i → PathP (λ j → X.Hom (F-map-path F yuniv xuniv x-is-x (~ i) j)
+                                  (F-map-path G zuniv xuniv y-is-y (~ i) j))
                     (ob .map) (ob' .map)) $
         Univalent.Hom-pathp-iso xuniv $
           X.pulll   (sym (isom.to .sq)) ∙

--- a/src/Cat/Monoidal/Base.lagda.md
+++ b/src/Cat/Monoidal/Base.lagda.md
@@ -263,6 +263,12 @@ to be sufficient to derive all the desired coherence in a monoidal
 category, this is not exactly trivial. We prove a few basic identities
 that follow from the axioms.
 
+::: source
+The proofs in this section are from Kelly [-@Kelly:coherence], but the
+visualisation as a triangular prism takes inspiration from the previous
+formalisation in [`agda-categories`](https://agda.github.io/agda-categories/Categories.Category.Monoidal.Properties.html).
+:::
+
 First, we will show that the two ways of going $1 \otimes A \otimes B
 \to A \otimes B$ (using the unitor on $A$ or on $A \otimes B$) are coherent.
 We do this by pasting isomorphisms together to form a triangular prism

--- a/src/Cat/Monoidal/Base.lagda.md
+++ b/src/Cat/Monoidal/Base.lagda.md
@@ -6,6 +6,7 @@ open import Cat.Bi.Base
 open import Cat.Prelude
 
 import Cat.Functor.Bifunctor as Bifunctor
+import Cat.Functor.Reasoning as Fr
 import Cat.Reasoning as Cr
 ```
 -->
@@ -59,6 +60,8 @@ respectively.
 
   _⊗₁_ : ∀ {w x y z} → Hom w x → Hom y z → Hom (w ⊗ y) (x ⊗ z)
   f ⊗₁ g = -⊗- .Functor.F₁ (f , g)
+
+  infixr 25 _⊗_
 ```
 -->
 
@@ -101,11 +104,18 @@ $\lambda$) are the **right unitor** (resp. **left unitor**).
   ρ→ : ∀ {X} → Hom X (X ⊗ Unit)
   ρ→ = unitor-r .Cr._≅_.to .η _
 
+  α≅ : ∀ {A B C} → (A ⊗ B) ⊗ C ≅ A ⊗ (B ⊗ C)
+  α≅ = isoⁿ→iso associator _
+
   α→ : ∀ A B C → Hom ((A ⊗ B) ⊗ C) (A ⊗ (B ⊗ C))
   α→ _ _ _ = associator .Cr._≅_.to .η _
 
   α← : ∀ A B C → Hom (A ⊗ (B ⊗ C)) ((A ⊗ B) ⊗ C)
   α← _ _ _ = associator .Cr._≅_.from .η _
+
+  module ⊗ = Fr -⊗-
+  module ▶ {A} = Fr (-⊗-.Right A)
+  module ◀ {A} = Fr (-⊗-.Left A)
 
   -- whiskering on the right
   _▶_ : ∀ A {B C} (g : Hom B C) → Hom (A ⊗ B) (A ⊗ C)

--- a/src/Cat/Monoidal/Braided.lagda.md
+++ b/src/Cat/Monoidal/Braided.lagda.md
@@ -1,0 +1,337 @@
+<!--
+```agda
+open import Cat.Functor.Naturality
+open import Cat.Functor.Bifunctor
+open import Cat.Monoidal.Base
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Reasoning
+
+open _=>_
+```
+-->
+
+```agda
+module Cat.Monoidal.Braided {o ℓ}
+  {C : Precategory o ℓ} (C-monoidal : Monoidal-category C)
+  where
+```
+
+# Braided and symmetric monoidal categories {defines="braided-monoidal-category braiding symmetric-monoidal-category"}
+
+<!--
+```agda
+open Cat.Reasoning C
+open Monoidal C-monoidal
+```
+-->
+
+A **braided monoidal category** is a [[monoidal category]] equipped with
+a *braiding*: a [[natural isomorphism]] $\beta : A \otimes B \cong B
+\otimes A$ satisfying some coherence conditions explained below.
+
+```agda
+record Braided-monoidal : Type (o ⊔ ℓ) where
+  field
+    braiding : -⊗- ≅ⁿ Flip -⊗-
+```
+
+<!--
+```agda
+  module β→ = _=>_ (braiding .Isoⁿ.to)
+  module β← = _=>_ (braiding .Isoⁿ.from)
+
+  β→ : ∀ {A B} → Hom (A ⊗ B) (B ⊗ A)
+  β→ = braiding .Isoⁿ.to ._=>_.η _
+
+  β← : ∀ {A B} → Hom (A ⊗ B) (B ⊗ A)
+  β← = braiding .Isoⁿ.from ._=>_.η _
+
+  β≅ : ∀ {A B} → A ⊗ B ≅ B ⊗ A
+  β≅ = isoⁿ→iso braiding _
+```
+-->
+
+The name "braiding" is meant to suggest that flipping $A \otimes B$
+twice in the same direction is not necessarily trivial, which we may
+represent using *braid diagrams* like this one:
+
+~~~{.quiver}
+\begin{tikzpicture}[
+  braid/.cd,
+  gap=.15,
+  every strand/.style={ultra thick},
+  strand 1/.style={cyan},
+  strand 2/.style={magenta}
+]
+  \pic (braid) {braid={s_1^{-1} s_1^{-1}}};
+  \node[above,color=diagramfg,at=(braid-1-s)] {$A$};
+  \node[below,color=diagramfg,at=(braid-1-e)] {$A$};
+  \node[above,color=diagramfg,at=(braid-2-s)] {$B$};
+  \node[below,color=diagramfg,at=(braid-2-e)] {$B$};
+\end{tikzpicture}
+~~~
+
+The above diagram represents the morphism $\beta \circ \beta : A \otimes
+B \to A \otimes B$; if the braiding *is* symmetric in the sense that this
+morphism is an identity (that is, if we can "untangle" the braid above
+by pulling the strands through each other), then we have a **symmetric
+monoidal category**, and it does not matter which direction we braid in.
+
+Our definition of a braided *monoidal category* is not complete yet: we
+also require coherences saying that the braiding interacts nicely with
+the associator, in the sense that the following hexagon commutes:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  & {A \otimes (B \otimes C)} & {(B \otimes C) \otimes A} \\
+  {(A \otimes B) \otimes C} &&& {B \otimes (C \otimes A)} \\
+  & {(B \otimes A) \otimes C} & {B \otimes (A \otimes C)}
+  \arrow["{\beta \otimes C}"', from=2-1, to=3-2]
+  \arrow["\alpha"', from=3-2, to=3-3]
+  \arrow["{B \otimes \beta}"', from=3-3, to=2-4]
+  \arrow["\alpha", from=2-1, to=1-2]
+  \arrow["\beta", from=1-2, to=1-3]
+  \arrow["\alpha", from=1-3, to=2-4]
+\end{tikzcd}\]
+~~~
+
+```agda
+  field
+    braiding-α→ : ∀ {A B C}
+      → (id ⊗₁ β→) ∘ α→ B A C ∘ (β→ ⊗₁ id) ≡ α→ B C A ∘ β→ ∘ α→ A B C
+```
+
+If the braiding is symmetric, then we're done. However, in general we
+also need a *second* hexagon expressing the same condition with the
+"backwards" braiding (or, equivalently, with the braiding and the
+backwards associator), which might not be the same as the forward
+braiding.
+
+```agda
+  field
+    unbraiding-α→ : ∀ {A B C}
+      → (id ⊗₁ β←) ∘ α→ B A C ∘ (β← ⊗₁ id) ≡ α→ B C A ∘ β← ∘ α→ A B C
+```
+
+<!--
+```agda
+  β←-α← : ∀ {A B C}
+    → (β← ⊗₁ id) ∘ α← B A C ∘ (id ⊗₁ β←) ≡ α← A B C ∘ β← ∘ α← B C A
+  β←-α← = inverse-unique refl refl
+    (◀.F-map-iso β≅ ∘Iso α≅ ∘Iso ▶.F-map-iso β≅)
+    (α≅ ∘Iso β≅ ∘Iso α≅)
+    (sym (assoc _ _ _) ·· braiding-α→ ·· assoc _ _ _)
+```
+-->
+
+A symmetric monoidal category simply bundles up a braided monoidal
+category with the property that its braiding is symmetric.
+
+```agda
+is-symmetric-braiding : -⊗- ≅ⁿ Flip -⊗- → Type (o ⊔ ℓ)
+is-symmetric-braiding braiding = ∀ {A B} → β→ ∘ β→ {A} {B} ≡ id
+  where
+    β→ : ∀ {A B} → Hom (A ⊗ B) (B ⊗ A)
+    β→ = braiding .Isoⁿ.to ._=>_.η _
+
+record Symmetric-monoidal : Type (o ⊔ ℓ) where
+  field
+    has-is-braided : Braided-monoidal
+
+  open Braided-monoidal has-is-braided hiding (β≅) public
+
+  field
+    has-is-symmetric : is-symmetric-braiding braiding
+
+  β≅ : ∀ {A B} → A ⊗ B ≅ B ⊗ A
+  β≅ = make-iso β→ β→ has-is-symmetric has-is-symmetric
+```
+
+In order to *construct* a symmetric monoidal category, as we discussed
+above, it is sufficient to give one of the hexagons: the other one
+follows by uniqueness of inverses.
+
+```agda
+record make-symmetric-monoidal : Type (o ⊔ ℓ) where
+  field
+    has-braiding : -⊗- ≅ⁿ Flip -⊗-
+    symmetric : is-symmetric-braiding has-braiding
+```
+
+<!--
+```agda
+  β→ : ∀ {A B} → Hom (A ⊗ B) (B ⊗ A)
+  β→ = has-braiding .Isoⁿ.to ._=>_.η _
+  β← : ∀ {A B} → Hom (A ⊗ B) (B ⊗ A)
+  β← = has-braiding .Isoⁿ.from ._=>_.η _
+
+  β→≡β← : Path (∀ {A B} → Hom (A ⊗ B) (B ⊗ A)) β→ β←
+  β→≡β← = ext λ {_} {_} → inverse-unique refl refl
+    (make-iso β→ β→ symmetric symmetric)
+    (isoⁿ→iso has-braiding _)
+    refl
+
+  open Braided-monoidal hiding (β→)
+  open Symmetric-monoidal hiding (β→)
+```
+-->
+
+```agda
+  field
+    has-braiding-α→ : ∀ {A B C}
+      → (id ⊗₁ β→) ∘ α→ B A C ∘ (β→ ⊗₁ id) ≡ α→ B C A ∘ β→ ∘ α→ A B C
+
+  to-symmetric-monoidal : Symmetric-monoidal
+  to-symmetric-monoidal .has-is-braided .braiding = has-braiding
+  to-symmetric-monoidal .has-is-braided .braiding-α→ = has-braiding-α→
+  to-symmetric-monoidal .has-is-braided .unbraiding-α→ {A} {B} {C} =
+    subst (λ β → (id ⊗₁ β {_} {_}) ∘ α→ B A C ∘ (β {_} {_} ⊗₁ id) ≡ α→ _ _ _ ∘ β {_} {_} ∘ α→ _ _ _)
+      β→≡β← has-braiding-α→
+  to-symmetric-monoidal .has-is-symmetric = symmetric
+
+open make-symmetric-monoidal using (to-symmetric-monoidal) public
+```
+
+## Properties
+
+<!--
+```agda
+module Braided (C-braided : Braided-monoidal) where
+  open Braided-monoidal C-braided public
+```
+-->
+
+Just like with [[monoidal categories]], the two hexagons relating the
+braiding with the associator automatically give us a whole lot of extra
+coherence, but it still takes a bit of work.
+
+::: {.definition #yang-baxter-equation}
+We start by proving the **Yang-Baxter equation**, which says,
+pictorially, that the following two ways of going from $A \otimes B
+\otimes C$ to $C \otimes B \otimes A$ are the same:
+:::
+
+<div class="mathpar">
+
+~~~{.quiver}
+\begin{tikzpicture}[
+  braid/.cd,
+  gap=.15,
+  every strand/.style={ultra thick},
+  strand 1/.style={cyan},
+  strand 2/.style={diagramfg},
+  strand 3/.style={magenta}
+]
+  \pic (braid) {braid={s_1^{-1} s_2^{-1} s_1^{-1}}};
+  \node[above,color=diagramfg,at=(braid-1-s)] {$A$};
+  \node[below,color=diagramfg,at=(braid-1-e)] {$A$};
+  \node[above,color=diagramfg,at=(braid-2-s)] {$B$};
+  \node[below,color=diagramfg,at=(braid-2-e)] {$B$};
+  \node[above,color=diagramfg,at=(braid-3-s)] {$C$};
+  \node[below,color=diagramfg,at=(braid-3-e)] {$C$};
+\end{tikzpicture}
+~~~
+
+$\equiv$
+
+~~~{.quiver}
+\begin{tikzpicture}[
+  braid/.cd,
+  gap=.15,
+  every strand/.style={ultra thick},
+  strand 1/.style={cyan},
+  strand 2/.style={diagramfg},
+  strand 3/.style={magenta}
+]
+  \pic (braid) {braid={s_2^{-1} s_1^{-1} s_2^{-1}}};
+  \node[above,color=diagramfg,at=(braid-1-s)] {$A$};
+  \node[below,color=diagramfg,at=(braid-1-e)] {$A$};
+  \node[above,color=diagramfg,at=(braid-2-s)] {$B$};
+  \node[below,color=diagramfg,at=(braid-2-e)] {$B$};
+  \node[above,color=diagramfg,at=(braid-3-s)] {$C$};
+  \node[below,color=diagramfg,at=(braid-3-e)] {$C$};
+\end{tikzpicture}
+~~~
+
+</div>
+
+That is, morally, $(\id \otimes \beta) \circ (\beta \otimes \id) \circ
+(\id \otimes \beta) \equiv (\beta \otimes \id) \circ (\id \otimes \beta)
+\circ (\beta \otimes \id)$, except we have to insert associators
+*everywhere* in order for this equation to make sense.
+
+```agda
+  yang-baxter : ∀ {A B C}
+    → (id ⊗₁ β→) ∘ α→ C A B ∘ (β→ ⊗₁ id) ∘ α← A C B ∘ (id ⊗₁ β→) ∘ α→ A B C
+    ≡ α→ C B A ∘ (β→ ⊗₁ id) ∘ α← B C A ∘ (id ⊗₁ β→) ∘ α→ B A C ∘ (β→ ⊗₁ id)
+  yang-baxter =
+    (id ⊗₁ β→) ∘ α→ _ _ _ ∘ (β→ ⊗₁ id) ∘ α← _ _ _ ∘ (id ⊗₁ β→) ∘ α→ _ _ _   ≡⟨ pushr (pushr refl) ⟩
+    ((id ⊗₁ β→) ∘ α→ _ _ _ ∘ (β→ ⊗₁ id)) ∘ α← _ _ _ ∘ (id ⊗₁ β→) ∘ α→ _ _ _ ≡⟨ extendl (rswizzle (braiding-α→ ∙ assoc _ _ _) (α≅ .invl)) ⟩
+    α→ _ _ _ ∘ β→ ∘ (id ⊗₁ β→) ∘ α→ _ _ _                                   ≡⟨ refl⟩∘⟨ extendl (β→.is-natural _ _ _) ⟩
+    α→ _ _ _ ∘ (β→ ⊗₁ id) ∘ β→ ∘ α→ _ _ _                                   ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ lswizzle braiding-α→ (α≅ .invr) ⟩
+    α→ _ _ _ ∘ (β→ ⊗₁ id) ∘ α← _ _ _ ∘ (id ⊗₁ β→) ∘ α→ _ _ _ ∘ (β→ ⊗₁ id)   ∎
+```
+
+We also derive more equations relating the braiding with the associator.
+
+```agda
+  β←-β←⊗id-α← : ∀ {A B C} → β← ∘ (β← ⊗₁ id) ∘ α← A B C ≡ α→ C B A ∘ (β← ⊗₁ id) ∘ β←
+  β←-β←⊗id-α← =
+    β← ∘ (β← ⊗₁ id) ∘ α← _ _ _                     ≡⟨ refl⟩∘⟨ sym (swizzle (sym (assoc _ _ _) ∙ sym unbraiding-α→ ∙ assoc _ _ _) (α≅ .invl) (pullr (▶.cancell (β≅ .invl)) ∙ α≅ .invr)) ⟩
+    β← ∘ (α← _ _ _ ∘ (id ⊗₁ β→)) ∘ α→ _ _ _ ∘ β←   ≡⟨ pushr (pullr (pushr refl)) ⟩
+    (β← ∘ α← _ _ _) ∘ ((id ⊗₁ β→) ∘ α→ _ _ _) ∘ β← ≡⟨ extendl (sym (swizzle β←-α← (pullr (▶.cancell (β≅ .invr)) ∙ α≅ .invr) (α≅ .invl))) ⟩
+    α→ _ _ _ ∘ (β← ⊗₁ id) ∘ β←                     ∎
+
+  β→-id⊗β→-α→ : ∀ {A B C} → β→ ∘ (id ⊗₁ β→) ∘ α→ A B C ≡ α← _ _ _ ∘ β→ ∘ (β→ ⊗₁ id)
+  β→-id⊗β→-α→ =
+    β→ ∘ (id ⊗₁ β→) ∘ α→ _ _ _   ≡⟨ pulll (β→.is-natural _ _ _) ⟩
+    ((β→ ⊗₁ id) ∘ β→) ∘ α→ _ _ _ ≡⟨ swizzle (sym β←-β←⊗id-α← ∙ assoc _ _ _)
+      (pullr (cancell (β≅ .invr)) ∙ ◀.annihilate (β≅ .invr))
+      (pullr (cancell (β≅ .invl)) ∙ ◀.annihilate (β≅ .invl)) ⟩
+    α← _ _ _ ∘ β→ ∘ (β→ ⊗₁ id)   ∎
+```
+
+We can also show that the unitors are related to each other via the
+braiding, which requires a surprising amount of work.
+
+::: source
+These proofs are adapted from [`braiding-coherence⊗unit`][agda-cats] in
+the agda-categories library: see there for an explanation and diagram.
+:::
+
+[agda-cats]: https://agda.github.io/agda-categories/Categories.Category.Monoidal.Braided.Properties.html#braiding-coherence%E2%8A%97unit
+
+```agda
+  λ←-β→ : ∀ {A} → λ← {A} ∘ β→ ≡ ρ←
+  λ←-β→ = push-eqⁿ (unitor-r ni⁻¹) $
+    (λ← ∘ β→) ⊗₁ id                                ≡⟨ insertl (β≅ .invr) ⟩
+    β← ∘ β→ ∘ ((λ← ∘ β→) ⊗₁ id)                    ≡⟨ refl⟩∘⟨ refl⟩∘⟨ ◀.F-∘ _ _ ∙ (sym triangle-λ← ⟩∘⟨refl) ⟩
+    β← ∘ β→ ∘ (λ← ∘ α→ _ _ _) ∘ (β→ ⊗₁ id)         ≡⟨ refl⟩∘⟨ extendl (pulll (sym (unitor-l .Isoⁿ.from .is-natural _ _ _))) ⟩
+    β← ∘ (λ← ∘ (id ⊗₁ β→)) ∘ α→ _ _ _ ∘ (β→ ⊗₁ id) ≡⟨ refl⟩∘⟨ pullr braiding-α→ ⟩
+    β← ∘ λ← ∘ α→ _ _ _ ∘ β→ ∘ α→ _ _ _             ≡⟨ refl⟩∘⟨ pulll triangle-λ← ⟩
+    β← ∘ (λ← ⊗₁ id) ∘ β→ ∘ α→ _ _ _                ≡⟨ refl⟩∘⟨ extendl (sym (β→.is-natural _ _ _)) ⟩
+    β← ∘ β→ ∘ (id ⊗₁ λ←) ∘ α→ _ _ _                ≡⟨ refl⟩∘⟨ refl⟩∘⟨ triangle-α→ ⟩
+    β← ∘ β→ ∘ (ρ← ⊗₁ id)                           ≡⟨ cancell (β≅ .invr) ⟩
+    ρ← ⊗₁ id                                       ∎
+
+  λ←-β← : ∀ {A} → λ← {A} ∘ β← ≡ ρ←
+  λ←-β← = push-eqⁿ (unitor-r ni⁻¹) $
+    (λ← ∘ β←) ⊗₁ id                                ≡⟨ insertl (β≅ .invl) ⟩
+    β→ ∘ β← ∘ ((λ← ∘ β←) ⊗₁ id)                    ≡⟨ refl⟩∘⟨ refl⟩∘⟨ ◀.F-∘ _ _ ∙ (sym triangle-λ← ⟩∘⟨refl) ⟩
+    β→ ∘ β← ∘ (λ← ∘ α→ _ _ _) ∘ (β← ⊗₁ id)         ≡⟨ refl⟩∘⟨ extendl (pulll (sym (unitor-l .Isoⁿ.from .is-natural _ _ _))) ⟩
+    β→ ∘ (λ← ∘ (id ⊗₁ β←)) ∘ α→ _ _ _ ∘ (β← ⊗₁ id) ≡⟨ refl⟩∘⟨ pullr unbraiding-α→ ⟩
+    β→ ∘ λ← ∘ α→ _ _ _ ∘ β← ∘ α→ _ _ _             ≡⟨ refl⟩∘⟨ pulll triangle-λ← ⟩
+    β→ ∘ (λ← ⊗₁ id) ∘ β← ∘ α→ _ _ _                ≡⟨ refl⟩∘⟨ extendl (sym (β←.is-natural _ _ _)) ⟩
+    β→ ∘ β← ∘ (id ⊗₁ λ←) ∘ α→ _ _ _                ≡⟨ refl⟩∘⟨ refl⟩∘⟨ triangle-α→ ⟩
+    β→ ∘ β← ∘ (ρ← ⊗₁ id)                           ≡⟨ cancell (β≅ .invl) ⟩
+    ρ← ⊗₁ id                                       ∎
+
+  ρ←-β← : ∀ {A} → ρ← {A} ∘ β← ≡ λ←
+  ρ←-β← = rswizzle (sym λ←-β→) (β≅ .invl)
+
+  ρ←-β→ : ∀ {A} → ρ← {A} ∘ β→ ≡ λ←
+  ρ←-β→ = rswizzle (sym λ←-β←) (β≅ .invr)
+```

--- a/src/Cat/Monoidal/Diagonals.lagda.md
+++ b/src/Cat/Monoidal/Diagonals.lagda.md
@@ -1,0 +1,51 @@
+<!--
+```agda
+open import Cat.Instances.Product
+open import Cat.Monoidal.Base
+open import Cat.Prelude
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Monoidal.Diagonals {o ℓ}
+  {C : Precategory o ℓ} (C-monoidal : Monoidal-category C)
+  where
+```
+
+# Monoidal categories with diagonals {defines="monoidal-category-with-diagonals"}
+
+<!--
+```agda
+open Cat.Reasoning C
+open Monoidal C-monoidal
+
+_ = λ≡ρ
+```
+-->
+
+A [[monoidal category]] can be equipped with a system of *diagonal
+morphisms* $\delta_A : A \to A \otimes A$. Of course, such a system
+should be natural in $A$; another sensible thing to require is that the
+diagonal $1 \to 1 \otimes 1$ agree with the left (`hence`{.Agda ident=λ≡ρ}
+also right) unitor.
+
+We call the resulting structure a **monoidal category with diagonals**.
+
+```agda
+record Diagonals : Type (o ⊔ ℓ) where
+  field
+    diagonals : Id => -⊗- F∘ Cat⟨ Id , Id ⟩
+
+  module δ = _=>_ diagonals
+
+  δ : ∀ {A} → Hom A (A ⊗ A)
+  δ = δ.η _
+
+  field
+    diagonal-λ→ : δ {Unit} ≡ λ→ {Unit}
+```
+
+The prototypical examples of monoidal categories with diagonals are
+[[cartesian monoidal categories]].

--- a/src/Cat/Monoidal/Diagram/Monoid.lagda.md
+++ b/src/Cat/Monoidal/Diagram/Monoid.lagda.md
@@ -3,9 +3,9 @@
 {-# OPTIONS --lossy-unification -vtc.decl:5 #-}
 open import Cat.Monoidal.Instances.Cartesian
 open import Cat.Displayed.Univalence.Thin
-open import Cat.Instances.Sets.Complete
 open import Cat.Displayed.Functor
 open import Cat.Bi.Diagram.Monad
+open import Cat.Monoidal.Functor
 open import Cat.Displayed.Base
 open import Cat.Displayed.Path
 open import Cat.Monoidal.Base
@@ -15,6 +15,7 @@ open import Cat.Prelude
 import Algebra.Monoid.Category as Mon
 import Algebra.Monoid as Mon
 
+import Cat.Functor.Reasoning
 import Cat.Diagram.Monad as Mo
 import Cat.Reasoning
 ```
@@ -231,9 +232,6 @@ module _ {o ℓ} {C : Precategory o ℓ} {M : Monoidal-category C} where
     H-Level-is-monoid-hom = prop-instance (Iso→is-hlevel 1 eqv hlevel!)
 
 private
-  Setsₓ : ∀ {ℓ} → Monoidal-category (Sets ℓ)
-  Setsₓ = Cartesian-monoidal Sets-products Sets-terminal
-
   Mon : ∀ {ℓ} → Displayed (Sets ℓ) _ _
   Mon = Thin-structure-over (Mon.Monoid-structure _)
 ```
@@ -259,7 +257,8 @@ Mon[Sets]≡Mon {ℓ} = Displayed-path F (λ a → is-iso→is-equiv (fiso a)) f
 ```
 
 The construction proceeds in three steps: First, put together a functor
-(displayed over the identity) $\rm{Mon}(\cC) \to \thecat{Mon}$; Then,
+([[displayed over|displayed functor]] the identity) $\rm{Mon}(\cC) \to
+\thecat{Mon}$; Then,
 prove that its action on objects ("step 2") and action on morphisms
 ("step 3") are independently equivalences of types. The characterisation
 of paths of displayed categories will take care of turning this data
@@ -299,4 +298,129 @@ into an identification.
     invs : Mon.Monoid-hom (F .F₀' a') (F .F₀' b') f → is-monoid-hom Setsₓ f a' b'
     invs m .pres-η = funext λ _ → m .pres-id
     invs m .pres-μ = funext λ _ → m .pres-⋆ _ _
+```
+
+## Monoidal functors preserve monoids
+
+<!--
+```agda
+module _ {oc ℓc od ℓd}
+  {C : Precategory oc ℓc} {D : Precategory od ℓd}
+  {MC : Monoidal-category C} {MD : Monoidal-category D}
+  ((F , MF) : Lax-monoidal-functor MC MD)
+  where
+  private module C where
+    open Cat.Reasoning C public
+    open Monoidal-category MC public
+  open Cat.Reasoning D
+  open Monoidal-category MD
+
+  open Functor F
+  private module F = Cat.Functor.Reasoning F
+  open Lax-monoidal-functor-on MF
+
+  open Displayed-functor
+  open Monoid-on
+  open is-monoid-hom
+```
+-->
+
+If $F$ is a [[lax monoidal functor]] between monoidal categories $\cC$
+and $\cD$, and $M$ is a monoid in $\cC$, then $FM$ can be equipped with
+the structure of a monoid in $\cC$.
+
+We can phrase this nicely as a [[displayed functor]] $\rm{Mon}_1(F) :
+\rm{Mon}(\cC) \to \rm{Mon}(\cD)$ over $F$:
+
+```agda
+  Mon₁[_] : Displayed-functor Mon[ MC ] Mon[ MD ] F
+  Mon₁[_] .F₀' m .η = F₁ (m .η) ∘ ε
+  Mon₁[_] .F₀' m .μ = F₁ (m .μ) ∘ φ
+```
+
+The unit laws are witnessed by the commutativity of this diagram:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {1\otimes FX} && FX && {FX \otimes 1} \\
+  & {F(1\otimes X)} & {F(X\otimes X)} & {F(X \otimes 1)} \\
+  {F1\otimes FX} && {FX \otimes FX} && {FX \otimes F1}
+  \arrow["{\epsilon\otimes FX}"', from=1-1, to=3-1]
+  \arrow["\lambda", from=1-1, to=1-3]
+  \arrow["{F\eta\otimes FX}"', from=3-1, to=3-3]
+  \arrow["\varphi"{description}, from=3-3, to=2-3]
+  \arrow["F\mu"{description}, from=2-3, to=1-3]
+  \arrow["\varphi", from=3-1, to=2-2]
+  \arrow["{F(\eta\otimes X)}"', from=2-2, to=2-3]
+  \arrow["F\lambda", from=2-2, to=1-3]
+  \arrow["F\rho"', from=2-4, to=1-3]
+  \arrow["{F(X \otimes \eta)}", from=2-4, to=2-3]
+  \arrow["{FX \otimes F\eta}", from=3-5, to=3-3]
+  \arrow["\varphi"', from=3-5, to=2-4]
+  \arrow["{FX \otimes \epsilon}", from=1-5, to=3-5]
+  \arrow["\rho"', from=1-5, to=1-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+  Mon₁[_] .F₀' m .μ-unitl =
+    (F₁ (m .μ) ∘ φ) ∘ ((F₁ (m .η) ∘ ε) ⊗₁ id)          ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (Σ-pathp refl (F.introl refl))) ⟩
+    F₁ (m .μ) ∘ φ ∘ (F₁ (m .η) ⊗₁ F₁ C.id) ∘ (ε ⊗₁ id) ≡⟨ refl⟩∘⟨ extendl (φ.is-natural _ _ _) ⟩
+    F₁ (m .μ) ∘ F₁ (m .η C.⊗₁ C.id) ∘ φ ∘ (ε ⊗₁ id)    ≡⟨ F.pulll (m .μ-unitl) ⟩
+    F₁ C.λ← ∘ φ ∘ (ε ⊗₁ id)                            ≡⟨ F-λ← ⟩
+    λ←                                                 ∎
+  Mon₁[_] .F₀' m .μ-unitr =
+    (F₁ (m .μ) ∘ φ) ∘ (id ⊗₁ (F₁ (m .η) ∘ ε))          ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (Σ-pathp (F.introl refl) refl)) ⟩
+    F₁ (m .μ) ∘ φ ∘ (F₁ C.id ⊗₁ F₁ (m .η)) ∘ (id ⊗₁ ε) ≡⟨ refl⟩∘⟨ extendl (φ.is-natural _ _ _) ⟩
+    F₁ (m .μ) ∘ F₁ (C.id C.⊗₁ m .η) ∘ φ ∘ (id ⊗₁ ε)    ≡⟨ F.pulll (m .μ-unitr) ⟩
+    F₁ C.ρ← ∘ φ ∘ (id ⊗₁ ε)                            ≡⟨ F-ρ← ⟩
+    ρ←                                                 ∎
+```
+
+... and the associativity by this one.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {FX \otimes (FX \otimes FX)} & {FX \otimes F(X \otimes X)} & {FX \otimes FX} \\
+  & {F(X \otimes (X \otimes X))} & {F(X \otimes X)} \\
+  && FX \\
+  & {F((X \otimes X) \otimes X)} & {F(X \otimes X)} \\
+  {(FX \otimes FX) \otimes FX} & {F(X \otimes X) \otimes FX} & {FX \otimes FX}
+  \arrow["{FX \otimes \varphi}", from=1-1, to=1-2]
+  \arrow["{FX \otimes F\mu}", from=1-2, to=1-3]
+  \arrow["\varphi", from=1-3, to=2-3]
+  \arrow["F\mu", from=2-3, to=3-3]
+  \arrow["{\alpha^{-1}}"', from=1-1, to=5-1]
+  \arrow["{\varphi\otimes FX}"', from=5-1, to=5-2]
+  \arrow["{F\mu \otimes FX}"', from=5-2, to=5-3]
+  \arrow["\varphi"', from=5-3, to=4-3]
+  \arrow["F\mu"', from=4-3, to=3-3]
+  \arrow["\varphi"', from=1-2, to=2-2]
+  \arrow["\varphi", from=5-2, to=4-2]
+  \arrow["{F\alpha^{-1}}"', from=2-2, to=4-2]
+  \arrow["{F(X \otimes \mu)}", from=2-2, to=2-3]
+  \arrow["{F(\mu \otimes X)}"', from=4-2, to=4-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+  Mon₁[_] .F₀' m .μ-assoc =
+    (F₁ (m .μ) ∘ φ) ∘ (id ⊗₁ (F₁ (m .μ) ∘ φ))                       ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (Σ-pathp (F.introl refl) refl)) ⟩
+    F₁ (m .μ) ∘ φ ∘ (F₁ C.id ⊗₁ F₁ (m .μ)) ∘ (id ⊗₁ φ)              ≡⟨ (refl⟩∘⟨ extendl (φ.is-natural _ _ _)) ⟩
+    F₁ (m .μ) ∘ F₁ (C.id C.⊗₁ m .μ) ∘ φ ∘ (id ⊗₁ φ)                 ≡⟨ F.pulll (m .μ-assoc) ⟩
+    F₁ (m .μ C.∘ (m .μ C.⊗₁ C.id) C.∘ C.α← _ _ _) ∘ φ ∘ (id ⊗₁ φ)   ≡⟨ F.popr (F.popr F-α←) ⟩
+    F₁ (m .μ) ∘ F₁ (m .μ C.⊗₁ C.id) ∘ φ ∘ (φ ⊗₁ id) ∘ α← _ _ _      ≡˘⟨ pullr (extendl (φ.is-natural _ _ _)) ⟩
+    (F₁ (m .μ) ∘ φ) ∘ (F₁ (m .μ) ⊗₁ F₁ C.id) ∘ (φ ⊗₁ id) ∘ α← _ _ _ ≡⟨ refl⟩∘⟨ ⊗.pulll (Σ-pathp refl (F.eliml refl)) ⟩
+    (F₁ (m .μ) ∘ φ) ∘ ((F₁ (m .μ) ∘ φ) ⊗₁ id) ∘ α← _ _ _            ∎
+```
+
+Functoriality for $\rm{Mon}_1(-)$ means that, given a monoid homomorphism
+$f : M \to N$, the map $Ff : FM \to FN$ is a monoid homomorphism
+between the induced monoids on $FM$ and $FN$.
+
+```agda
+  Mon₁[_] .F₁' h .pres-η = F.pulll (h .pres-η)
+  Mon₁[_] .F₁' h .pres-μ = F.extendl (h .pres-μ) ∙ pushr (sym (φ.is-natural _ _ _))
+  Mon₁[_] .F-id' = prop!
+  Mon₁[_] .F-∘' = prop!
 ```

--- a/src/Cat/Monoidal/Functor.lagda.md
+++ b/src/Cat/Monoidal/Functor.lagda.md
@@ -1,0 +1,268 @@
+<!--
+```agda
+open import Cat.Functor.Naturality
+open import Cat.Monoidal.Diagonals
+open import Cat.Instances.Product
+open import Cat.Monoidal.Braided
+open import Cat.Monoidal.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Monoidal.Functor {oc ℓc od ℓd}
+  {C : Precategory oc ℓc} (C-monoidal : Monoidal-category C)
+  {D : Precategory od ℓd} (D-monoidal : Monoidal-category D)
+  where
+```
+
+# Monoidal functors {defines="monoidal-functor lax-monoidal-functor oplax-monoidal-functor"}
+
+<!--
+```agda
+open Cat.Reasoning D
+
+private
+  module C = Monoidal-category C-monoidal
+  module D = Monoidal-category D-monoidal
+```
+-->
+
+Categorifying the fact that a morphism between [[monoids]] is expected
+to preserve the unit and multiplication, a [[functor]] between [[monoidal
+categories]] should come *equipped* with [[natural isomorphisms]]
+
+$$
+\begin{align*}
+FA \otimes FB &\cong F(A \otimes B) \\
+1 &\cong F1
+\end{align*}
+$$
+
+witnessing that it preserves the tensor product and unit.
+
+However, just like for [[lax functors]] between [[bicategories]], we have
+the option of requiring only a natural *transformation* in one direction
+or the other.
+If we choose the forward direction $FA \otimes FB \to F(A \otimes B)$,
+we obtain the notion of a **lax monoidal functor**; choosing the
+opposite direction instead would yield an **oplax monoidal functor**.
+
+We begin by defining the *structure* of a lax monoidal functor on a given
+functor $F$: this consists of the aforementioned morphisms, as well
+as some coherence conditions similar to the ones for a [[lax functor]].
+
+```agda
+record Lax-monoidal-functor-on (F : Functor C D) : Type (oc ⊔ ℓc ⊔ od ⊔ ℓd) where
+  private module F = Cat.Functor.Reasoning F
+
+  field
+    ε : Hom D.Unit (F.₀ C.Unit)
+    F-mult : D.-⊗- F∘ (F F× F) => F F∘ C.-⊗-
+
+  module φ = _=>_ F-mult
+
+  φ : ∀ {A B} → Hom (F.₀ A D.⊗ F.₀ B) (F.₀ (A C.⊗ B))
+  φ = φ.η _
+
+  field
+    F-α→ : ∀ {A B C}
+      → F.₁ (C.α→ A B C) ∘ φ ∘ (φ D.⊗₁ id) ≡ φ ∘ (id D.⊗₁ φ) ∘ D.α→ _ _ _
+    F-λ← : ∀ {A} → F.₁ (C.λ← {A}) ∘ φ ∘ (ε D.⊗₁ id) ≡ D.λ←
+    F-ρ← : ∀ {A} → F.₁ (C.ρ← {A}) ∘ φ ∘ (id D.⊗₁ ε) ≡ D.ρ←
+```
+
+<!--
+```agda
+  F-α← : ∀ {A B C}
+    → F.₁ (C.α← A B C) ∘ φ ∘ (id D.⊗₁ φ) ≡ φ ∘ (φ D.⊗₁ id) ∘ D.α← _ _ _
+  F-α← = swizzle (sym (F-α→ ∙ assoc _ _ _)) (D.α≅ .invl) (F.F-map-iso C.α≅ .invr)
+    ∙ sym (assoc _ _ _)
+```
+-->
+
+```agda
+Lax-monoidal-functor : Type (oc ⊔ ℓc ⊔ od ⊔ ℓd)
+Lax-monoidal-functor = Σ (Functor C D) Lax-monoidal-functor-on
+```
+
+A **monoidal functor**, or **strong monoidal functor**[^strong], is
+then simply a lax monoidal functor whose structure morphisms are
+[[invertible]].
+
+[^strong]: Not to be confused with a [[strong|strong functor]] monoidal
+functor, in the sense of a monoidal functor equipped with a [[strength]].
+
+```agda
+record Monoidal-functor-on (F : Functor C D) : Type (oc ⊔ ℓc ⊔ od ⊔ ℓd) where
+  field
+    lax : Lax-monoidal-functor-on F
+
+  open Lax-monoidal-functor-on lax public
+
+  field
+    ε-inv : is-invertible ε
+    F-mult-inv : is-invertibleⁿ F-mult
+
+Monoidal-functor : Type (oc ⊔ ℓc ⊔ od ⊔ ℓd)
+Monoidal-functor = Σ (Functor C D) Monoidal-functor-on
+```
+
+## Braided and symmetric monoidal functors {defines="braided-monoidal-functor symmetric-monoidal-functor"}
+
+A monoidal functor between [[braided monoidal categories]] can additionally
+preserve the braiding in the sense that the following diagram commutes,
+yielding the notion of a **braided monoidal functor**.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {FA \otimes FB} & {F(A \otimes B)} \\
+  {FB \otimes FA} & {F(B \otimes A)}
+  \arrow["\varphi", from=1-1, to=1-2]
+  \arrow["\beta"', from=1-1, to=2-1]
+  \arrow["\varphi"', from=2-1, to=2-2]
+  \arrow["F\beta", from=1-2, to=2-2]
+\end{tikzcd}\]
+~~~
+
+<!--
+```agda
+module _
+  (C-braided : Braided-monoidal C-monoidal)
+  (D-braided : Braided-monoidal D-monoidal)
+  where
+  module CB = Braided-monoidal C-braided
+  module DB = Braided-monoidal D-braided
+```
+-->
+
+```agda
+  is-braided-functor : Lax-monoidal-functor → Type (oc ⊔ ℓd)
+  is-braided-functor (F , lax) = ∀ {A B} → φ ∘ DB.β→ ≡ F.₁ CB.β→ ∘ φ {A} {B}
+    where
+      module F = Functor F
+      open Lax-monoidal-functor-on lax
+```
+
+A **symmetric monoidal functor** between [[symmetric monoidal categories]]
+is just a braided monoidal functor, since there is no extra structure to
+preserve.
+
+<!--
+```agda
+module _
+  (C-symmetric : Symmetric-monoidal C-monoidal)
+  (D-symmetric : Symmetric-monoidal D-monoidal)
+  where
+  module CS = Symmetric-monoidal C-symmetric
+  module DS = Symmetric-monoidal D-symmetric
+```
+-->
+
+```agda
+  is-symmetric-functor : Lax-monoidal-functor → Type (oc ⊔ ℓd)
+  is-symmetric-functor = is-braided-functor CS.has-is-braided DS.has-is-braided
+```
+
+## Diagonal monoidal functors {defines="diagonal-monoidal-functor idempotent-monoidal-functor"}
+
+If the source and target categories are equipped with [[diagonal
+morphisms|monoidal category with diagonals]], then a **diagonal
+monoidal functor**, or **idempotent monoidal functor** is a monoidal
+functor that makes the following diagram commute:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  FA \\
+  {FA \otimes FA} & {F(A \otimes A)}
+  \arrow["\delta"', from=1-1, to=2-1]
+  \arrow["\varphi"', from=2-1, to=2-2]
+  \arrow["F\delta", from=1-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+<!--
+```agda
+module _
+  (C-diagonal : Diagonals C-monoidal)
+  (D-diagonal : Diagonals D-monoidal)
+  where
+  module CD = Diagonals C-diagonal
+  module DD = Diagonals D-diagonal
+```
+-->
+
+```agda
+  is-diagonal-functor : Lax-monoidal-functor → Type (oc ⊔ ℓd)
+  is-diagonal-functor (F , lax) = ∀ {A} → φ ∘ DD.δ ≡ F.₁ (CD.δ {A})
+    where
+      module F = Functor F
+      open Lax-monoidal-functor-on lax
+```
+
+The "idempotent" terminology comes from the semantics of programming
+languages, where lax monoidal functors are used to model certain kinds
+of effectful computations, as a "static" alternative to [[monads]].
+In that setting, an idempotent monoidal functor (or "idempotent
+applicative functor") represents an effect that can be executed
+multiple times with the same effect as executing it once: for example,
+reading from an immutable data source or throwing an exception.
+
+# Monoidal natural transformations {defines="monoidal-natural-transformation"}
+
+The notion of [[natural transformation]] between functors can also be
+refined in the case of monoidal functors: a **monoidal natural
+transformation** $\alpha : F \To G$ is one such that the following
+diagrams commute.
+
+<div class="mathpar">
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {FA \otimes FB} & {GA \otimes GB} \\
+  {F(A \otimes B)} & {G(A \otimes B)}
+  \arrow[from=1-1, to=2-1]
+  \arrow["{\alpha_A \otimes \alpha_B}", from=1-1, to=1-2]
+  \arrow[from=1-2, to=2-2]
+  \arrow["{\alpha_{A\otimes B}}"', from=2-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  1 \\
+  F1 & G1
+  \arrow[from=1-1, to=2-1]
+  \arrow["{\alpha_1}"', from=2-1, to=2-2]
+  \arrow[from=1-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+</div>
+
+<!--
+```agda
+module _ ((F , F-monoidal) (G , G-monoidal) : Lax-monoidal-functor) where
+  module FM = Lax-monoidal-functor-on F-monoidal
+  module GM = Lax-monoidal-functor-on G-monoidal
+  open _=>_
+```
+-->
+
+```agda
+  record is-monoidal-transformation (α : F => G) : Type (oc ⊔ ℓc ⊔ ℓd) where
+    field
+      nat-ε : α .η C.Unit ∘ FM.ε ≡ GM.ε
+      nat-φ : ∀ {A B} → α .η _ ∘ FM.φ {A} {B} ≡ GM.φ ∘ (α .η _ D.⊗₁ α .η _)
+```
+
+Note that, since monoidal categories can be thought of as one-object
+[[bicategories]], we may expect to also have [[modifications]] between
+monoidal natural transformations, but this is not the case: the
+categorical ladder ends here. This is analogous to the fact that
+[[monoids]] only form a category and not a bicategory, even when
+viewed as one-object categories: there simply aren't enough objects
+to have interesting 3-cells (resp. 2-cells)!

--- a/src/Cat/Monoidal/Instances/Cartesian.lagda.md
+++ b/src/Cat/Monoidal/Instances/Cartesian.lagda.md
@@ -1,8 +1,11 @@
 <!--
 ```agda
+open import Cat.Instances.Sets.Complete
 open import Cat.Diagram.Product.Solver
+open import Cat.Monoidal.Diagonals
 open import Cat.Instances.Functor
 open import Cat.Diagram.Terminal
+open import Cat.Monoidal.Braided
 open import Cat.Monoidal.Base
 open import Cat.Prelude
 
@@ -15,36 +18,39 @@ import Cat.Reasoning as Cr
 module Cat.Monoidal.Instances.Cartesian where
 ```
 
-# Cartesian monoidal categories
+# Cartesian monoidal categories {defines="cartesian-monoidal-category"}
 
-Unlike with [categories] and [bicategories], there is no handy example
-of [monoidal category] that is as canonical as how the collection of all
+Unlike with [[categories]] and [[bicategories]], there is no handy example
+of [[monoidal category]] that is as canonical as how the collection of all
 $n$-categories is an $(n+1)$-category. However, we do have _a_ certain
-canonical pool of examples to draw from: all the _Cartesian monoidal
-categories_, also known as _finite-products categories_.
+canonical pool of examples to draw from: all the **Cartesian monoidal
+categories**, also known as _finite-products categories_.
 
-[categories]: Cat.Base.html
-[bicategories]: Cat.Bi.Base.html
-[monoidal category]: Cat.Monoidal.Base.html
+```agda
+module _
+  {o ℓ} {C : Precategory o ℓ}
+  (open Cat.Diagram.Product C)
+  (prods : ∀ A B → Product A B) (term : Terminal C)
+  where
+```
 
 <!--
 ```agda
-module _ {o ℓ} {C : Precategory o ℓ} where
-  open Cat.Diagram.Product C
-  open Monoidal-category
+  open Monoidal-category hiding (_⊗₁_)
+  open Braided-monoidal
+  open Symmetric-monoidal
+  open Diagonals hiding (δ)
   open make-natural-iso
   open Cr C
+  open Binary-products prods
+  open Terminal term
 ```
 -->
 
 ```agda
-  Cartesian-monoidal : (∀ A B → Product A B) → Terminal C → Monoidal-category C
-  Cartesian-monoidal prods term = mon where
-    open Binary-products prods
-    open Terminal term
-    mon : Monoidal-category C
-    mon .-⊗- = ×-functor
-    mon .Unit = top
+  Cartesian-monoidal : Monoidal-category C
+  Cartesian-monoidal .-⊗- = ×-functor
+  Cartesian-monoidal .Unit = top
 ```
 
 There's nothing much to say about this result: It's pretty much just
@@ -55,46 +61,87 @@ by the properties of limits. Translating this intuitive explanation to a
 formal proof requires a _lot_ of calculation, however:
 
 ```agda
-    mon .unitor-l = to-natural-iso ni where
-      ni : make-natural-iso _ _
-      ni .eta x = ⟨ ! , id ⟩
-      ni .inv x = π₂
-      ni .eta∘inv x = Product.unique₂ (prods _ _)
-        (pulll π₁∘⟨⟩ ∙ sym (!-unique _)) (cancell π₂∘⟨⟩) (!-unique₂ _ _) (idr _)
-      ni .inv∘eta x = π₂∘⟨⟩
-      ni .natural x y f = Product.unique₂ (prods _ _)
-        (pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ cancelr π₂∘⟨⟩)
-        (!-unique₂ _ _) (pulll π₂∘⟨⟩ ∙ idl f)
-    mon .unitor-r = to-natural-iso ni where
-      ni : make-natural-iso _ _
-      ni .eta x = ⟨ id , ! ⟩
-      ni .inv x = π₁
-      ni .eta∘inv x = Product.unique₂ (prods _ _)
-        (pulll π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ sym (!-unique _))
-        (idr _) (sym (!-unique _))
-      ni .inv∘eta x = π₁∘⟨⟩
-      ni .natural x y f = Product.unique₂ (prods _ _)
-        (pulll π₁∘⟨⟩ ·· pullr π₁∘⟨⟩ ·· idr f)
-        (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· idl !)
-        (pulll π₁∘⟨⟩ ∙ idl f)
-        (!-unique₂ _ _)
-    mon .associator = to-natural-iso ni where
-      ni : make-natural-iso _ _
-      ni .eta x = ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩
-      ni .inv x = ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩
-      ni .eta∘inv x =
-        ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ≡⟨ products! C prods ⟩
-        id ∎
-      ni .inv∘eta x =
-        ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ≡⟨ products! C prods ⟩
-        id ∎
-      ni .natural x y f =
-        ⟨ f .fst ∘ π₁ , ⟨ f .snd .fst ∘ π₁ , f .snd .snd ∘ π₂ ⟩ ∘ π₂ ⟩ ∘ ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩     ≡⟨ products! C prods ⟩
-        ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ∘ ⟨ (⟨ f .fst ∘ π₁ , f .snd .fst ∘ π₂ ⟩ ∘ π₁) , (f .snd .snd ∘ π₂) ⟩ ∎
-    mon .triangle = Product.unique (prods _ _) _
-      (pulll π₁∘⟨⟩ ·· pullr π₁∘⟨⟩ ·· π₁∘⟨⟩ ∙ introl refl)
-      (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· idl _)
-    mon .pentagon =
-      ⟨ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ π₁ , id ∘ π₂ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ id ∘ π₁ , ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ π₂ ⟩ ≡⟨ products! C prods ⟩
-      ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∎
+  Cartesian-monoidal .unitor-l = to-natural-iso ni where
+    ni : make-natural-iso _ _
+    ni .eta x = ⟨ ! , id ⟩
+    ni .inv x = π₂
+    ni .eta∘inv x = Product.unique₂ (prods _ _)
+      (pulll π₁∘⟨⟩ ∙ sym (!-unique _)) (cancell π₂∘⟨⟩) (!-unique₂ _ _) (idr _)
+    ni .inv∘eta x = π₂∘⟨⟩
+    ni .natural x y f = Product.unique₂ (prods _ _)
+      (pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ cancelr π₂∘⟨⟩)
+      (!-unique₂ _ _) (pulll π₂∘⟨⟩ ∙ idl f)
+  Cartesian-monoidal .unitor-r = to-natural-iso ni where
+    ni : make-natural-iso _ _
+    ni .eta x = ⟨ id , ! ⟩
+    ni .inv x = π₁
+    ni .eta∘inv x = Product.unique₂ (prods _ _)
+      (pulll π₁∘⟨⟩ ∙ idl _) (pulll π₂∘⟨⟩ ∙ sym (!-unique _))
+      (idr _) (sym (!-unique _))
+    ni .inv∘eta x = π₁∘⟨⟩
+    ni .natural x y f = Product.unique₂ (prods _ _)
+      (pulll π₁∘⟨⟩ ·· pullr π₁∘⟨⟩ ·· idr f)
+      (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· idl !)
+      (pulll π₁∘⟨⟩ ∙ idl f)
+      (!-unique₂ _ _)
+  Cartesian-monoidal .associator = to-natural-iso ni where
+    ni : make-natural-iso _ _
+    ni .eta x = ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩
+    ni .inv x = ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩
+    ni .eta∘inv x =
+      ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ≡⟨ products! C prods ⟩
+      id ∎
+    ni .inv∘eta x =
+      ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ≡⟨ products! C prods ⟩
+      id ∎
+    ni .natural x y f =
+      ⟨ f .fst ∘ π₁ , ⟨ f .snd .fst ∘ π₁ , f .snd .snd ∘ π₂ ⟩ ∘ π₂ ⟩ ∘ ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩     ≡⟨ products! C prods ⟩
+      ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ∘ ⟨ (⟨ f .fst ∘ π₁ , f .snd .fst ∘ π₂ ⟩ ∘ π₁) , (f .snd .snd ∘ π₂) ⟩ ∎
+  Cartesian-monoidal .triangle = Product.unique (prods _ _) _
+    (pulll π₁∘⟨⟩ ·· pullr π₁∘⟨⟩ ·· π₁∘⟨⟩ ∙ introl refl)
+    (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· idl _)
+  Cartesian-monoidal .pentagon =
+    ⟨ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ π₁ , id ∘ π₂ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ id ∘ π₁ , ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ π₂ ⟩ ≡⟨ products! C prods ⟩
+    ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∎
 ```
+
+Cartesian monoidal categories also inherit a lot of additional structure
+from the categorical product. In particular, they are [[symmetric monoidal
+categories]].
+
+```agda
+  Cartesian-symmetric : Symmetric-monoidal Cartesian-monoidal
+  Cartesian-symmetric = to-symmetric-monoidal mk where
+    swap-natural
+      : ∀ {A B C D} ((f , g) : Hom A C × Hom B D)
+      → (g ⊗₁ f) ∘ swap ≡ swap ∘ (f ⊗₁ g)
+    swap-natural (f , g) =
+      (g ⊗₁ f) ∘ swap                       ≡⟨ ⟨⟩∘ _ ⟩
+      ⟨ (g ∘ π₁) ∘ swap , (f ∘ π₂) ∘ swap ⟩ ≡⟨ ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩) (pullr π₂∘⟨⟩) ⟩
+      ⟨ g ∘ π₂ , f ∘ π₁ ⟩                   ≡˘⟨ ap₂ ⟨_,_⟩ π₂∘⟨⟩ π₁∘⟨⟩ ⟩
+      ⟨ π₂ ∘ (f ⊗₁ g) , π₁ ∘ (f ⊗₁ g) ⟩     ≡˘⟨ ⟨⟩∘ _ ⟩
+      swap ∘ (f ⊗₁ g)                       ∎
+
+    open make-symmetric-monoidal
+    mk : make-symmetric-monoidal Cartesian-monoidal
+    mk .has-braiding = iso→isoⁿ
+      (λ _ → invertible→iso swap swap-is-iso) swap-natural
+    mk .symmetric = ⟨⟩∘ _ ∙ ap₂ ⟨_,_⟩ π₂∘⟨⟩ π₁∘⟨⟩ ∙ ⟨⟩-η
+    mk .has-braiding-α→ = products! C prods
+```
+
+We also have a system of [[diagonal morphisms|monoidal category with diagonals]]:
+
+```agda
+  Cartesian-diagonal : Diagonals Cartesian-monoidal
+  Cartesian-diagonal .diagonals ._=>_.η A = δ
+  Cartesian-diagonal .diagonals ._=>_.is-natural A B f = products! C prods
+  Cartesian-diagonal .diagonal-λ→ = ap ⟨_, id ⟩ (sym (!-unique _))
+```
+
+<!--
+```agda
+Setsₓ : ∀ {ℓ} → Monoidal-category (Sets ℓ)
+Setsₓ = Cartesian-monoidal Sets-products Sets-terminal
+```
+-->

--- a/src/Cat/Monoidal/Instances/Day.lagda.md
+++ b/src/Cat/Monoidal/Instances/Day.lagda.md
@@ -26,7 +26,6 @@ module Cat.Monoidal.Instances.Day
 <!--
 ```agda
 open Monoidal-category cmon
-private module ⊗ = Fr -⊗-
 
 open make-natural-iso
 open Cowedge

--- a/src/Cat/Monoidal/Reverse.lagda.md
+++ b/src/Cat/Monoidal/Reverse.lagda.md
@@ -1,0 +1,67 @@
+<!--
+```agda
+open import Cat.Functor.Naturality
+open import Cat.Functor.Bifunctor
+open import Cat.Functor.Coherence
+open import Cat.Monoidal.Base
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Reasoning
+
+open Monoidal-category
+```
+-->
+
+```agda
+module Cat.Monoidal.Reverse {o ℓ}
+  {C : Precategory o ℓ} (C-monoidal : Monoidal-category C)
+  where
+```
+
+<!--
+```agda
+open Cat.Reasoning C
+private module C = Monoidal-category C-monoidal
+open _=>_
+```
+-->
+
+# Reverse monoidal categories {defines="reverse-monoidal-category"}
+
+Given a [[monoidal category]] $\cC$ with tensor product $\otimes :
+\cC \times \cC \to \cC$, we can define the **reverse** monoidal category
+$\cC^\rm{rev}$ with the same unit and the tensor product flipped
+around: $A \otimes^\rm{rev} B = B \otimes A$.
+
+```agda
+_^rev : Monoidal-category C
+_^rev .-⊗- = Flip C.-⊗-
+_^rev .Unit = C.Unit
+```
+
+The coherence isomorphisms are straightforward to obtain from those of
+$\cC$: the left and right unitors are swapped, and the associator is
+reversed and has its arguments swapped.
+
+```agda
+_^rev .unitor-l = iso→isoⁿ (isoⁿ→iso C.unitor-r)
+  λ f → sym (C.unitor-r .Isoⁿ.to .is-natural _ _ f)
+_^rev .unitor-r = iso→isoⁿ (isoⁿ→iso C.unitor-l)
+  λ f → sym (C.unitor-l .Isoⁿ.to .is-natural _ _ f)
+_^rev .associator = iso→isoⁿ
+  (λ (a , b , c) → isoⁿ→iso (C.associator ni⁻¹) (c , b , a))
+  λ (f , g , h) → sym (C.associator .Isoⁿ.from .is-natural _ _ (h , g , f))
+_^rev .triangle = C.triangle-α→
+_^rev .pentagon = C.pentagon-α→
+```
+
+<!--
+```agda
+_ = Deloop
+```
+-->
+
+Thinking of monoidal categories as one-object [[bicategories]] (via the
+`Deloop`{.Agda}ing construction), the $-^\rm{rev}$ operation corresponds to
+flipping the 1-cells of a bicategory, leaving the 2-cells unchanged.

--- a/src/Cat/Monoidal/Strength.lagda.md
+++ b/src/Cat/Monoidal/Strength.lagda.md
@@ -1,0 +1,341 @@
+<!--
+```agda
+open import 1Lab.Reflection.Record
+
+open import Cat.Monoidal.Instances.Cartesian
+open import Cat.Functor.Naturality
+open import Cat.Instances.Product
+open import Cat.Monoidal.Braided
+open import Cat.Monoidal.Reverse
+open import Cat.Functor.Compose
+open import Cat.Monoidal.Base
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Reasoning
+
+open _=>_
+```
+-->
+
+```agda
+module Cat.Monoidal.Strength where
+```
+
+# Strong functors {defines="strong-functor strength left-strength right-strength"}
+
+<!--
+```agda
+module _
+  {o ℓ} {C : Precategory o ℓ}
+  (C-monoidal : Monoidal-category C)
+  (F : Functor C C)
+  where
+  open Cat.Reasoning C
+  open Monoidal-category C-monoidal
+  open Functor F
+  private module F = Cat.Functor.Reasoning F
+```
+-->
+
+A **left strength** for a [[functor]] $F : \cC \to \cC$ on a [[monoidal
+category]] $\cC$ is a [[natural transformation]]
+
+$$
+\sigma : A \otimes FB \to F (A \otimes B)
+$$
+
+interacting nicely with the left unitor and associator.
+
+```agda
+  record Left-strength : Type (o ⊔ ℓ) where
+    field
+      left-strength : -⊗- F∘ (Id F× F) => F F∘ -⊗-
+
+    module σ = _=>_ left-strength
+
+    σ : ∀ {A B} → Hom (A ⊗ F₀ B) (F₀ (A ⊗ B))
+    σ = σ.η _
+
+    field
+      left-strength-λ← : ∀ {A} → F₁ (λ← {A}) ∘ σ ≡ λ←
+      left-strength-α→ : ∀ {A B C}
+        → F₁ (α→ A B C) ∘ σ ≡ σ ∘ (id ⊗₁ σ) ∘ α→ A B (F₀ C)
+```
+
+Reversely^[That is, on the other side of the [[reverse monoidal
+category]] duality.], a **right strength** is a natural transformation
+
+$$
+\tau : FA \otimes B \to F (A \otimes B)
+$$
+
+interacting nicely with the *right* unitor and associator.
+
+```agda
+  record Right-strength : Type (o ⊔ ℓ) where
+    field
+      right-strength : -⊗- F∘ (F F× Id) => F F∘ -⊗-
+
+    module τ = _=>_ right-strength
+
+    τ : ∀ {A B} → Hom (F₀ A ⊗ B) (F₀ (A ⊗ B))
+    τ = τ.η _
+
+    field
+      right-strength-ρ← : ∀ {A} → F₁ (ρ← {A}) ∘ τ ≡ ρ←
+      right-strength-α← : ∀ {A B C}
+        → F₁ (α← A B C) ∘ τ ≡ τ ∘ (τ ⊗₁ id) ∘ α← (F₀ A) B C
+```
+
+<!--
+```agda
+    right-strength-α→ : ∀ {A B C} → τ ∘ α→ (F₀ A) B C ≡ F₁ (α→ A B C) ∘ τ ∘ (τ ⊗₁ id)
+    right-strength-α→ = sym $ swizzle
+      (sym (right-strength-α← ∙ assoc _ _ _))
+      (α≅ .invr)
+      (F.F-map-iso α≅ .invl)
+```
+-->
+
+A **strength** for $F$ is a pair of a left strength and a right strength
+inducing a single operation $A \otimes FB \otimes C \to F (A \otimes
+B \otimes C)$, i.e. making the following diagram commute:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {(A \otimes FB) \otimes C} & {A \otimes (FB \otimes C)} \\
+  {F(A \otimes B) \otimes C} & {A \otimes F(B \otimes C)} \\
+  {F((A \otimes B) \otimes C)} & {F(A \otimes (B \otimes C))}
+  \arrow["\alpha", from=1-1, to=1-2]
+  \arrow["{\sigma \otimes C}"', from=1-1, to=2-1]
+  \arrow["\tau"', from=2-1, to=3-1]
+  \arrow["F\alpha"', from=3-1, to=3-2]
+  \arrow["{A \otimes \tau}", from=1-2, to=2-2]
+  \arrow["\sigma", from=2-2, to=3-2]
+\end{tikzcd}\]
+~~~
+
+```agda
+  record Strength : Type (o ⊔ ℓ) where
+    field
+      strength-left : Left-strength
+      strength-right : Right-strength
+
+    open Left-strength strength-left public
+    open Right-strength strength-right public
+
+    field
+      strength-α→ : ∀ {A B C}
+        → F₁ (α→ A B C) ∘ τ ∘ (σ ⊗₁ id) ≡ σ ∘ (id ⊗₁ τ) ∘ α→ A (F₀ B) C
+```
+
+A functor equipped with a strength is called a **strong functor**.
+
+<!--
+```agda
+  private unquoteDecl left-eqv = declare-record-iso left-eqv (quote Left-strength)
+  Left-strength-path
+    : ∀ {a b} → a .Left-strength.left-strength ≡ b .Left-strength.left-strength
+    → a ≡ b
+  Left-strength-path p = Equiv.injective (Iso→Equiv left-eqv) (Σ-prop-path (λ _ → hlevel 1) p)
+
+  private unquoteDecl right-eqv = declare-record-iso right-eqv (quote Right-strength)
+  Right-strength-path
+    : ∀ {a b} → a .Right-strength.right-strength ≡ b .Right-strength.right-strength
+    → a ≡ b
+  Right-strength-path p = Equiv.injective (Iso→Equiv right-eqv) (Σ-prop-path (λ _ → hlevel 1) p)
+```
+-->
+
+## Symmetry
+
+<!--
+```agda
+  module _ (C-braided : Braided-monoidal C-monoidal) where
+    open Braided C-monoidal C-braided
+    open is-iso
+```
+-->
+
+In a [[symmetric monoidal category]] (or even just a [[braided monoidal
+category]], if one is careful about directions), there is an equivalence
+between the notions of left and right strength: we can obtain one from
+the other by "conjugating" with the braiding, as illustrated by this
+diagram.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {A \otimes FB} & {FB \otimes A} \\
+  {F (A \otimes B)} & {F (B \otimes A)}
+  \arrow["\sigma"', from=1-1, to=2-1]
+  \arrow["\tau", from=1-2, to=2-2]
+  \arrow["\beta", "\sim"', from=1-1, to=1-2]
+  \arrow["F\beta"', "\sim", from=2-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+Therefore, the literature usually speaks of "strength" in a symmetric
+monoidal category to mean either a left or a right strength, but note
+that this is not quite the same as a `Strength`{.Agda} as defined above,
+which has left and right strengths *not necessarily related* by the
+braiding. If they are, we will say that the strength is *symmetric*.
+
+```agda
+    is-symmetric-strength : Strength → Type (o ⊔ ℓ)
+    is-symmetric-strength s = ∀ {A B} → τ {A} {B} ∘ β→ ≡ F₁ β→ ∘ σ
+      where open Strength s
+```
+
+<details>
+<summary>
+The construction of the equivalence between left and right strengths
+is extremely tedious, so we leave the details to the curious reader.
+
+```agda
+    left≃right : Iso Left-strength Right-strength
+```
+
+</summary>
+
+```agda
+    left≃right .fst l = r where
+      open Left-strength l
+      open Right-strength
+      r : Right-strength
+      r .right-strength .η _ = F₁ β→ ∘ σ ∘ β←
+      r .right-strength .is-natural _ _ (f , g) =
+        (F₁ β→ ∘ σ ∘ β←) ∘ (F₁ f ⊗₁ g) ≡⟨ pullr (pullr (β←.is-natural _ _ _)) ⟩
+        F₁ β→ ∘ σ ∘ (g ⊗₁ F₁ f) ∘ β←   ≡⟨ refl⟩∘⟨ extendl (σ.is-natural _ _ _) ⟩
+        F₁ β→ ∘ F₁ (g ⊗₁ f) ∘ σ ∘ β←   ≡⟨ F.extendl (β→.is-natural _ _ _) ⟩
+        F₁ (f ⊗₁ g) ∘ F₁ β→ ∘ σ ∘ β←   ∎
+      r .right-strength-ρ← =
+        F₁ ρ← ∘ F₁ β→ ∘ σ ∘ β← ≡⟨ F.pulll ρ←-β→ ⟩
+        F₁ λ← ∘ σ ∘ β←         ≡⟨ pulll left-strength-λ← ⟩
+        λ← ∘ β←                ≡⟨ λ←-β← ⟩
+        ρ←                     ∎
+      r .right-strength-α← =
+        F₁ (α← _ _ _) ∘ F₁ β→ ∘ σ ∘ β←                                       ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pushl3 (sym (lswizzle (σ.is-natural _ _ _) (F.annihilate (◀.annihilate (β≅ .invl))))) ⟩
+        F₁ (α← _ _ _) ∘ F₁ β→ ∘ F₁ (β→ ⊗₁ id) ∘ σ ∘ (β← ⊗₁ ⌜ F₁ id ⌝) ∘ β←   ≡⟨ ap! F-id ⟩
+        F₁ (α← _ _ _) ∘ F₁ β→ ∘ F₁ (β→ ⊗₁ id) ∘ σ ∘ (β← ⊗₁ id) ∘ β←          ≡⟨ F.extendl3 (sym β→-id⊗β→-α→) ⟩
+        F₁ β→ ∘ F₁ (id ⊗₁ β→) ∘ F₁ (α→ _ _ _) ∘ σ ∘ (β← ⊗₁ id) ∘ β←          ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pulll left-strength-α→ ⟩
+        F₁ β→ ∘ F₁ (id ⊗₁ β→) ∘ (σ ∘ (id ⊗₁ σ) ∘ α→ _ _ _) ∘ (β← ⊗₁ id) ∘ β← ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pullr (pullr refl) ⟩
+        F₁ β→ ∘ F₁ (id ⊗₁ β→) ∘ σ ∘ (id ⊗₁ σ) ∘ α→ _ _ _ ∘ (β← ⊗₁ id) ∘ β←   ≡⟨ refl⟩∘⟨ pushr (pushr (refl⟩∘⟨ sym β←-β←⊗id-α←)) ⟩
+        F₁ β→ ∘ (F₁ (id ⊗₁ β→) ∘ σ ∘ (id ⊗₁ σ)) ∘ β← ∘ (β← ⊗₁ id) ∘ α← _ _ _ ≡˘⟨ refl⟩∘⟨ pulll (▶.shufflel (σ.is-natural _ _ _)) ⟩
+        F₁ β→ ∘ σ ∘ (id ⊗₁ (F₁ β→ ∘ σ)) ∘ β← ∘ (β← ⊗₁ id) ∘ α← _ _ _         ≡⟨ pushr (pushr (extendl (sym (β←.is-natural _ _ _)))) ⟩
+        (F₁ β→ ∘ σ ∘ β←) ∘ ((F₁ β→ ∘ σ) ⊗₁ id) ∘ (β← ⊗₁ id) ∘ α← _ _ _       ≡⟨ refl⟩∘⟨ ◀.pulll (sym (assoc _ _ _)) ⟩
+        (F₁ β→ ∘ σ ∘ β←) ∘ ((F₁ β→ ∘ σ ∘ β←) ⊗₁ id) ∘ α← _ _ _               ∎
+    left≃right .snd .inv r = l where
+      open Right-strength r
+      open Left-strength
+      l : Left-strength
+      l .left-strength .η _ = F₁ β← ∘ τ ∘ β→
+      l .left-strength .is-natural _ _ (f , g) =
+        (F₁ β← ∘ τ ∘ β→) ∘ (f ⊗₁ F₁ g) ≡⟨ pullr (pullr (β→.is-natural _ _ _)) ⟩
+        F₁ β← ∘ τ ∘ (F₁ g ⊗₁ f) ∘ β→   ≡⟨ refl⟩∘⟨ extendl (τ.is-natural _ _ _) ⟩
+        F₁ β← ∘ F₁ (g ⊗₁ f) ∘ τ ∘ β→   ≡⟨ F.extendl (β←.is-natural _ _ _) ⟩
+        F₁ (f ⊗₁ g) ∘ F₁ β← ∘ τ ∘ β→   ∎
+      l .left-strength-λ← =
+        F₁ λ← ∘ F₁ β← ∘ τ ∘ β→ ≡⟨ F.pulll λ←-β← ⟩
+        F₁ ρ← ∘ τ ∘ β→         ≡⟨ pulll right-strength-ρ← ⟩
+        ρ← ∘ β→                ≡⟨ ρ←-β→ ⟩
+        λ←                     ∎
+      l .left-strength-α→ =
+        F₁ (α→ _ _ _) ∘ F₁ β← ∘ τ ∘ β→                                       ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pushl3 (sym (lswizzle (τ.is-natural _ _ _) (F.annihilate (▶.annihilate (β≅ .invr))))) ⟩
+        F₁ (α→ _ _ _) ∘ F₁ β← ∘ F₁ (id ⊗₁ β←) ∘ τ ∘ (⌜ F₁ id ⌝ ⊗₁ β→) ∘ β→   ≡⟨ ap! F-id ⟩
+        F₁ (α→ _ _ _) ∘ F₁ β← ∘ F₁ (id ⊗₁ β←) ∘ τ ∘ (id ⊗₁ β→) ∘ β→          ≡⟨ F.extendl3 ((refl⟩∘⟨ β←.is-natural _ _ _) ∙ sym β←-β←⊗id-α←) ⟩
+        F₁ β← ∘ F₁ (β← ⊗₁ id) ∘ F₁ (α← _ _ _) ∘ τ ∘ (id ⊗₁ β→) ∘ β→          ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pulll right-strength-α← ⟩
+        F₁ β← ∘ F₁ (β← ⊗₁ id) ∘ (τ ∘ (τ ⊗₁ id) ∘ α← _ _ _) ∘ (id ⊗₁ β→) ∘ β→ ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pullr (pullr refl) ⟩
+        F₁ β← ∘ F₁ (β← ⊗₁ id) ∘ τ ∘ (τ ⊗₁ id) ∘ α← _ _ _ ∘ (id ⊗₁ β→) ∘ β→   ≡⟨ refl⟩∘⟨ pushr (pushr (refl⟩∘⟨ ((refl⟩∘⟨ sym (β→.is-natural _ _ _)) ∙ sym β→-id⊗β→-α→))) ⟩
+        F₁ β← ∘ (F₁ (β← ⊗₁ id) ∘ τ ∘ (τ ⊗₁ id)) ∘ β→ ∘ (id ⊗₁ β→) ∘ α→ _ _ _ ≡˘⟨ refl⟩∘⟨ pulll (◀.shufflel (τ.is-natural _ _ _)) ⟩
+        F₁ β← ∘ τ ∘ ((F₁ β← ∘ τ) ⊗₁ id) ∘ β→ ∘ (id ⊗₁ β→) ∘ α→ _ _ _         ≡⟨ pushr (pushr (extendl (sym (β→.is-natural _ _ _)))) ⟩
+        (F₁ β← ∘ τ ∘ β→) ∘ (id ⊗₁ (F₁ β← ∘ τ)) ∘ (id ⊗₁ β→) ∘ α→ _ _ _       ≡⟨ refl⟩∘⟨ ▶.pulll (sym (assoc _ _ _)) ⟩
+        (F₁ β← ∘ τ ∘ β→) ∘ (id ⊗₁ (F₁ β← ∘ τ ∘ β→)) ∘ α→ _ _ _               ∎
+    left≃right .snd .rinv r = Right-strength-path $ ext λ (A , B) →
+      F₁ β→ ∘ (F₁ β← ∘ τ ∘ β→) ∘ β← ≡⟨ extendl (F.cancell (β≅ .invl)) ⟩
+      τ ∘ β→ ∘ β←                   ≡⟨ elimr (β≅ .invl) ⟩
+      τ                             ∎
+      where open Right-strength r
+    left≃right .snd .linv l = Left-strength-path $ ext λ (A , B) →
+      F₁ β← ∘ (F₁ β→ ∘ σ ∘ β←) ∘ β→ ≡⟨ extendl (F.cancell (β≅ .invr)) ⟩
+      σ ∘ β← ∘ β→                   ≡⟨ elimr (β≅ .invr) ⟩
+      σ                             ∎
+      where open Left-strength l
+```
+</details>
+
+## Duality
+
+As hinted to above, a right strength for $F$ on $\cC$ can equivalently
+be defined as a left strength on the [[reverse monoidal category]]
+$\cC^\rm{rev}$. It is entirely trivial to show that the two definitions
+are equivalent:
+
+<!--
+```agda
+module _ {o ℓ} {C : Precategory o ℓ}
+  (M : Monoidal-category C) (F : Functor C C)
+  where
+  open is-iso
+```
+-->
+
+```agda
+  left^rev≃right : Left-strength (M ^rev) F ≃ Right-strength M F
+  left^rev≃right = Iso→Equiv is where
+    is : Iso _ _
+    is .fst l = record
+      { right-strength = NT (λ _ → σ) λ _ _ _ → σ.is-natural _ _ _
+      ; right-strength-ρ← = left-strength-λ←
+      ; right-strength-α← = left-strength-α→
+      } where open Left-strength l
+    is .snd .inv r = record
+      { left-strength = NT (λ _ → τ) λ _ _ _ → τ.is-natural _ _ _
+      ; left-strength-λ← = right-strength-ρ←
+      ; left-strength-α→ = right-strength-α←
+      } where open Right-strength r
+    is .snd .rinv _ = Right-strength-path _ _ trivial!
+    is .snd .linv _ = Left-strength-path _ _ trivial!
+```
+
+## Sets-endofunctors are strong
+
+<!--
+```agda
+module _ {ℓ} (F : Functor (Sets ℓ) (Sets ℓ)) where
+  open Functor F
+  open Left-strength
+```
+-->
+
+Every endofunctor on $\Sets$, seen as a [[cartesian monoidal category]],
+can be equipped with a canonical symmetric strength: the tensor product
+$A \otimes FB$ is the actual product of sets, so, given $a : A$, we can
+simply apply the functorial action of $F$ on the function $\lambda b.
+(a, b)$, yielding a function $FB \to F(A \times B)$.
+
+```agda
+  Sets-strength : Left-strength Setsₓ F
+  Sets-strength .left-strength .η (A , B) (a , Fb) = F₁ (a ,_) Fb
+  Sets-strength .left-strength .is-natural (A , B) (C , D) (ac , bd) =
+    ext λ a Fb → (sym (F-∘ _ _) ∙ F-∘ _ _) $ₚ Fb
+  Sets-strength .left-strength-λ← =
+    ext λ _ Fa → (sym (F-∘ _ _) ∙ F-id) $ₚ Fa
+  Sets-strength .left-strength-α→ =
+    ext λ a b Fc → (sym (F-∘ _ _) ∙ F-∘ _ _) $ₚ Fc
+```
+
+This is an instance of a more general fact: in a *closed*
+monoidal category $\cC$ (that is, one with an [[adjunction]] $- \otimes
+X \dashv [X, -]$, for example coming from a [[cartesian closed]] category),
+left strengths for endofunctors $F : \cC \to \cC$ are equivalent to
+$\cC$-*enrichments* of F: that is, natural transformations
+
+$$
+\hom_\cC([A, B], [FA, FB])
+$$
+
+internalising the functorial action $F_1 : \hom(A, B) \to \hom(FA, FB)$.
+Then, what we have shown boils down to the fact that every endofunctor
+on $\Sets$ is trivially $\Sets$-enriched!

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -386,7 +386,7 @@ has-section+monic→has-retract sect monic .is-retract =
 -->
 
 
-## Isos {defines="isomorphism"}
+## Isos {defines="isomorphism invertible"}
 
 Maps $f : A \to B$ and $g : B \to A$ are **inverses** when we have $f
 \circ g$ and $g \circ f$ both equal to the identity. A map $f : A \to B$

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -494,6 +494,7 @@ _∘Iso_ : a ≅ b → b ≅ c → a ≅ c
 (f ∘Iso g) .inverses = Inverses-∘ (f .inverses) (g .inverses)
 
 infixr 40 _∘Iso_
+infixr 41 _Iso⁻¹
 
 invertible-∘
   : ∀ {f : Hom b c} {g : Hom a b}
@@ -598,17 +599,17 @@ private
 
 abstract
   inverse-unique
-    : {x y : Ob} (p : x ≡ y) {b d : Ob} (q : b ≡ d) {f : x ≅ b} {g : y ≅ d}
+    : {x y : Ob} (p : x ≡ y) {b d : Ob} (q : b ≡ d) (f : x ≅ b) (g : y ≅ d)
     → PathP (λ i → Hom (p i) (q i)) (f .to) (g .to)
     → PathP (λ i → Hom (q i) (p i)) (f .from) (g .from)
   inverse-unique =
-    J' (λ a c p → ∀ {b d} (q : b ≡ d) {f : a ≅ b} {g : c ≅ d}
+    J' (λ a c p → ∀ {b d} (q : b ≡ d) (f : a ≅ b) (g : c ≅ d)
       → PathP (λ i → Hom (p i) (q i)) (f .to) (g .to)
       → PathP (λ i → Hom (q i) (p i)) (f .from) (g .from))
-      λ x → J' (λ b d q → {f : x ≅ b} {g : x ≅ d}
+      λ x → J' (λ b d q → (f : x ≅ b) (g : x ≅ d)
                 → PathP (λ i → Hom x (q i)) (f .to) (g .to)
                 → PathP (λ i → Hom (q i) x) (f .from) (g .from))
-            λ y {f} {g} p →
+            λ y f g p →
               f .from                     ≡˘⟨ ap (f .from ∘_) (g .invl) ∙ idr _ ⟩
               f .from ∘ g .to ∘ g .from   ≡⟨ assoc _ _ _ ⟩
               (f .from ∘ g .to) ∘ g .from ≡⟨ ap (_∘ g .from) (ap (f .from ∘_) (sym p) ∙ f .invr) ∙ idl _ ⟩
@@ -618,13 +619,13 @@ abstract
   : (p : a ≡ c) (q : b ≡ d) {f : a ≅ b} {g : c ≅ d}
   → PathP (λ i → Hom (p i) (q i)) (f ._≅_.to) (g ._≅_.to)
   → PathP (λ i → p i ≅ q i) f g
-≅-pathp p q {f = f} {g = g} r = ≅-pathp-internal p q r (inverse-unique p q {f = f} {g = g} r)
+≅-pathp p q {f = f} {g = g} r = ≅-pathp-internal p q r (inverse-unique p q f g r)
 
 ≅-pathp-from
   : (p : a ≡ c) (q : b ≡ d) {f : a ≅ b} {g : c ≅ d}
   → PathP (λ i → Hom (q i) (p i)) (f ._≅_.from) (g ._≅_.from)
   → PathP (λ i → p i ≅ q i) f g
-≅-pathp-from p q {f = f} {g = g} r = ≅-pathp-internal p q (inverse-unique q p {f = f Iso⁻¹} {g = g Iso⁻¹} r) r
+≅-pathp-from p q {f = f} {g = g} r = ≅-pathp-internal p q (inverse-unique q p (f Iso⁻¹) (g Iso⁻¹) r) r
 
 ≅-path : {f g : a ≅ b} → f ._≅_.to ≡ g ._≅_.to → f ≡ g
 ≅-path = ≅-pathp refl refl

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -29,7 +29,7 @@ Most of these helpers were taken from `agda-categories`.
 private variable
   u v w x y z : Ob
   a a' a'' b b' b'' c c' c'' d d' d'' : Hom x y
-  f g h i : Hom x y
+  f g g' h h' i : Hom x y
 ```
 -->
 
@@ -94,6 +94,14 @@ module _ (ab≡c : a ∘ b ≡ c) where abstract
   pull-inner : (f ∘ a) ∘ (b ∘ g) ≡ f ∘ c ∘ g
   pull-inner {f = f} = sym (assoc _ _ _) ∙ ap (f ∘_) pulll
 
+module _ (abc≡d : a ∘ b ∘ c ≡ d) where abstract
+  pulll3 : a ∘ (b ∘ (c ∘ f)) ≡ d ∘ f
+  pulll3 {f = f} =
+    a ∘ b ∘ c ∘ f   ≡⟨ ap (a ∘_) (assoc _ _ _) ⟩
+    a ∘ (b ∘ c) ∘ f ≡⟨ assoc _ _ _ ⟩
+    (a ∘ b ∘ c) ∘ f ≡⟨ ap (_∘ f) abc≡d ⟩
+    d ∘ f           ∎
+
 module _ (c≡ab : c ≡ a ∘ b) where abstract
   pushl : c ∘ f ≡ a ∘ (b ∘ f)
   pushl = sym (pulll (sym c≡ab))
@@ -103,6 +111,10 @@ module _ (c≡ab : c ≡ a ∘ b) where abstract
 
   push-inner : f ∘ c ∘ g ≡ (f ∘ a) ∘ (b ∘ g)
   push-inner {f = f} = ap (f ∘_) pushl ∙ assoc _ _ _
+
+module _ (d≡abc : d ≡ a ∘ b ∘ c) where abstract
+  pushl3 : d ∘ f ≡ a ∘ (b ∘ (c ∘ f))
+  pushl3 = sym (pulll3 (sym d≡abc))
 
 module _ (p : f ∘ h ≡ g ∘ i) where abstract
   extendl : f ∘ (h ∘ b) ≡ g ∘ (i ∘ b)
@@ -121,6 +133,10 @@ module _ (p : f ∘ h ≡ g ∘ i) where abstract
 
   extend-inner : a ∘ f ∘ h ∘ b ≡ a ∘ g ∘ i ∘ b
   extend-inner {a = a} = ap (a ∘_) extendl
+
+module _ (p : a ∘ b ∘ c ≡ d ∘ f ∘ g) where abstract
+  extendl3 : a ∘ (b ∘ (c ∘ h)) ≡ d ∘ (f ∘ (g ∘ h))
+  extendl3 = pulll3 p ∙ sym (pulll3 refl)
 ```
 
 We also define some useful combinators for performing repeated pulls/pushes.
@@ -135,12 +151,12 @@ abstract
     f ∘ g ∘ h ∘ i   ≡⟨ pulll p ⟩
     (a ∘ b) ∘ h ∘ i ≡⟨ pullr (pushr q) ⟩
     a ∘ (b ∘ c) ∘ d ∎
-  
+
   centralizel
     : f ∘ g ≡ a ∘ b
     → f ∘ g ∘ h ∘ i ≡ a ∘ (b ∘ h) ∘ i
   centralizel p = centralize p refl
-  
+
   centralizer
     : h ∘ i ≡ c ∘ d
     → f ∘ g ∘ h ∘ i ≡ f ∘ (g ∘ c) ∘ d
@@ -200,6 +216,16 @@ rswizzle {g = g} {i = i} {h = h} {f = f} p q =
   g ∘ f       ≡⟨ ap₂ _∘_ p refl ⟩
   (i ∘ h) ∘ f ≡⟨ cancelr q ⟩
   i           ∎
+```
+
+The following "swizzle" operation can be pictured as flipping a
+commutative square along an axis, provided the morphisms on that axis
+are invertible.
+
+```agda
+swizzle : f ∘ g ≡ h ∘ i → g ∘ g' ≡ id → h' ∘ h ≡ id → h' ∘ f ≡ i ∘ g'
+swizzle {f = f} {g = g} {h = h} {i = i} {g' = g'} {h' = h'} p q r =
+  lswizzle (sym (assoc _ _ _ ∙ rswizzle (sym p) q)) r
 ```
 
 ## Isomorphisms
@@ -322,11 +348,14 @@ some cute mixfix notation from `agda-categories` which allows us to write
 _⟩∘⟨_ : f ≡ h → g ≡ i → f ∘ g ≡ h ∘ i
 _⟩∘⟨_ = ap₂ _∘_
 
-infixr 40 _⟩∘⟨_
+infixr 20 _⟩∘⟨_
 
 refl⟩∘⟨_ : g ≡ h → f ∘ g ≡ f ∘ h
 refl⟩∘⟨_ {f = f} p = ap (f ∘_) p
 
 _⟩∘⟨refl : f ≡ h → f ∘ g ≡ h ∘ g
 _⟩∘⟨refl {g = g} p = ap (_∘ g) p
+
+infix 21 refl⟩∘⟨_
+infix 22 _⟩∘⟨refl
 ```

--- a/src/Cat/Univalent/Instances/Algebra.lagda.md
+++ b/src/Cat/Univalent/Instances/Algebra.lagda.md
@@ -182,7 +182,7 @@ ident=F-map-path}, and we can correct the source:
       same-mults' =
         transport
           (λ j → PathP
-            (λ i → C.Hom (F-map-path isc isc (Monad.M M) A₀≅X₀ (~ j) i) (A₀≡X₀ i))
+            (λ i → C.Hom (F-map-path (Monad.M M) isc isc A₀≅X₀ (~ j) i) (A₀≡X₀ i))
             (Am .ν) (Xm .ν))
           same-mults
 

--- a/src/Cat/Univalent/Rezk/Universal.lagda.md
+++ b/src/Cat/Univalent/Rezk/Universal.lagda.md
@@ -448,7 +448,7 @@ This proof _really_ isn't commented. I'm sorry.
         m' = H.iso.from (h₀' B.∘Iso (h' B.Iso⁻¹))
 
         α : k a₀ h₀ .from ≡ F.₁ (m .from) C.∘ k a h .from
-        α = C.inverse-unique _ _ {f = k a₀ h₀} {g = F-map-iso F m C.∘Iso k a h} $
+        α = C.inverse-unique _ _ (k a₀ h₀) (F-map-iso F m C.∘Iso k a h) $
           sym (kcomm _ _ _ (H.ε-lswizzle (h .invl)))
 
         γ : H.₁ (m' .to) B.∘ H.₁ l₀ ≡ H.₁ l B.∘ H.₁ (m .to)

--- a/src/Data/Dec/Base.lagda.md
+++ b/src/Data/Dec/Base.lagda.md
@@ -13,7 +13,7 @@ module Data.Dec.Base where
 # Decidable types {defines="decidable type-of-decisions discrete"}
 
 The type `Dec`{.Agda}, of **decisions** for a type `A`, is a renaming of
-the coproduct `A + ¬ A`. A value of `Dec A` witnesses not that `A`
+the coproduct `A ⊎ ¬ A`. A value of `Dec A` witnesses not that `A`
 is decidable, but that it _has been decided_; A witness of decidability,
 then, is a proof assigning decisions to values of a certain type.
 
@@ -131,7 +131,7 @@ private variable
 
 We then have the following basic instances for combining decisions,
 expressing that the class of decidable types is closed under products
-and negation, and contains the empty type.
+and functions, and contains the unit type and the empty type.
 
 ```agda
 instance
@@ -140,15 +140,16 @@ instance
   Dec-× {Q = _} ⦃ yes p ⦄ ⦃ no ¬q ⦄ = no λ z → ¬q (snd z)
   Dec-× {Q = _} ⦃ no ¬p ⦄ ⦃ _ ⦄     = no λ z → ¬p (fst z)
 
+  Dec-→ : ⦃ _ : Dec P ⦄ ⦃ _ : Dec Q ⦄ → Dec (P → Q)
+  Dec-→ {Q = _} ⦃ yes p ⦄ ⦃ yes q ⦄ = yes λ _ → q
+  Dec-→ {Q = _} ⦃ yes p ⦄ ⦃ no ¬q ⦄ = no λ pq → ¬q (pq p)
+  Dec-→ {Q = _} ⦃ no ¬p ⦄ ⦃ q ⦄ = yes λ p → absurd (¬p p)
+
   Dec-⊤ : Dec ⊤
   Dec-⊤ = yes tt
 
   Dec-⊥ : Dec ⊥
   Dec-⊥ = no id
-
-  Dec-¬ : ⦃ _ : Dec A ⦄ → Dec (A → ⊥)
-  Dec-¬ {A = _} ⦃ yes a ⦄ = no λ ¬a → ¬a a
-  Dec-¬ {A = _} ⦃ no ¬a ⦄ = yes ¬a
 ```
 
 <!--

--- a/src/HoTT.lagda.md
+++ b/src/HoTT.lagda.md
@@ -310,8 +310,8 @@ _ = Discrete
 * Definition 3.4.1: `LEM`{.Agda}
 * Definition 3.4.2: `DNE`{.Agda}
 * Definition 3.4.3:
-  i. `Dec`{.Agda}
-  iii. `Discrete`{.Agda}
+  * (i) `Dec`{.Agda}
+  * (iii) `Discrete`{.Agda}
 
 ### 3.5: Subsets and propositional resizing
 
@@ -1067,11 +1067,11 @@ _ = separation
 * Lemma 10.5.6: `presentation`{.Agda}
 * Definition 10.5.7: `Presentation.members`{.Agda}
 * Theorem 10.5.8:
-  i. `extensionality`{.Agda}
-  ii. `empty-set`{.Agda}
-  iii. `pairing`{.Agda}
-  iv. `zero∈ℕ`{.Agda}, `suc∈ℕ`{.Agda}
-  v. `union`{.Agda}
-  vii. `∈-induction`{.Agda}
-  viii. `replacement`{.Agda}
-  ix. `separation`{.Agda}
+  * (i) `extensionality`{.Agda}
+  * (ii) `empty-set`{.Agda}
+  * (iii) `pairing`{.Agda}
+  * (iv) `zero∈ℕ`{.Agda}, `suc∈ℕ`{.Agda}
+  * (v) `union`{.Agda}
+  * (vii) `∈-induction`{.Agda}
+  * (viii) `replacement`{.Agda}
+  * (ix) `separation`{.Agda}

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -205,3 +205,16 @@
   archivePrefix={arXiv},
   primaryClass={math.CT}
 }
+
+@article{Kelly:coherence,
+  title = {On MacLane's conditions for coherence of natural associativities, commutativities, etc.},
+  journal = {Journal of Algebra},
+  volume = {1},
+  number = {4},
+  pages = {397-402},
+  year = {1964},
+  issn = {0021-8693},
+  doi = {https://doi.org/10.1016/0021-8693(64)90018-3},
+  url = {https://www.sciencedirect.com/science/article/pii/0021869364900183},
+  author = {G.M Kelly}
+}

--- a/support/diagram.tex
+++ b/support/diagram.tex
@@ -10,6 +10,7 @@
 \usetikzlibrary{calc}
 \usetikzlibrary{fit}
 \usetikzlibrary{decorations.pathmorphing}
+\usetikzlibrary{braids}
 
 \ExplSyntaxOn
 \NewDocumentCommand{\definealphabet}{mmmm}


### PR DESCRIPTION
# Description

- reverse monoidal categories
- braided, symmetric monoidal categories
- monoidal categories with diagonals
- cartesian monoidal categories are symmetric monoidal with diagonals
- (lax) monoidal functors, braided/symmetric/diagonal monoidal functors, monoidal natural transformations
- monoidal functors take monoids to monoids, functorially
- a bunch of extra coherence properties for monoidal and braided monoidal categories
- tensorial strengths, equivalence between left and right strengths in a braided monoidal category, every Sets-endofunctor is strong

My initial motivation was to understand the precise relationship between (symmetric) monoidal monads and commutative strong monads, which is why I'm formalising strengths here, but that page could use more prose. Edits welcome.

Some proofs are truly nightmarish, and I feel like we're still missing some important reasoning combinators for isomorphisms but I don't want to think about it right now.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
