### PR TITLE
Strong, commutative, idempotent, monoidal monads

### DIFF
--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -771,6 +771,15 @@ module Equiv {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A ≃ B) where
       (sym p)
     .linv → J (λ _ p → ap to (sym (η _) ∙ ap from p) ∙ ε _ ≡ p)
       (sym (∙-swapr (∙-idl _ ∙ ap sym (sym (zig _)) ∙ sym (∙-idr _) ∙ sym (ap-∙ to _ _))))
+
+module Iso {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} ((f , f-iso) : Iso A B) where
+  open is-iso f-iso renaming (inverse to inverse-iso)
+
+  injective : ∀ {x y} → f x ≡ f y → x ≡ y
+  injective p = sym (linv _) ·· ap inv p ·· linv _
+
+  inverse : Iso B A
+  inverse = inv , inverse-iso
 ```
 -->
 

--- a/src/Algebra/Group.lagda.md
+++ b/src/Algebra/Group.lagda.md
@@ -128,7 +128,7 @@ private unquoteDecl eqv = declare-record-iso eqv (quote is-group)
 
 is-group-is-prop : ∀ {ℓ} {A : Type ℓ} {_*_ : A → A → A}
                  → is-prop (is-group _*_)
-is-group-is-prop {A = A} x y = Equiv.injective (Iso→Equiv eqv) $
+is-group-is-prop {A = A} x y = Iso.injective eqv $
      1x=1y
   ,ₚ funext (λ a →
       monoid-inverse-unique x.has-is-monoid a _ _

--- a/src/Algebra/Magma/Unital/EckmannHilton.lagda.md
+++ b/src/Algebra/Magma/Unital/EckmannHilton.lagda.md
@@ -12,7 +12,7 @@ open import Algebra.Monoid
 module Algebra.Magma.Unital.EckmannHilton where
 ```
 
-# The Eckmann-Hilton argument
+# The Eckmann-Hilton argument {defines="eckmann-hilton-argument"}
 
 The **Eckmann-Hilton argument** shows that two
 `unital magmas`{.Agda ident=is-unital-magma} on the same carrier type that

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -516,11 +516,20 @@ be shown to be a set using the standard `hlevel`{.Agda} machinery.
 
 ```agda
   private unquoteDecl eqv = declare-record-iso eqv (quote _=>_)
-  Nat-is-set : is-set (F => G)
-  Nat-is-set = Iso→is-hlevel 2 eqv (hlevel 2) where
-    open C.HLevel-instance
-    open D.HLevel-instance
+  opaque
+    Nat-is-set : is-set (F => G)
+    Nat-is-set = Iso→is-hlevel 2 eqv (hlevel 2) where
+      open C.HLevel-instance
+      open D.HLevel-instance
 ```
+
+<!--
+```agda
+  instance
+    H-Level-Nat : H-Level (F => G) 2
+    H-Level-Nat = basic-instance 2 Nat-is-set
+```
+-->
 
 Another fundamental lemma is that equality of natural transformations
 depends only on equality of the family of morphisms, since being natural

--- a/src/Cat/Bi/Diagram/Monad.lagda.md
+++ b/src/Cat/Bi/Diagram/Monad.lagda.md
@@ -21,7 +21,7 @@ module _ {o ℓ ℓ'} (B : Prebicategory o ℓ ℓ') where
 ```
 -->
 
-# Monads in a bicategory
+# Monads in a bicategory {defines="monad-in"}
 
 Recall that a [monad] _on_ a category $\cC$ consists of a functor $M :
 \cC \to \cC$ and natural transformations $\mu : MM \To M$, $\eta : \id

--- a/src/Cat/Diagram/Monad.lagda.md
+++ b/src/Cat/Diagram/Monad.lagda.md
@@ -133,6 +133,7 @@ objects which "commutes with the algebras".
 ```agda
   record Algebra-hom (M : Monad) (X Y : Algebra M) : Type (o ⊔ h) where
     no-eta-equality
+    constructor algebra-hom
     private
       module X = Algebra-on (X .snd)
       module Y = Algebra-on (Y .snd)
@@ -306,7 +307,7 @@ faithful.
     Forget-is-faithful = ext
 ```
 
-## Free algebras
+## Free algebras {defines="free-algebra"}
 
 In exactly the same way that we may construct a _[free group]_ by taking
 the inhabitants of some set $X$ as generating the "words" of a group, we

--- a/src/Cat/Diagram/Monad/Idempotent.lagda.md
+++ b/src/Cat/Diagram/Monad/Idempotent.lagda.md
@@ -1,0 +1,270 @@
+<!--
+```agda
+open import Cat.Functor.Adjoint.Reflective
+open import Cat.Monoidal.Strength.Monad
+open import Cat.Functor.Naturality
+open import Cat.Functor.Properties
+open import Cat.Monoidal.Diagonals
+open import Cat.Monoidal.Functor
+open import Cat.Diagram.Monad
+open import Cat.Monoidal.Base
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Reasoning
+
+open Algebra-on
+open Functor
+```
+-->
+
+```agda
+module Cat.Diagram.Monad.Idempotent {o ℓ}
+  {C : Precategory o ℓ} (monad : Monad C)
+  where
+```
+
+# Idempotent monads {defines="idempotent-monad"}
+
+<!--
+```agda
+open Cat.Reasoning C
+open Monad monad
+private
+  module M = Cat.Functor.Reasoning M
+```
+-->
+
+A [[monad]] $M$ is said to be **idempotent** if it "squares to itself"
+in the sense that its multiplication is a [[natural isomorphism]] $\mu :
+M^2 \cong M$.
+
+```agda
+is-idempotent-monad : Type (o ⊔ ℓ)
+is-idempotent-monad = is-invertibleⁿ mult
+```
+
+The intuition is that an idempotent monad on $\cC$ equips its algebras
+with *property*, rather than structure: in that sense, it contains
+exactly as much information as a [[reflective subcategory]] of $\cC$.
+More precisely, the forgetful functor from the [[Eilenberg-Moore category]]
+of an idempotent monad is a reflective subcategory inclusion, and
+conversely any reflective [[adjunction]] $F \dashv U$ yields an
+idempotent monad $UF$.
+
+This means that idempotent monads may be used to interpret *modalities*
+in type theory. As a motivating, if informal, example, think of the
+($\infty$-)category of types and functions: the property of being an
+[[$n$-type]] defines a reflective subuniverse whose corresponding
+idempotent monad is the $n$-[[truncation]] operator.
+
+We start by showing the following elementary characterisation: a monad
+is idempotent if and only if $\eta M, M \eta : M \To M^2$ are equal.
+In the forwards direction, the monad laws tell us that $\mu \circ \eta M
+\equiv \mu \circ M \eta$, and we've assumed that $\mu$ is invertible,
+hence in particular [[monic]].
+
+```agda
+opaque
+  idempotent→η≡Mη : is-idempotent-monad → ∀ A → η (M₀ A) ≡ M₁ (η A)
+  idempotent→η≡Mη idem A = invertible→monic
+    (is-invertibleⁿ→is-invertible idem A) _ _
+    (right-ident ∙ sym left-ident)
+```
+
+For the other direction, we can prove a slightly more general result:
+assuming $\eta M \equiv M \eta$, *any* $M$-[[algebra|monad algebra]] $\nu : MA \to A$
+is invertible. Indeed, algebra laws guarantee that $\eta M$ is a right
+inverse of $\nu$; we check that it is also a left inverse by a short
+computation involving the naturality of $\eta$.
+
+```agda
+η≡Mη→algebra-invertible
+  : (∀ A → η (M₀ A) ≡ M₁ (η A))
+  → ∀ (A : Algebra _ monad)
+  → is-invertible (A .snd .ν)
+η≡Mη→algebra-invertible h (A , alg) = make-invertible (η _) (alg .ν-unit) $
+  η A ∘ alg .ν           ≡⟨ unit.is-natural _ _ _ ⟩
+  M₁ (alg .ν) ∘ η (M₀ A) ≡⟨ refl⟩∘⟨ h A ⟩
+  M₁ (alg .ν) ∘ M₁ (η A) ≡⟨ M.annihilate (alg .ν-unit) ⟩
+  id                     ∎
+```
+
+In particular, by applying this to the [[*free* algebras]] we get that
+$\mu$ is componentwise invertible.
+
+```agda
+η≡Mη→idempotent : (∀ A → η (M₀ A) ≡ M₁ (η A)) → is-idempotent-monad
+η≡Mη→idempotent h = invertible→invertibleⁿ _ λ A →
+  η≡Mη→algebra-invertible h (Free _ monad .F₀ A)
+
+idempotent≃η≡Mη : is-idempotent-monad ≃ (∀ A → η (M₀ A) ≡ M₁ (η A))
+idempotent≃η≡Mη = prop-ext! idempotent→η≡Mη η≡Mη→idempotent
+```
+
+As a consequence, if $\mu$ is only componentwise *[[monic]]*, then
+we can still conclude that $\eta M \equiv M \eta$ and hence that $M$
+is idempotent.
+
+```agda
+μ-monic→idempotent : (∀ A → is-monic (μ A)) → is-idempotent-monad
+μ-monic→idempotent monic = η≡Mη→idempotent λ A →
+  monic _ _ _ (right-ident ∙ sym left-ident)
+```
+
+Finally, we turn to showing the equivalence with reflective subcategories.
+
+The forgetful functor out of the Eilenberg-Moore category is always
+[[faithful|faithful functor]], so we need to show that it is [[full|full functor]]; that
+is, that any map $f : A \to B$ between $M$-algebras is an algebra
+morphism, in that it makes the outer square commute:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  MA & MB \\
+  A & B
+  \arrow["a"', from=1-1, to=2-1]
+  \arrow["b", from=1-2, to=2-2]
+  \arrow["Mf", from=1-1, to=1-2]
+  \arrow["f"', from=2-1, to=2-2]
+  \arrow["{\eta_A}"', curve={height=6pt}, from=2-1, to=1-1]
+  \arrow["{\eta_B}", curve={height=-6pt}, from=2-2, to=1-2]
+\end{tikzcd}\]
+~~~
+
+As we showed earlier, the algebras $a$ and $b$ are both inverses of
+$\eta$, so this reduces to showing that the *inner* square commutes,
+which is just the naturality of $\eta$.
+
+```agda
+idempotent→reflective : is-idempotent-monad → is-reflective (Free⊣Forget _ monad)
+idempotent→reflective idem = full+faithful→ff (Forget _ monad)
+  (λ {(A , a)} {(B , b)} f → inc (algebra-hom f
+    (sym (swizzle (sym (unit.is-natural _ _ _))
+      (η≡Mη→algebra-invertible (idempotent→η≡Mη idem) (A , a) .is-invertible.invr)
+      (b .ν-unit)))
+    , refl))
+  (Forget-is-faithful _ monad)
+```
+
+<!--
+```agda
+_ = is-reflective→is-monadic
+```
+-->
+
+In the other direction, we will show that, if the free-forgetful
+adjunction is reflective, then $M$ is an idempotent monad. Note that
+this doesn't lose any generality over our initial claim, since any
+reflective adjunction $F \dashv U$ `is monadic`{.Agda
+ident=is-reflective→is-monadic}!
+
+Since the adjunction is reflective, we know the counit of the adjunction
+$\epsilon : F \circ U \To \Id$ is an isomorphism; hence the whiskering
+$U \epsilon F$ must be as well, but this is exactly the multiplication
+of our monad.
+
+```agda
+reflective→idempotent : is-reflective (Free⊣Forget _ monad) → is-idempotent-monad
+reflective→idempotent ref = invertible→invertibleⁿ _ λ A →
+  iso→invertible (F-map-iso (Forget _ monad)
+    (is-reflective→counit-is-iso (Free⊣Forget _ monad) ref
+      {Free _ monad .F₀ A}))
+
+idempotent≃reflective : is-idempotent-monad ≃ is-reflective (Free⊣Forget _ monad)
+idempotent≃reflective = prop-ext! idempotent→reflective reflective→idempotent
+```
+
+## Strong idempotent monads
+
+Being an idempotent monad is quite a strong property. Indeed, if the monad
+is also [[strong|strong monad]], then it has to be [[commutative|commutative monad]].
+
+<!--
+```agda
+module _ (idem : is-idempotent-monad) (Cᵐ : Monoidal-category C) (s : Monad-strength Cᵐ monad) where
+  open Monoidal-category Cᵐ
+  open Monad-strength s
+```
+-->
+
+::: source
+The following proof comes from the nLab page on [idempotent monads];
+see there for a diagram.
+:::
+
+[idempotent monads]: https://ncatlab.org/nlab/show/idempotent+monad#idempotent_strong_monads_are_commutative
+
+```agda
+  opaque
+    idempotent→commutative : is-commutative-strength s
+    idempotent→commutative = ext λ (A , B) →
+      μ _ ∘ M₁ τ ∘ σ                                              ≡⟨ insertl right-ident ⟩
+      μ _ ∘ η _ ∘ μ _ ∘ M₁ τ ∘ σ                                  ≡⟨ refl⟩∘⟨ unit.is-natural _ _ _ ⟩
+      μ _ ∘ M₁ (μ _ ∘ M₁ τ ∘ σ) ∘ η _                             ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ right-strength-η ⟩
+      μ _ ∘ M₁ (μ _ ∘ M₁ τ ∘ σ) ∘ τ ∘ (⌜ η _ ⌝ ⊗₁ id)             ≡⟨ ap! (idempotent→η≡Mη idem _) ⟩
+      μ _ ∘ M₁ (μ _ ∘ M₁ τ ∘ σ) ∘ τ ∘ (M₁ (η _) ⊗₁ id)            ≡⟨ refl⟩∘⟨ refl⟩∘⟨ τ.is-natural _ _ _ ⟩
+      μ _ ∘ M₁ (μ _ ∘ M₁ τ ∘ σ) ∘ M₁ (η _ ⊗₁ ⌜ id ⌝) ∘ τ          ≡˘⟨ ap¡ M-id ⟩
+      μ _ ∘ M₁ (μ _ ∘ M₁ τ ∘ σ) ∘ M₁ (η _ ⊗₁ M₁ id) ∘ τ           ≡⟨ refl⟩∘⟨ M.popr (M.popr (extendl (M.weave (σ.is-natural _ _ _)))) ⟩
+      μ _ ∘ M₁ (μ _) ∘ M₁ (M₁ τ) ∘ M₁ (M₁ (η _ ⊗₁ id)) ∘ M₁ σ ∘ τ ≡⟨ refl⟩∘⟨ refl⟩∘⟨ M.pulll (M.collapse right-strength-η) ⟩
+      μ _ ∘ M₁ (μ _) ∘ M₁ (M₁ (η _)) ∘ M₁ σ ∘ τ                   ≡⟨ refl⟩∘⟨ M.cancell left-ident ⟩
+      μ _ ∘ M₁ σ ∘ τ                                              ∎
+```
+
+If furthermore we are in a [[monoidal category with diagonals]],
+then the [[monoidal functor]] induced by the strength is automatically
+an [[idempotent monoidal functor]].
+
+The proof is by chasing the following slightly wonky diagram.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  MA &&& {MA \times MA} & {M(A \times MA)} \\
+  & MMA \\
+  && {M(MA \times MA)} & {M^2(A \times MA)} \\
+  \\
+  {M(A \times A)} && {M(A \times MA)} && {M(A \times MA)} \\
+  & {M^2(A \times A)}
+  \arrow["\mu", curve={height=-6pt}, from=6-2, to=5-1]
+  \arrow["M\delta"', from=1-1, to=5-1]
+  \arrow["M\eta"', curve={height=6pt}, from=1-1, to=2-2]
+  \arrow["M\delta", from=2-2, to=3-3]
+  \arrow["M\tau", from=3-3, to=3-4]
+  \arrow["\eta", from=1-4, to=3-3]
+  \arrow["M\eta"{pos=0.8}, curve={height=-6pt}, from=5-1, to=6-2]
+  \arrow["{M(\eta\times\eta)}", from=5-1, to=3-3]
+  \arrow["{M(A \times \eta)}", from=5-1, to=5-3]
+  \arrow["{M(\eta\times MA)}", from=5-3, to=3-3]
+  \arrow["\eta"', from=5-3, to=3-4]
+  \arrow["\tau", from=1-4, to=1-5]
+  \arrow["\delta", from=1-1, to=1-4]
+  \arrow["\eta", curve={height=-6pt}, from=1-1, to=2-2]
+  \arrow["M\sigma", from=5-3, to=6-2]
+  \arrow["\eta", from=1-5, to=3-4]
+  \arrow["\mu", from=3-4, to=5-5]
+  \arrow[Rightarrow, no head, from=1-5, to=5-5]
+  \arrow[Rightarrow, no head, from=5-5, to=5-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+  module _ (Cᵈ : Diagonals Cᵐ) where
+    open Diagonals Cᵈ
+
+    opaque
+      idempotent-monad→diagonal
+        : is-diagonal-functor _ _ Cᵈ Cᵈ (M , strength→monoidal s)
+      idempotent-monad→diagonal =
+        (μ _ ∘ M₁ σ ∘ τ) ∘ δ                                             ≡⟨ pullr (pullr (insertl right-ident)) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ η _ ∘ τ ∘ δ                                   ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ unit.is-natural _ _ _ ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ (τ ∘ δ) ∘ η _                              ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ idempotent→η≡Mη idem _ ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ (τ ∘ δ) ∘ M₁ (η _)                         ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.pushl refl ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ τ ∘ M₁ δ ∘ M₁ (η _)                        ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.weave (δ.is-natural _ _ _) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ τ ∘ M₁ (η _ ⊗₁ η _) ∘ M₁ δ                 ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.pushl (⊗.expand (sym (idr _) ,ₚ sym (idl _))) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ τ ∘ M₁ (η _ ⊗₁ id) ∘ M₁ (id ⊗₁ η _) ∘ M₁ δ ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.pulll right-strength-η ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ (η _) ∘ M₁ (id ⊗₁ η _) ∘ M₁ δ              ≡⟨ refl⟩∘⟨ refl⟩∘⟨ cancell left-ident ⟩
+        μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ η _) ∘ M₁ δ                               ≡⟨ refl⟩∘⟨ M.pulll left-strength-η ⟩
+        μ _ ∘ M₁ (η _) ∘ M₁ δ                                            ≡⟨ cancell left-ident ⟩
+        M₁ δ                                                             ∎
+```

--- a/src/Cat/Displayed/Cartesian/Indexing.lagda.md
+++ b/src/Cat/Displayed/Cartesian/Indexing.lagda.md
@@ -325,7 +325,7 @@ Last but definitely not least, the `hexagon`{.Agda} witnessing the
 coherence of associativity follows again by uniqueness of cartesian
 lifts, by the commutativity of the following diagram.
 
-~~~{.quiver style="height: 375px !important;"}
+~~~{.quiver}
 \[\begin{tikzcd}
   {f^*g^*h^*a'} &&&&&& {f^*g^*h^*a'} \\
   {f^*g^*h^*a'} & {g^*h^*a'} &&&& {g^*h^*a'} & {(gf)^*h^*a'} \\

--- a/src/Cat/Functor/Adjoint/Monadic.lagda.md
+++ b/src/Cat/Functor/Adjoint/Monadic.lagda.md
@@ -17,7 +17,7 @@ open _=>_
 ```
 -->
 
-# Monadic adjunctions
+# Monadic adjunctions {defines="monadic-adjunction monadic-functor monadic"}
 
 An adjunction $F \dashv G$ between functors $F : C \to D$ and $G : D \to
 C$ is _monadic_ if the induced `comparison functor`{.Agda

--- a/src/Cat/Functor/Adjoint/Reflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Reflective.lagda.md
@@ -59,8 +59,8 @@ When this is the case, we refer to the [[left adjoint]] functor $L$ as the
 **reflector**, and $\iota$ exhibits $\cC$ as a **reflective
 subcategory** of $\cD$. Reflective subcategory inclusions are of
 particular importance because they are [monadic functors]: They exhibit
-$\cC$ as the category of algebras for an (idempotent) monad on
-$\cD$.
+$\cC$ as the category of algebras for an ([[idempotent|idempotent monad]])
+monad on $\cD$.
 :::
 
 [monadic functors]: Cat.Functor.Adjoint.Monadic.html

--- a/src/Cat/Functor/Naturality.lagda.md
+++ b/src/Cat/Functor/Naturality.lagda.md
@@ -29,6 +29,7 @@ module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} where
     module C = Cat.Reasoning C
   open Functor
   open _=>_
+  open CD using (H-Level-is-invertible) public
 ```
 -->
 

--- a/src/Cat/Functor/Reasoning.lagda.md
+++ b/src/Cat/Functor/Reasoning.lagda.md
@@ -2,9 +2,9 @@
 ```agda
 open import 1Lab.Path
 
+open import Cat.Functor.Base using (module F-iso)
 open import Cat.Base
 
-import Cat.Functor.Base
 import Cat.Reasoning
 ```
 -->
@@ -20,7 +20,7 @@ private
   module 𝒞 = Cat.Reasoning 𝒞
   module 𝒟 = Cat.Reasoning 𝒟
 open Functor F public
-open Cat.Functor.Base.F-iso F public
+open F-iso F public
 ```
 
 <!--
@@ -84,6 +84,9 @@ module _ (abc≡d : a 𝒞.∘ b 𝒞.∘ c ≡ d) where
   pulll3 : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ (F₁ c 𝒟.∘ f)) ≡ F₁ d 𝒟.∘ f
   pulll3 = 𝒟.pulll3 collapse3
 
+  pullr3 : ((f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b) 𝒟.∘ F₁ c ≡ f 𝒟.∘ F₁ d
+  pullr3 = 𝒟.pullr3 collapse3
+
 module _ (c≡ab : c ≡ a 𝒞.∘ b) where
   expand : F₁ c ≡ F₁ a 𝒟.∘ F₁ b
   expand = sym (collapse (sym c≡ab))
@@ -115,6 +118,9 @@ module _ (p : a 𝒞.∘ b 𝒞.∘ c ≡ a' 𝒞.∘ b' 𝒞.∘ c') where
   extendl3 : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ (F₁ c 𝒟.∘ f)) ≡ F₁ a' 𝒟.∘ (F₁ b' 𝒟.∘ (F₁ c' 𝒟.∘ f))
   extendl3 = 𝒟.extendl3 weave3
 
+  extendr3 : ((f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b) 𝒟.∘ F₁ c ≡ ((f 𝒟.∘ F₁ a') 𝒟.∘ F₁ b') 𝒟.∘ F₁ c'
+  extendr3 = 𝒟.extendr3 weave3
+
 module _ (p : F₁ a 𝒟.∘ F₁ c ≡ F₁ b 𝒟.∘ F₁ d) where
   swap : F₁ (a 𝒞.∘ c) ≡ F₁ (b 𝒞.∘ d)
   swap = F-∘ a c ·· p ·· sym (F-∘  b d)
@@ -137,7 +143,7 @@ shuffler p = popr p ∙ (𝒟.assoc _ _ _)
 ```agda
 module _ (inv : a 𝒞.∘ b ≡ 𝒞.id) where
   annihilate : F₁ a 𝒟.∘ F₁ b ≡ 𝒟.id
-  annihilate = sym (F-∘ a b) ∙ ap F₁ inv ∙ F-id
+  annihilate = collapse inv ∙ F-id
 
   cancell : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ f) ≡ f
   cancell = 𝒟.cancell annihilate
@@ -153,6 +159,22 @@ module _ (inv : a 𝒞.∘ b ≡ 𝒞.id) where
 
   cancel-inner : (f 𝒟.∘ F₁ a) 𝒟.∘ (F₁ b 𝒟.∘ g) ≡ f 𝒟.∘ g
   cancel-inner = 𝒟.cancel-inner annihilate
+
+module _ (inv : a 𝒞.∘ b 𝒞.∘ c ≡ 𝒞.id) where
+  annihilate3 : F₁ a 𝒟.∘ F₁ b 𝒟.∘ F₁ c ≡ 𝒟.id
+  annihilate3 = collapse3 inv ∙ F-id
+
+  cancell3 : F₁ a 𝒟.∘ (F₁ b 𝒟.∘ (F₁ c 𝒟.∘ f)) ≡ f
+  cancell3 = 𝒟.cancell3 annihilate3
+
+  cancelr3 : ((f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b) 𝒟.∘ F₁ c ≡ f
+  cancelr3 = 𝒟.cancelr3 annihilate3
+
+  insertl3 : f ≡ F₁ a 𝒟.∘ (F₁ b 𝒟.∘ (F₁ c 𝒟.∘ f))
+  insertl3 = 𝒟.insertl3 annihilate3
+
+  insertr3 : f ≡ ((f 𝒟.∘ F₁ a) 𝒟.∘ F₁ b) 𝒟.∘ F₁ c
+  insertr3 = 𝒟.insertr3 annihilate3
 ```
 
 ## Notation

--- a/src/Cat/Instances/Product.lagda.md
+++ b/src/Cat/Instances/Product.lagda.md
@@ -15,6 +15,7 @@ module Cat.Instances.Product where
 ```agda
 open Precategory
 open Functor
+open _=>_
 private variable
   o₁ h₁ o₂ h₂ : Level
   B C D E : Precategory o₁ h₁
@@ -115,6 +116,14 @@ _F×_ {B = B} {D = D} {C = C} {E = E} G H = func
   func .F₁ (f , g) = G .F₁ f , H .F₁ g
   func .F-id = G .F-id ,ₚ H .F-id
   func .F-∘ (f , g) (f' , g') = G .F-∘ f f' ,ₚ H .F-∘ g g'
+
+_nt×_
+  : {F G : Functor B D} {H K : Functor C E}
+  → F => G → H => K → (F F× H) => (G F× K)
+_nt×_ α β .η (c , d) = α .η c , β .η d
+_nt×_ α β .is-natural (c , d) (c' , d') (f , g) = Σ-pathp
+  (α .is-natural c c' f)
+  (β .is-natural d d' g)
 ```
 
 <!--

--- a/src/Cat/Monoidal/Braided.lagda.md
+++ b/src/Cat/Monoidal/Braided.lagda.md
@@ -15,7 +15,7 @@ open _=>_
 
 ```agda
 module Cat.Monoidal.Braided {o ℓ}
-  {C : Precategory o ℓ} (C-monoidal : Monoidal-category C)
+  {C : Precategory o ℓ} (Cᵐ : Monoidal-category C)
   where
 ```
 
@@ -24,7 +24,7 @@ module Cat.Monoidal.Braided {o ℓ}
 <!--
 ```agda
 open Cat.Reasoning C
-open Monoidal C-monoidal
+open Monoidal Cᵐ
 ```
 -->
 
@@ -139,9 +139,9 @@ is-symmetric-braiding braiding = ∀ {A B} → β→ ∘ β→ {A} {B} ≡ id
 
 record Symmetric-monoidal : Type (o ⊔ ℓ) where
   field
-    has-is-braided : Braided-monoidal
+    Cᵇ : Braided-monoidal
 
-  open Braided-monoidal has-is-braided hiding (β≅) public
+  open Braided-monoidal Cᵇ hiding (β≅) public
 
   field
     has-is-symmetric : is-symmetric-braiding braiding
@@ -185,9 +185,9 @@ record make-symmetric-monoidal : Type (o ⊔ ℓ) where
       → (id ⊗₁ β→) ∘ α→ B A C ∘ (β→ ⊗₁ id) ≡ α→ B C A ∘ β→ ∘ α→ A B C
 
   to-symmetric-monoidal : Symmetric-monoidal
-  to-symmetric-monoidal .has-is-braided .braiding = has-braiding
-  to-symmetric-monoidal .has-is-braided .braiding-α→ = has-braiding-α→
-  to-symmetric-monoidal .has-is-braided .unbraiding-α→ {A} {B} {C} =
+  to-symmetric-monoidal .Cᵇ .braiding = has-braiding
+  to-symmetric-monoidal .Cᵇ .braiding-α→ = has-braiding-α→
+  to-symmetric-monoidal .Cᵇ .unbraiding-α→ {A} {B} {C} =
     subst (λ β → (id ⊗₁ β {_} {_}) ∘ α→ B A C ∘ (β {_} {_} ⊗₁ id) ≡ α→ _ _ _ ∘ β {_} {_} ∘ α→ _ _ _)
       β→≡β← has-braiding-α→
   to-symmetric-monoidal .has-is-symmetric = symmetric
@@ -199,8 +199,8 @@ open make-symmetric-monoidal using (to-symmetric-monoidal) public
 
 <!--
 ```agda
-module Braided (C-braided : Braided-monoidal) where
-  open Braided-monoidal C-braided public
+module Braided (Cᵇ : Braided-monoidal) where
+  open Braided-monoidal Cᵇ public
 ```
 -->
 

--- a/src/Cat/Monoidal/Diagonals.lagda.md
+++ b/src/Cat/Monoidal/Diagonals.lagda.md
@@ -10,7 +10,7 @@ import Cat.Reasoning
 
 ```agda
 module Cat.Monoidal.Diagonals {o ℓ}
-  {C : Precategory o ℓ} (C-monoidal : Monoidal-category C)
+  {C : Precategory o ℓ} (Cᵐ : Monoidal-category C)
   where
 ```
 
@@ -19,7 +19,7 @@ module Cat.Monoidal.Diagonals {o ℓ}
 <!--
 ```agda
 open Cat.Reasoning C
-open Monoidal C-monoidal
+open Monoidal Cᵐ
 
 _ = λ≡ρ
 ```

--- a/src/Cat/Monoidal/Diagram/Monoid.lagda.md
+++ b/src/Cat/Monoidal/Diagram/Monoid.lagda.md
@@ -364,13 +364,13 @@ The unit laws are witnessed by the commutativity of this diagram:
 
 ```agda
   Mon₁[_] .F₀' m .μ-unitl =
-    (F₁ (m .μ) ∘ φ) ∘ ((F₁ (m .η) ∘ ε) ⊗₁ id)          ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (Σ-pathp refl (F.introl refl))) ⟩
+    (F₁ (m .μ) ∘ φ) ∘ ((F₁ (m .η) ∘ ε) ⊗₁ id)          ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (refl ,ₚ F.introl refl)) ⟩
     F₁ (m .μ) ∘ φ ∘ (F₁ (m .η) ⊗₁ F₁ C.id) ∘ (ε ⊗₁ id) ≡⟨ refl⟩∘⟨ extendl (φ.is-natural _ _ _) ⟩
     F₁ (m .μ) ∘ F₁ (m .η C.⊗₁ C.id) ∘ φ ∘ (ε ⊗₁ id)    ≡⟨ F.pulll (m .μ-unitl) ⟩
     F₁ C.λ← ∘ φ ∘ (ε ⊗₁ id)                            ≡⟨ F-λ← ⟩
     λ←                                                 ∎
   Mon₁[_] .F₀' m .μ-unitr =
-    (F₁ (m .μ) ∘ φ) ∘ (id ⊗₁ (F₁ (m .η) ∘ ε))          ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (Σ-pathp (F.introl refl) refl)) ⟩
+    (F₁ (m .μ) ∘ φ) ∘ (id ⊗₁ (F₁ (m .η) ∘ ε))          ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (F.introl refl ,ₚ refl)) ⟩
     F₁ (m .μ) ∘ φ ∘ (F₁ C.id ⊗₁ F₁ (m .η)) ∘ (id ⊗₁ ε) ≡⟨ refl⟩∘⟨ extendl (φ.is-natural _ _ _) ⟩
     F₁ (m .μ) ∘ F₁ (C.id C.⊗₁ m .η) ∘ φ ∘ (id ⊗₁ ε)    ≡⟨ F.pulll (m .μ-unitr) ⟩
     F₁ C.ρ← ∘ φ ∘ (id ⊗₁ ε)                            ≡⟨ F-ρ← ⟩
@@ -405,12 +405,12 @@ The unit laws are witnessed by the commutativity of this diagram:
 
 ```agda
   Mon₁[_] .F₀' m .μ-assoc =
-    (F₁ (m .μ) ∘ φ) ∘ (id ⊗₁ (F₁ (m .μ) ∘ φ))                       ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (Σ-pathp (F.introl refl) refl)) ⟩
+    (F₁ (m .μ) ∘ φ) ∘ (id ⊗₁ (F₁ (m .μ) ∘ φ))                       ≡⟨ pullr (refl⟩∘⟨ ⊗.expand (F.introl refl ,ₚ refl)) ⟩
     F₁ (m .μ) ∘ φ ∘ (F₁ C.id ⊗₁ F₁ (m .μ)) ∘ (id ⊗₁ φ)              ≡⟨ (refl⟩∘⟨ extendl (φ.is-natural _ _ _)) ⟩
     F₁ (m .μ) ∘ F₁ (C.id C.⊗₁ m .μ) ∘ φ ∘ (id ⊗₁ φ)                 ≡⟨ F.pulll (m .μ-assoc) ⟩
     F₁ (m .μ C.∘ (m .μ C.⊗₁ C.id) C.∘ C.α← _ _ _) ∘ φ ∘ (id ⊗₁ φ)   ≡⟨ F.popr (F.popr F-α←) ⟩
     F₁ (m .μ) ∘ F₁ (m .μ C.⊗₁ C.id) ∘ φ ∘ (φ ⊗₁ id) ∘ α← _ _ _      ≡˘⟨ pullr (extendl (φ.is-natural _ _ _)) ⟩
-    (F₁ (m .μ) ∘ φ) ∘ (F₁ (m .μ) ⊗₁ F₁ C.id) ∘ (φ ⊗₁ id) ∘ α← _ _ _ ≡⟨ refl⟩∘⟨ ⊗.pulll (Σ-pathp refl (F.eliml refl)) ⟩
+    (F₁ (m .μ) ∘ φ) ∘ (F₁ (m .μ) ⊗₁ F₁ C.id) ∘ (φ ⊗₁ id) ∘ α← _ _ _ ≡⟨ refl⟩∘⟨ ⊗.pulll (refl ,ₚ F.eliml refl) ⟩
     (F₁ (m .μ) ∘ φ) ∘ ((F₁ (m .μ) ∘ φ) ⊗₁ id) ∘ α← _ _ _            ∎
 ```
 

--- a/src/Cat/Monoidal/Functor.lagda.md
+++ b/src/Cat/Monoidal/Functor.lagda.md
@@ -14,20 +14,20 @@ import Cat.Reasoning
 
 ```agda
 module Cat.Monoidal.Functor {oc ℓc od ℓd}
-  {C : Precategory oc ℓc} (C-monoidal : Monoidal-category C)
-  {D : Precategory od ℓd} (D-monoidal : Monoidal-category D)
+  {C : Precategory oc ℓc} (Cᵐ : Monoidal-category C)
+  {D : Precategory od ℓd} (Dᵐ : Monoidal-category D)
   where
 ```
 
-# Monoidal functors {defines="monoidal-functor lax-monoidal-functor oplax-monoidal-functor"}
+# Monoidal functors {defines="monoidal-functor lax-monoidal-functor oplax-monoidal-functor strong-monoidal-functor"}
 
 <!--
 ```agda
 open Cat.Reasoning D
 
 private
-  module C = Monoidal-category C-monoidal
-  module D = Monoidal-category D-monoidal
+  module C = Monoidal-category Cᵐ
+  module D = Monoidal-category Dᵐ
 ```
 -->
 
@@ -81,6 +81,15 @@ record Lax-monoidal-functor-on (F : Functor C D) : Type (oc ⊔ ℓc ⊔ od ⊔ 
     → F.₁ (C.α← A B C) ∘ φ ∘ (id D.⊗₁ φ) ≡ φ ∘ (φ D.⊗₁ id) ∘ D.α← _ _ _
   F-α← = swizzle (sym (F-α→ ∙ assoc _ _ _)) (D.α≅ .invl) (F.F-map-iso C.α≅ .invr)
     ∙ sym (assoc _ _ _)
+
+private unquoteDecl eqv = declare-record-iso eqv (quote Lax-monoidal-functor-on)
+Lax-monoidal-functor-on-path
+  : ∀ {F} {l l' : Lax-monoidal-functor-on F}
+  → l .Lax-monoidal-functor-on.ε ≡ l' .Lax-monoidal-functor-on.ε
+  → l .Lax-monoidal-functor-on.F-mult ≡ l' .Lax-monoidal-functor-on.F-mult
+  → l ≡ l'
+Lax-monoidal-functor-on-path p q = Iso.injective eqv
+  (Σ-pathp p (Σ-prop-pathp (λ _ _ → hlevel 1) q))
 ```
 -->
 
@@ -131,17 +140,17 @@ yielding the notion of a **braided monoidal functor**.
 <!--
 ```agda
 module _
-  (C-braided : Braided-monoidal C-monoidal)
-  (D-braided : Braided-monoidal D-monoidal)
+  (Cᵇ : Braided-monoidal Cᵐ)
+  (Dᵇ : Braided-monoidal Dᵐ)
   where
-  module CB = Braided-monoidal C-braided
-  module DB = Braided-monoidal D-braided
+  module Cᵇ = Braided-monoidal Cᵇ
+  module Dᵇ = Braided-monoidal Dᵇ
 ```
 -->
 
 ```agda
   is-braided-functor : Lax-monoidal-functor → Type (oc ⊔ ℓd)
-  is-braided-functor (F , lax) = ∀ {A B} → φ ∘ DB.β→ ≡ F.₁ CB.β→ ∘ φ {A} {B}
+  is-braided-functor (F , lax) = ∀ {A B} → φ ∘ Dᵇ.β→ ≡ F.₁ Cᵇ.β→ ∘ φ {A} {B}
     where
       module F = Functor F
       open Lax-monoidal-functor-on lax
@@ -154,17 +163,17 @@ preserve.
 <!--
 ```agda
 module _
-  (C-symmetric : Symmetric-monoidal C-monoidal)
-  (D-symmetric : Symmetric-monoidal D-monoidal)
+  (Cˢ : Symmetric-monoidal Cᵐ)
+  (Dˢ : Symmetric-monoidal Dᵐ)
   where
-  module CS = Symmetric-monoidal C-symmetric
-  module DS = Symmetric-monoidal D-symmetric
+  open Symmetric-monoidal Cˢ using (Cᵇ)
+  open Symmetric-monoidal Dˢ using () renaming (Cᵇ to Dᵇ)
 ```
 -->
 
 ```agda
   is-symmetric-functor : Lax-monoidal-functor → Type (oc ⊔ ℓd)
-  is-symmetric-functor = is-braided-functor CS.has-is-braided DS.has-is-braided
+  is-symmetric-functor = is-braided-functor Cᵇ Dᵇ
 ```
 
 ## Diagonal monoidal functors {defines="diagonal-monoidal-functor idempotent-monoidal-functor"}
@@ -187,17 +196,17 @@ functor that makes the following diagram commute:
 <!--
 ```agda
 module _
-  (C-diagonal : Diagonals C-monoidal)
-  (D-diagonal : Diagonals D-monoidal)
+  (Cᵈ : Diagonals Cᵐ)
+  (Dᵈ : Diagonals Dᵐ)
   where
-  module CD = Diagonals C-diagonal
-  module DD = Diagonals D-diagonal
+  module Cᵈ = Diagonals Cᵈ
+  module Dᵈ = Diagonals Dᵈ
 ```
 -->
 
 ```agda
   is-diagonal-functor : Lax-monoidal-functor → Type (oc ⊔ ℓd)
-  is-diagonal-functor (F , lax) = ∀ {A} → φ ∘ DD.δ ≡ F.₁ (CD.δ {A})
+  is-diagonal-functor (F , lax) = ∀ {A} → φ ∘ Dᵈ.δ ≡ F.₁ (Cᵈ.δ {A})
     where
       module F = Functor F
       open Lax-monoidal-functor-on lax

--- a/src/Cat/Monoidal/Monad.lagda.md
+++ b/src/Cat/Monoidal/Monad.lagda.md
@@ -1,0 +1,711 @@
+<!--
+```agda
+open import Cat.Monoidal.Strength.Monad
+open import Cat.Functor.Naturality
+open import Cat.Instances.Product
+open import Cat.Monoidal.Strength
+open import Cat.Monoidal.Braided
+open import Cat.Monoidal.Reverse
+open import Cat.Functor.Compose
+open import Cat.Diagram.Monad
+open import Cat.Monoidal.Base
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Monoidal.Functor
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Monoidal.Monad where
+```
+
+# Monoidal monads {defines="monoidal-monad"}
+
+<!--
+```agda
+module _ {o ℓ}
+  {C : Precategory o ℓ} (Cᵐ : Monoidal-category C)
+  where
+  open Cat.Reasoning C
+  open Cat.Monoidal.Functor Cᵐ Cᵐ
+  open Monoidal-category Cᵐ
+```
+-->
+
+A **monoidal monad** on a [[monoidal category]] $\cC$ is a [[monad]] on
+$\cC$ whose underlying endofunctor is also equipped with the structure
+of a [[lax monoidal functor]], in a way that the two structures agree;
+alternatively, it is a [[monad *in*]] the [[bicategory]] of
+monoidal categories, lax monoidal functors and [[monoidal natural
+transformations]].
+
+```agda
+  record Monoidal-monad-on (monad : Monad C) : Type (o ⊔ ℓ) where
+    open Monad monad
+    field
+      monad-monoidal : Lax-monoidal-functor-on M
+
+    open Lax-monoidal-functor-on monad-monoidal renaming
+      (F-mult to M-mult; F-α← to M-α←; F-α→ to M-α→; F-λ← to M-λ←; F-ρ← to M-ρ←)
+      public
+```
+
+To summarise, we have the following data laying around:
+
+$$
+\begin{align*}
+\eta_A &: A \to M A & \mu_A &: M^2 A \to M A \\
+\epsilon &: 1 \to M 1 & \varphi_{A,B} &: M A \otimes M B \to M (A \otimes B)
+\end{align*}
+$$
+
+The precise interaction we ask for is that the monad's unit and
+multiplication be [[monoidal natural transformations]]^[With respect to
+the induced lax monoidal structures on $\Id$ and $M^2$.]; this requires a
+total of *four* conditions.
+
+That $\eta$ is a monoidal natural transformation is captured by the
+following two diagrams:
+
+<div class="mathpar">
+
+~~~{.quiver}
+\[\begin{tikzcd}[column sep=tiny]
+  & 1 \\
+  1 && M1
+  \arrow[Rightarrow, no head, from=1-2, to=2-1]
+  \arrow["\epsilon", from=1-2, to=2-3]
+  \arrow["{\eta_1}"', from=2-1, to=2-3]
+\end{tikzcd}\]
+~~~
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {A \otimes B} & {MA \otimes MB} \\
+  {A \otimes B} & {M (A \otimes B)}
+  \arrow[Rightarrow, no head, from=1-1, to=2-1]
+  \arrow["{\eta_A \otimes \eta_B}", from=1-1, to=1-2]
+  \arrow["{\varphi_{A,B}}", from=1-2, to=2-2]
+  \arrow["{\eta_{A \otimes B}}"', from=2-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+</div>
+
+```agda
+    field
+      unit-ε : ε ≡ η Unit
+      unit-φ : ∀ {A B} → φ {A} {B} ∘ (η A ⊗₁ η B) ≡ η (A ⊗ B)
+```
+
+Notice that the diagram on the left entirely determines $\epsilon$ to be
+$\eta_1$.
+
+Then, for $\mu$ to be monoidal means that these two diagrams commute:
+
+<div class="mathpar">
+
+~~~{.quiver}
+\[\begin{tikzcd}[column sep=tiny]
+  & 1 \\
+  {M^21} && M1
+  \arrow["{M\epsilon \circ \epsilon}"', from=1-2, to=2-1]
+  \arrow["{\mu_1}"', from=2-1, to=2-3]
+  \arrow["\epsilon", from=1-2, to=2-3]
+\end{tikzcd}\]
+~~~
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {M^2 A \otimes M^2 B} & {MA \otimes MB} \\
+  {M (MA \otimes MB)} \\
+  {M^2 (A \otimes B)} & {M (A \otimes B)}
+  \arrow["{\varphi_{MA,MB}}"', from=1-1, to=2-1]
+  \arrow["{M\varphi_{A,B}}"', from=2-1, to=3-1]
+  \arrow["{\mu_A \otimes \mu_B}", from=1-1, to=1-2]
+  \arrow["{\varphi_{A,B}}", from=1-2, to=3-2]
+  \arrow["{\mu_{A \otimes B}}"', from=3-1, to=3-2]
+\end{tikzcd}\]
+~~~
+
+</div>
+
+The diagram on the left automatically commutes because of the monad laws,
+since $\epsilon$ is forced to be $\eta_1$, so we only need to require
+the diagram on the right. This is the biggest requirement: so far, we're
+describing a structure that any [[strong monad]] could be equipped with,
+but making the last diagram commute requires a [[commutative monad]],
+as we will see in the rest of this module.
+
+```agda
+    mult-ε : ε ≡ μ Unit ∘ M₁ ε ∘ ε
+    mult-ε = insertl (ap (λ x → _ ∘ M₁ x) unit-ε ∙ left-ident)
+
+    field
+      mult-φ : ∀ {A B} → φ {A} {B} ∘ (μ A ⊗₁ μ B) ≡ μ (A ⊗ B) ∘ M₁ φ ∘ φ
+
+  Monoidal-monad : Type (o ⊔ ℓ)
+  Monoidal-monad = Σ (Monad C) Monoidal-monad-on
+```
+
+<!--
+```agda
+  private unquoteDecl eqv = declare-record-iso eqv (quote Monoidal-monad-on)
+  Monoidal-monad-on-path
+    : ∀ {M} {a b : Monoidal-monad-on M}
+    → a .Monoidal-monad-on.monad-monoidal ≡ b .Monoidal-monad-on.monad-monoidal
+    → a ≡ b
+  Monoidal-monad-on-path p = Iso.injective eqv (Σ-prop-path (λ _ → hlevel 1) p)
+```
+-->
+
+## Duality
+
+<!--
+```agda
+module _ {o ℓ}
+  {C : Precategory o ℓ} {Cᵐ : Monoidal-category C}
+  {monad : Monad C}
+  where
+  open Cat.Reasoning C
+  open Cat.Monoidal.Functor Cᵐ Cᵐ
+  open Monoidal-category Cᵐ
+  open Monad monad
+  private
+    module M = Cat.Functor.Reasoning M
+```
+-->
+
+As the definition of a monoidal monad is completely symmetric with
+respect to the tensor product, we straightforwardly get a monoidal
+monad on the [[reverse monoidal category]] $\cC^\rm{rev}$ from a
+monoidal monad on $\cC$.
+
+```agda
+  monoidal-monad^rev : Monoidal-monad-on Cᵐ monad → Monoidal-monad-on (Cᵐ ^rev) monad
+  monoidal-monad^rev m = record
+    { monad-monoidal = record
+      { ε = ε
+      ; F-mult = NT (λ _ → φ) λ _ _ _ → M-mult ._=>_.is-natural _ _ _
+      ; F-α→ = M-α←
+      ; F-λ← = M-ρ←
+      ; F-ρ← = M-λ←
+      }
+    ; unit-ε = unit-ε
+    ; unit-φ = unit-φ
+    ; mult-φ = mult-φ
+    } where open Monoidal-monad-on m
+```
+
+## As commutative monads
+
+We now turn to proving the following result, alluded to above: the
+structure of a monoidal monad on a given monad is *equivalent* to the
+structure of a [[commutative strength]] for that monad!
+
+::: source
+This is a slight generalisation of a result by Kock [-@Kock:monoidal-monads],
+who proves that *symmetric* monoidal monads on a [[symmetric monoidal
+category]] correspond to commutative strengths (which are assumed to be
+symmetric).
+:::
+
+The guiding intuition is that the monoidal structure on $M$ allows
+*parallel*, or "vertical" composition of effects; this is illustrated by
+the `mult-φ`{.Agda} diagram if we label the monadic "layers" as follows:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {M_1 M_2 A \otimes M_3 M_4 B} & {M_{12} A \otimes M_{34} B} \\
+  {M^1_3 (M_2 A \otimes M_4 B)} \\
+  {M^1_3 M^2_4 (A \otimes B)} & {M^{12}_{34} (A \otimes B)}
+  \arrow["{\varphi_{MA,MB}}"', from=1-1, to=2-1]
+  \arrow["{M\varphi_{A,B}}"', from=2-1, to=3-1]
+  \arrow["{\mu_A \otimes \mu_B}", from=1-1, to=1-2]
+  \arrow["{\varphi_{A,B}}", from=1-2, to=3-2]
+  \arrow["{\mu_{A \otimes B}}"', from=3-1, to=3-2]
+\end{tikzcd}\]
+~~~
+
+This should be reminiscent of the two composition structures in the
+hypotheses to the [[Eckmann-Hilton argument]], which suggests that the
+two ways to sequence effects ("monadically" and "monoidally") should be
+the same, and, moreover, commutative.
+
+### Commutative monads from monoidal monads
+
+We start by constructing a [[left monad strength]] from a monoidal monad,
+by composing the unit of the monad with the monoidal multiplication:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {A \otimes MB} & {MA \otimes MB} & {M (A \otimes B)}
+  \arrow["{\eta_A \otimes MB}", from=1-1, to=1-2]
+  \arrow["{\varphi_{A,B}}", from=1-2, to=1-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+  monoidal→left-strength
+    : Monoidal-monad-on Cᵐ monad → Left-monad-strength Cᵐ monad
+  monoidal→left-strength m = l where
+    open Monoidal-monad-on m
+    open Left-strength
+    open Left-monad-strength
+
+    l : Left-monad-strength Cᵐ monad
+    l .functor-strength .left-strength = M-mult ∘nt (-⊗- ▸ (unit nt× idnt))
+```
+
+<details>
+<summary>
+We leave the verification of the strength axioms for the curious
+reader; they are entirely monotonous.
+</summary>
+
+```agda
+    l .functor-strength .left-strength-λ← =
+      M₁ λ← ∘ φ ∘ (η _ ⊗₁ id) ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ ap (_⊗₁ id) unit-ε ⟩
+      M₁ λ← ∘ φ ∘ (ε ⊗₁ id)   ≡⟨ M-λ← ⟩
+      λ←                      ∎
+    l .functor-strength .left-strength-α→ =
+      M₁ (α→ _ _ _) ∘ φ ∘ (η _ ⊗₁ id)                          ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ ◀.collapse unit-φ ⟩
+      M₁ (α→ _ _ _) ∘ φ ∘ (φ ⊗₁ id) ∘ ((η _ ⊗₁ η _) ⊗₁ id)     ≡⟨ extendl3 M-α→ ⟩
+      φ ∘ (id ⊗₁ φ) ∘ α→ _ _ _ ∘ ((η _ ⊗₁ η _) ⊗₁ id)          ≡⟨ refl⟩∘⟨ refl⟩∘⟨ associator .Isoⁿ.to ._=>_.is-natural _ _ _ ⟩
+      φ ∘ (id ⊗₁ φ) ∘ (η _ ⊗₁ (η _ ⊗₁ id)) ∘ α→ _ _ _          ≡⟨ refl⟩∘⟨ ⊗.pulll (idl _ ,ₚ refl) ⟩
+      φ ∘ (η _ ⊗₁ (φ ∘ (η _ ⊗₁ id))) ∘ α→ _ _ _                ≡⟨ pushr (⊗.pushl (sym (idr _) ,ₚ sym (idl _))) ⟩
+      (φ ∘ (η _ ⊗₁ id)) ∘ (id ⊗₁ (φ ∘ (η _ ⊗₁ id))) ∘ α→ _ _ _ ∎
+    l .left-strength-η =
+      (φ ∘ (η _ ⊗₁ id)) ∘ (id ⊗₁ η _) ≡⟨ pullr (⊗.collapse (idr _ ,ₚ idl _)) ⟩
+      φ ∘ (η _ ⊗₁ η _)                ≡⟨ unit-φ ⟩
+      η _                             ∎
+    l .left-strength-μ =
+      (φ ∘ (η _ ⊗₁ id)) ∘ (id ⊗₁ μ _)                      ≡⟨ pullr (⊗.collapse (idr _ ,ₚ idl _)) ⟩
+      φ ∘ (η _ ⊗₁ μ _)                                     ≡˘⟨ refl⟩∘⟨ ⊗.collapse3 (cancell left-ident ,ₚ elimr (eliml M-id)) ⟩
+      φ ∘ (μ _ ⊗₁ μ _) ∘ (M₁ (η _) ⊗₁ M₁ id) ∘ (η _ ⊗₁ id) ≡⟨ pulll mult-φ ⟩
+      (μ _ ∘ M₁ φ ∘ φ) ∘ (M₁ (η _) ⊗₁ M₁ id) ∘ (η _ ⊗₁ id) ≡⟨ pullr (pullr (extendl (φ.is-natural _ _ _))) ⟩
+      μ _ ∘ M₁ φ ∘ M₁ (η _ ⊗₁ id) ∘ φ ∘ (η _ ⊗₁ id)        ≡⟨ refl⟩∘⟨ M.pulll refl ⟩
+      μ _ ∘ M₁ (φ ∘ (η _ ⊗₁ id)) ∘ φ ∘ (η _ ⊗₁ id)         ∎
+```
+</details>
+
+<!--
+```agda
+module _ {o ℓ}
+  {C : Precategory o ℓ} (Cᵐ : Monoidal-category C)
+  (monad : Monad C)
+  where
+  open Cat.Reasoning C
+  open Cat.Monoidal.Functor Cᵐ Cᵐ
+  open Monoidal-category Cᵐ
+  open Monad monad
+  private
+    module M = Cat.Functor.Reasoning M
+    module M² = Cat.Functor.Reasoning (M F∘ M)
+  open is-iso
+```
+-->
+
+[[Reversing|reverse monoidal category]] the construction, we also get a
+right strength.
+
+```agda
+  monoidal≃commutative
+    : Monoidal-monad-on Cᵐ monad
+    ≃ Σ (Monad-strength Cᵐ monad) is-commutative-strength
+  monoidal≃commutative = Iso→Equiv is where
+    is : Iso _ _
+    is .fst m = s , s-comm module to-strength where
+      open Monoidal-monad-on m
+      open Monad-strength
+      s : Monad-strength Cᵐ monad
+      s .strength-left = monoidal→left-strength m
+      s .strength-right = monad-strength^rev .fst
+        (monoidal→left-strength (monoidal-monad^rev m))
+```
+
+<details>
+<summary>
+The coherence of the strengths is tedious; it involves the naturality of
+the associator and the coherence of the monoidal multiplication with the
+associator.
+</summary>
+
+~~~{.quiver}
+\[\begin{tikzcd}[column sep=small]
+  {(A\otimes MB)\otimes C} &&& {A\otimes (MB\otimes C)} \\
+  {(MA\otimes MB)\otimes C} &&& {A\otimes (MB\otimes MC)} \\
+  {M(A\otimes B)\otimes C} & {(MA\otimes MB)\otimes MC} & {MA\otimes (MB\otimes MC)} & {A\otimes M(B\otimes C)} \\
+  {M(A\otimes B)\otimes MC} &&& {MA\otimes M(B\otimes C)} \\
+  {M((A\otimes B)\otimes C)} &&& {M(A\otimes (B\otimes C))}
+  \arrow[from=1-1, to=1-4]
+  \arrow[from=5-1, to=5-4]
+  \arrow[from=1-1, to=2-1]
+  \arrow[from=2-1, to=3-1]
+  \arrow[from=1-4, to=2-4]
+  \arrow[from=2-4, to=3-4]
+  \arrow[from=3-1, to=4-1]
+  \arrow[from=4-1, to=5-1]
+  \arrow[from=3-4, to=4-4]
+  \arrow[from=4-4, to=5-4]
+  \arrow[from=2-1, to=3-2]
+  \arrow[from=3-2, to=3-3]
+  \arrow[from=3-3, to=4-4]
+  \arrow[from=2-4, to=3-3]
+  \arrow[from=3-2, to=4-1]
+\end{tikzcd}\]
+~~~
+
+```agda
+      s .strength-α→ =
+        M₁ (α→ _ _ _) ∘ (φ ∘ (id ⊗₁ η _)) ∘ ((φ ∘ (η _ ⊗₁ id)) ⊗₁ id) ≡⟨ refl⟩∘⟨ pullr (⊗.weave (idl _ ,ₚ id-comm)) ⟩
+        M₁ (α→ _ _ _) ∘ φ ∘ (φ ⊗₁ id) ∘ ((η _ ⊗₁ id) ⊗₁ η _)          ≡⟨ extendl3 M-α→ ⟩
+        φ ∘ (id ⊗₁ φ) ∘ α→ _ _ _ ∘ ((η _ ⊗₁ id) ⊗₁ η _)               ≡⟨ refl⟩∘⟨ refl⟩∘⟨ associator .Isoⁿ.to ._=>_.is-natural _ _ _ ⟩
+        φ ∘ (id ⊗₁ φ) ∘ (η _ ⊗₁ (id ⊗₁ η _)) ∘ α→ _ _ _               ≡⟨ pushr (extendl (⊗.weave (id-comm-sym ,ₚ sym (idl _)))) ⟩
+        (φ ∘ (η _ ⊗₁ id)) ∘ (id ⊗₁ (φ ∘ (id ⊗₁ η _))) ∘ α→ _ _ _      ∎
+```
+</details>
+
+The crucial part is the proof that the strength thus defined is
+[[commutative|commutative monad]].
+Recall that this means that the two monoidal multiplications induced by
+the strength agree; in fact, we will show that they are both equal to
+$\varphi$!
+
+For the left-to-right composition, this is witnessed by the commutativity
+of the following diagram; the other direction is completely symmetric.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {MA\otimes MB} && {MA \otimes MB} \\
+  {MA\otimes M^2 B} & {M^2 A\otimes M^2 B} \\
+  {M(A\otimes MB)} \\
+  {M(MA\otimes MB)} \\
+  {M^2(A\otimes B)} && {M(A\otimes B)}
+  \arrow["{MA \otimes \eta_{MB}}"', from=1-1, to=2-1]
+  \arrow["\varphi"', from=2-1, to=3-1]
+  \arrow["\mu"', from=5-1, to=5-3]
+  \arrow["{M(\eta_A \otimes MB)}"', from=3-1, to=4-1]
+  \arrow["M\varphi"', from=4-1, to=5-1]
+  \arrow["{M\eta_A\otimes M^2 B}", from=2-1, to=2-2]
+  \arrow["\varphi", from=2-2, to=4-1]
+  \arrow["{\mu_A\otimes \mu_B}"', from=2-2, to=1-3]
+  \arrow["\varphi", from=1-3, to=5-3]
+  \arrow[Rightarrow, no head, from=1-1, to=1-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+      opaque
+        left≡φ : left-φ s ≡ M-mult
+        left≡φ = ext λ (A , B) →
+          μ _ ∘ M₁ (φ ∘ (η _ ⊗₁ id)) ∘ φ ∘ (id ⊗₁ η _)       ≡⟨ refl⟩∘⟨ M.popr (extendl (sym (φ.is-natural _ _ _))) ⟩
+          μ _ ∘ M₁ φ ∘ φ ∘ (M₁ (η _) ⊗₁ M₁ id) ∘ (id ⊗₁ η _) ≡⟨ pushr (pushr (refl⟩∘⟨ ⊗.collapse (elimr refl ,ₚ M.eliml refl))) ⟩
+          (μ _ ∘ M₁ φ ∘ φ) ∘ (M₁ (η _) ⊗₁ η _)               ≡˘⟨ pulll mult-φ ⟩
+          φ ∘ (μ _ ⊗₁ μ _) ∘ (M₁ (η _) ⊗₁ η _)               ≡⟨ elimr (⊗.annihilate (left-ident ,ₚ right-ident)) ⟩
+          φ                                                  ∎
+
+        right≡φ : right-φ s ≡ M-mult
+        right≡φ = ext λ (A , B) →
+          μ _ ∘ M₁ (φ ∘ (id ⊗₁ η _)) ∘ φ ∘ (η _ ⊗₁ id)       ≡⟨ refl⟩∘⟨ M.popr (extendl (sym (φ.is-natural _ _ _))) ⟩
+          μ _ ∘ M₁ φ ∘ φ ∘ (M₁ id ⊗₁ M₁ (η _)) ∘ (η _ ⊗₁ id) ≡⟨ pushr (pushr (refl⟩∘⟨ ⊗.collapse (M.eliml refl ,ₚ elimr refl))) ⟩
+          (μ _ ∘ M₁ φ ∘ φ) ∘ (η _ ⊗₁ M₁ (η _))               ≡˘⟨ pulll mult-φ ⟩
+          φ ∘ (μ _ ⊗₁ μ _) ∘ (η _ ⊗₁ M₁ (η _))               ≡⟨ elimr (⊗.annihilate (right-ident ,ₚ left-ident)) ⟩
+          φ                                                  ∎
+
+        s-comm : is-commutative-strength s
+        s-comm = right≡φ ∙ sym left≡φ
+```
+
+### Monoidal monads from commutative monads
+
+In the other direction, we are given a commutative strength and we must
+construct a monoidal monad. We already [[know|monoidal functors from
+strong monads]] how to construct a monoidal *functor* structure on a
+strong monad; all that remains is to check that it makes the monad
+structure monoidal.
+
+```agda
+    is .snd .inv (s , s-comm) = m where
+      open Monad-strength s
+      open Monoidal-monad-on
+      open Lax-monoidal-functor-on
+
+      m : Monoidal-monad-on Cᵐ monad
+      m .monad-monoidal = strength→monoidal s
+```
+
+The monoidal unit is $\eta_1$ by definition.
+
+```agda
+      m .unit-ε = refl
+```
+
+<details>
+<summary>
+The `unit-φ`{.Agda} coherence is not very interesting.
+</summary>
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {A\otimes B} && {MA\otimes MB} \\
+  & {A\otimes MB} & {M(A\otimes MB)} \\
+  && {M²(A\otimes B)} \\
+  {M(A \otimes B)} && {M(A\otimes B)}
+  \arrow["{\eta_A \otimes \eta_B}", from=1-1, to=1-3]
+  \arrow["\tau", from=1-3, to=2-3]
+  \arrow["M\sigma", from=2-3, to=3-3]
+  \arrow["{A \otimes \eta_B}", from=1-1, to=2-2]
+  \arrow["\eta", from=2-2, to=2-3]
+  \arrow["\mu", from=3-3, to=4-3]
+  \arrow["{\eta_{A\otimes B}}"', from=1-1, to=4-1]
+  \arrow[Rightarrow, no head, from=4-1, to=4-3]
+  \arrow["\sigma"', from=2-2, to=4-1]
+  \arrow["\eta", from=4-1, to=3-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+      m .unit-φ =
+        (μ _ ∘ M₁ σ ∘ τ) ∘ (η _ ⊗₁ η _)            ≡⟨ pullr (pullr (refl⟩∘⟨ ⊗.expand (intror refl ,ₚ introl refl))) ⟩
+        μ _ ∘ M₁ σ ∘ τ ∘ (η _ ⊗₁ id) ∘ (id ⊗₁ η _) ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pulll right-strength-η ⟩
+        μ _ ∘ M₁ σ ∘ η _ ∘ (id ⊗₁ η _)             ≡˘⟨ refl⟩∘⟨ extendl (unit.is-natural _ _ _) ⟩
+        μ _ ∘ η _ ∘ σ ∘ (id ⊗₁ η _)                ≡⟨ cancell right-ident ⟩
+        σ ∘ (id ⊗₁ η _)                            ≡⟨ left-strength-η ⟩
+        η _                                        ∎
+```
+</details>
+
+As expected, the proof of `mult-φ`{.Agda} involves the commutativity of
+the strength. At a very high level, we are trying to collapse
+the sequence $\tau\sigma\tau\sigma$ to $\tau\sigma$: we first need
+to commute the two strengths in the middle to obtain $\tau\tau\sigma
+\sigma$, and then use the fact that two consecutive applications of the
+strengths result in just one after commuting with $\mu$.
+Concretely, this manifests as the following diagram, where the
+commutation of the strengths is highlighted.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {M^2 A\otimes M^2 B} &&& {MA\otimes MB} \\
+  {M(MA\otimes M^2 B)} && {MA\otimes M^2B} \\
+  {M^2(MA\otimes MB)} & {M^2(A \otimes M^2 B)} \\
+  {M(MA\otimes MB)} & {M^3(A \otimes MB)} & {M(A\otimes M^2 B)} \\
+  &&& {M(A\otimes MB)} \\
+  {M^2(A\otimes MB)} && {M^3(A\otimes B)} \\
+  & {M(A \otimes MB)} \\
+  {M^3(A\otimes B)} &&& {M^2(A\otimes B)} \\
+  &&& {M(A\otimes B)}
+  \arrow["{\mu\otimes \mu}", from=1-1, to=1-4]
+  \arrow["\tau"', from=1-1, to=2-1]
+  \arrow["M\sigma"', draw={rgb,255:red,214;green,92;blue,214}, from=2-1, to=3-1]
+  \arrow["\mu"', from=3-1, to=4-1]
+  \arrow["M\tau"', from=4-1, to=6-1]
+  \arrow["{M^2\sigma}"', from=6-1, to=8-1]
+  \arrow["\tau", from=1-4, to=5-4]
+  \arrow["M\sigma", from=5-4, to=8-4]
+  \arrow["\mu", from=8-4, to=9-4]
+  \arrow["{M^2\tau}"', draw={rgb,255:red,214;green,92;blue,214}, from=3-1, to=4-2]
+  \arrow["{(M)\mu}"', draw={rgb,255:red,214;green,92;blue,214}, from=4-2, to=6-1]
+  \arrow["\mu"', from=6-1, to=7-2]
+  \arrow["M\tau", draw={rgb,255:red,214;green,92;blue,214}, from=2-1, to=3-2]
+  \arrow["{M^2\sigma}", draw={rgb,255:red,214;green,92;blue,214}, from=3-2, to=4-2]
+  \arrow["{\mu\otimes MMB}"', from=1-1, to=2-3]
+  \arrow["{MA\otimes \mu}"', from=2-3, to=1-4]
+  \arrow["\mu", from=3-2, to=4-3]
+  \arrow["M\sigma", from=4-3, to=6-1]
+  \arrow["{M^2\sigma}", from=6-1, to=6-3]
+  \arrow["{M(A\otimes\mu)}", from=4-3, to=5-4]
+  \arrow["\tau", from=2-3, to=4-3]
+  \arrow["{(M)\mu}", from=6-3, to=8-4]
+  \arrow["M\sigma", from=7-2, to=8-4]
+  \arrow["{(M)\mu}"', from=8-1, to=8-4]
+\end{tikzcd}\]
+~~~
+
+The morphisms labelled $(M)\mu$ alternate between being $\mu$ and $M\mu$,
+in a way that is allowed by the associativity law because they are
+followed by $\mu$.
+
+```agda
+      m .mult-φ =
+        (μ _ ∘ M₁ σ ∘ τ) ∘ (μ _ ⊗₁ μ _)                        ≡⟨ refl⟩∘⟨ ⊗.expand (M.introl refl ,ₚ intror refl) ⟩
+        (μ _ ∘ M₁ σ ∘ τ) ∘ (M₁ id ⊗₁ μ _) ∘ (μ _ ⊗₁ id)        ≡⟨ pullr (pullr (extendl (τ.is-natural _ _ _))) ⟩
+        μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ μ _) ∘ τ ∘ (μ _ ⊗₁ id)          ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ right-strength-μ ⟩
+        μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ μ _) ∘ μ _ ∘ M₁ τ ∘ τ           ≡⟨ refl⟩∘⟨ M.pulll (left-strength-μ ∙ assoc _ _ _) ⟩
+        μ _ ∘ M₁ ((μ _ ∘ M₁ σ) ∘ σ) ∘ μ _ ∘ M₁ τ ∘ τ           ≡⟨ refl⟩∘⟨ extendl (M.popr (sym (mult.is-natural _ _ _))) ⟩
+        μ _ ∘ M₁ (μ _ ∘ M₁ σ) ∘ (μ _ ∘ M₁ (M₁ σ)) ∘ M₁ τ ∘ τ   ≡⟨ extendl (M.popl mult-assoc) ⟩
+        (μ _ ∘ μ _) ∘ M₁ (M₁ σ) ∘ (μ _ ∘ M₁ (M₁ σ)) ∘ M₁ τ ∘ τ ≡⟨ pullr (extendl (mult.is-natural _ _ _)) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ (μ _ ∘ M₁ (M₁ σ)) ∘ M₁ τ ∘ τ        ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ extendl (extendl mult-assoc) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ (M₁ (μ _) ∘ M₁ (M₁ σ)) ∘ M₁ τ ∘ τ   ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ sym (assoc _ _ _) ∙ M.extendl3 (sym (s-comm ηₚ _)) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ (μ _) ∘ M₁ (M₁ τ) ∘ M₁ σ ∘ τ     ≡⟨ refl⟩∘⟨ refl⟩∘⟨ extendl mult-assoc ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ μ _ ∘ M₁ (M₁ τ) ∘ M₁ σ ∘ τ          ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ extendl (mult.is-natural _ _ _) ⟩
+        μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ τ ∘ μ _ ∘ M₁ σ ∘ τ               ≡˘⟨ refl⟩∘⟨ extendl (mult.is-natural _ _ _) ⟩
+        μ _ ∘ μ _ ∘ M₁ (M₁ σ) ∘ M₁ τ ∘ μ _ ∘ M₁ σ ∘ τ          ≡˘⟨ extendl mult-assoc ⟩
+        μ _ ∘ M₁ (μ _) ∘ M₁ (M₁ σ) ∘ M₁ τ ∘ μ _ ∘ M₁ σ ∘ τ     ≡⟨ refl⟩∘⟨ M.pulll3 refl ⟩
+        μ _ ∘ M₁ (μ _ ∘ M₁ σ ∘ τ) ∘ μ _ ∘ M₁ σ ∘ τ             ∎
+```
+
+### Wrapping up
+
+Finally, we check that these two transformations are mutual inverses.
+
+Given a commutative strength, we must check that the round-trip defined
+above yields the same left and right strengths we started with; the
+situation isn't entirely symmetric because we've made a *choice* to
+use the right strength first when defining the monoidal structure, but
+both verifications are straightforward.
+
+```agda
+    is .snd .rinv (s , s-comm) = Σ-prop-path (λ _ → hlevel 1)
+      (Monad-strength-path Cᵐ monad
+        (Left-monad-strength-path Cᵐ monad
+          (Left-strength-path Cᵐ M (sym l)))
+        (Right-monad-strength-path Cᵐ monad
+          (Right-strength-path Cᵐ M (sym r))))
+      where
+        open Monad-strength s
+        l : left-strength ≡ is .fst (is .snd .inv (s , s-comm)) .fst .Monad-strength.left-strength
+        l = ext λ (A , B) →
+          σ                              ≡⟨ insertl right-ident ⟩
+          μ _ ∘ η _ ∘ σ                  ≡⟨ refl⟩∘⟨ unit.is-natural _ _ _ ⟩
+          μ _ ∘ M₁ σ ∘ η _               ≡˘⟨ pullr (pullr right-strength-η) ⟩
+          (μ _ ∘ M₁ σ ∘ τ) ∘ (η _ ⊗₁ id) ∎
+        r : right-strength ≡ is .fst (is .snd .inv (s , s-comm)) .fst .Monad-strength.right-strength
+        r = ext λ (A , B) →
+          τ                                     ≡⟨ insertl left-ident ⟩
+          μ _ ∘ M₁ (η _) ∘ τ                    ≡˘⟨ refl⟩∘⟨ M.pulll left-strength-η ⟩
+          μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ η _) ∘ τ       ≡˘⟨ pullr (pullr (τ.is-natural _ _ _)) ⟩
+          (μ _ ∘ M₁ σ ∘ τ) ∘ (⌜ M₁ id ⌝ ⊗₁ η _) ≡⟨ ap! M-id ⟩
+          (μ _ ∘ M₁ σ ∘ τ) ∘ (id ⊗₁ η _)        ∎
+```
+
+For the other round-trip, we've *already* proved above that we get the
+same $\varphi$ we started with; moreover, the monoidal unit $\epsilon$
+becomes $\eta_1$, but the axioms of a monoidal monad force those to be
+the same, so we're done.
+
+```agda
+    is .snd .linv m = Monoidal-monad-on-path Cᵐ
+      (Lax-monoidal-functor-on-path
+        (sym unit-ε)
+        (to-strength.left≡φ m))
+      where open Monoidal-monad-on m
+```
+
+<!--
+```agda
+  module monoidal≃commutative = Equiv monoidal≃commutative
+```
+-->
+
+### Symmetric monoidal monads and commutative symmetric strengths {defines="symmetric-monoidal-monad"}
+
+We can now refine this to Kock's [-@Kock:monoidal-monads] original
+result, which concerns *symmetric* monoidal monads in a [[symmetric
+monoidal category]].
+
+<!--
+```agda
+  module _ (Cˢ : Symmetric-monoidal Cᵐ) where
+    open Symmetric-monoidal Cˢ
+```
+-->
+
+We define a **symmetric monoidal monad** as a monoidal monad whose
+underlying monoidal functor is [[symmetric|symmetric monoidal functor]].
+
+```agda
+    is-symmetric-monoidal-monad : Monoidal-monad-on Cᵐ monad → Type (o ⊔ ℓ)
+    is-symmetric-monoidal-monad m = is-symmetric-functor Cˢ Cˢ
+      (_ , m .Monoidal-monad-on.monad-monoidal)
+```
+
+Then, we have that, *over* the above identification between monoidal
+monads and commutative strengths, the property of being a *symmetric*
+monoidal monad is identified with the property of being a *symmetric*
+strength.
+
+Given a symmetric monoidal monad, we immediately see that the induced
+left and right strengths are related by the braiding.
+
+<!--
+```agda
+    module _ (m : Monoidal-monad-on Cᵐ monad) where
+      open Monoidal-monad-on m
+```
+-->
+
+```agda
+      symmetric-monoidal→symmetric-strength
+        : is-symmetric-monoidal-monad m
+        → is-symmetric-monad-strength Cᵇ (monoidal≃commutative.to m .fst)
+      symmetric-monoidal→symmetric-strength sy =
+        (φ ∘ (id ⊗₁ η _)) ∘ β→  ≡⟨ pullr (sym (β→.is-natural _ _ _)) ⟩
+        φ ∘ β→ ∘ (η _ ⊗₁ id)    ≡⟨ extendl sy ⟩
+        M₁ β→ ∘ φ ∘ (η _ ⊗₁ id) ∎
+```
+
+Now, given a symmetric commutative strength, we can use the commutativity
+as follows to conclude that the induced monoidal functor is symmetric:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {MA \otimes MB} && {MB \otimes MA} \\
+  {M(A \otimes MB)} & {M(MA \otimes B)} & {M (B \otimes MA)} \\
+  {M^2 (A \otimes B)} && {M^2 (B \otimes A)} \\
+  {M (A \otimes B)} && {M (B \otimes A)}
+  \arrow["\beta", from=1-1, to=1-3]
+  \arrow["\tau"', from=1-1, to=2-1]
+  \arrow["M\sigma"', from=2-1, to=3-1]
+  \arrow["\mu"', from=3-1, to=4-1]
+  \arrow["\tau", from=1-3, to=2-3]
+  \arrow["M\sigma", from=2-3, to=3-3]
+  \arrow["\mu", from=3-3, to=4-3]
+  \arrow["M\beta"', from=4-1, to=4-3]
+  \arrow["\sigma"', from=1-1, to=2-2]
+  \arrow["M\tau"', from=2-2, to=3-1]
+  \arrow["M\beta", from=2-2, to=2-3]
+  \arrow["{M^2\beta}", from=3-1, to=3-3]
+\end{tikzcd}\]
+~~~
+
+<!--
+```agda
+    module _ ((s , s-comm) : Σ _ is-commutative-strength) where
+      open Monad-strength s
+```
+-->
+
+```agda
+      symmetric-strength→symmetric-monoidal
+        : is-symmetric-monad-strength Cᵇ s
+        → is-symmetric-monoidal-monad (monoidal≃commutative.from (s , s-comm))
+      symmetric-strength→symmetric-monoidal sy =
+        (μ _ ∘ M₁ σ ∘ τ) ∘ β→       ≡⟨ pullr (pullr sy) ⟩
+        μ _ ∘ M₁ σ ∘ M₁ β→ ∘ σ      ≡˘⟨ refl⟩∘⟨ M.extendl (swizzle sy has-is-symmetric (M.annihilate has-is-symmetric)) ⟩
+        μ _ ∘ M₁ (M₁ β→) ∘ M₁ τ ∘ σ ≡⟨ extendl (mult.is-natural _ _ _) ⟩
+        M₁ β→ ∘ μ _ ∘ M₁ τ ∘ σ      ≡⟨ refl⟩∘⟨ s-comm ηₚ _ ⟩
+        M₁ β→ ∘ μ _ ∘ M₁ σ ∘ τ      ∎
+```
+
+Packaging all of this together, we conclude with the desired equivalence
+between the *structure* of a symmetric monoidal monad and the *structure*
+of a symmetric commutative strength.
+
+```agda
+    symmetric-monoidal≃symmetric-commutative
+      : Σ (Monoidal-monad-on Cᵐ monad) is-symmetric-monoidal-monad
+      ≃ Σ (Monad-strength Cᵐ monad) (λ s →
+        is-commutative-strength s × is-symmetric-monad-strength Cᵇ s)
+    symmetric-monoidal≃symmetric-commutative =
+      Σ-ap monoidal≃commutative (λ m → prop-ext!
+        (symmetric-monoidal→symmetric-strength m)
+        (λ sy → subst is-symmetric-monoidal-monad (monoidal≃commutative.η m)
+          (symmetric-strength→symmetric-monoidal
+            (monoidal≃commutative.to m) sy)))
+      ∙e Σ-assoc e⁻¹
+```

--- a/src/Cat/Monoidal/Reverse.lagda.md
+++ b/src/Cat/Monoidal/Reverse.lagda.md
@@ -15,14 +15,14 @@ open Monoidal-category
 
 ```agda
 module Cat.Monoidal.Reverse {o ℓ}
-  {C : Precategory o ℓ} (C-monoidal : Monoidal-category C)
+  {C : Precategory o ℓ} (Cᵐ : Monoidal-category C)
   where
 ```
 
 <!--
 ```agda
 open Cat.Reasoning C
-private module C = Monoidal-category C-monoidal
+private module C = Monoidal-category Cᵐ
 open _=>_
 ```
 -->

--- a/src/Cat/Monoidal/Strength.lagda.md
+++ b/src/Cat/Monoidal/Strength.lagda.md
@@ -29,11 +29,11 @@ module Cat.Monoidal.Strength where
 ```agda
 module _
   {o ℓ} {C : Precategory o ℓ}
-  (C-monoidal : Monoidal-category C)
+  (Cᵐ : Monoidal-category C)
   (F : Functor C C)
   where
   open Cat.Reasoning C
-  open Monoidal-category C-monoidal
+  open Monoidal-category Cᵐ
   open Functor F
   private module F = Cat.Functor.Reasoning F
 ```
@@ -139,13 +139,13 @@ A functor equipped with a strength is called a **strong functor**.
   Left-strength-path
     : ∀ {a b} → a .Left-strength.left-strength ≡ b .Left-strength.left-strength
     → a ≡ b
-  Left-strength-path p = Equiv.injective (Iso→Equiv left-eqv) (Σ-prop-path (λ _ → hlevel 1) p)
+  Left-strength-path p = Iso.injective left-eqv (Σ-prop-path (λ _ → hlevel 1) p)
 
   private unquoteDecl right-eqv = declare-record-iso right-eqv (quote Right-strength)
   Right-strength-path
     : ∀ {a b} → a .Right-strength.right-strength ≡ b .Right-strength.right-strength
     → a ≡ b
-  Right-strength-path p = Equiv.injective (Iso→Equiv right-eqv) (Σ-prop-path (λ _ → hlevel 1) p)
+  Right-strength-path p = Iso.injective right-eqv (Σ-prop-path (λ _ → hlevel 1) p)
 ```
 -->
 
@@ -153,8 +153,8 @@ A functor equipped with a strength is called a **strong functor**.
 
 <!--
 ```agda
-  module _ (C-braided : Braided-monoidal C-monoidal) where
-    open Braided C-monoidal C-braided
+  module _ (Cᵇ : Braided-monoidal Cᵐ) where
+    open Braided Cᵐ Cᵇ
     open is-iso
 ```
 -->
@@ -180,7 +180,9 @@ Therefore, the literature usually speaks of "strength" in a symmetric
 monoidal category to mean either a left or a right strength, but note
 that this is not quite the same as a `Strength`{.Agda} as defined above,
 which has left and right strengths *not necessarily related* by the
-braiding. If they are, we will say that the strength is *symmetric*.
+braiding. If they are, we will say that the strength is *symmetric*;
+such a strength contains exactly the information of a left (or right)
+strength.
 
 ```agda
     is-symmetric-strength : Strength → Type (o ⊔ ℓ)
@@ -282,8 +284,8 @@ module _ {o ℓ} {C : Precategory o ℓ}
 -->
 
 ```agda
-  left^rev≃right : Left-strength (M ^rev) F ≃ Right-strength M F
-  left^rev≃right = Iso→Equiv is where
+  strength^rev : Left-strength (M ^rev) F ≃ Right-strength M F
+  strength^rev = Iso→Equiv is where
     is : Iso _ _
     is .fst l = record
       { right-strength = NT (λ _ → σ) λ _ _ _ → σ.is-natural _ _ _
@@ -299,7 +301,7 @@ module _ {o ℓ} {C : Precategory o ℓ}
     is .snd .linv _ = Left-strength-path _ _ trivial!
 ```
 
-## Sets-endofunctors are strong
+## Sets-endofunctors are strong {defines="sets-endofunctors-are-strong"}
 
 <!--
 ```agda

--- a/src/Cat/Monoidal/Strength/Monad.lagda.md
+++ b/src/Cat/Monoidal/Strength/Monad.lagda.md
@@ -1,0 +1,403 @@
+<!--
+```agda
+open import Cat.Monoidal.Instances.Cartesian
+open import Cat.Functor.Coherence
+open import Cat.Instances.Product
+open import Cat.Monoidal.Strength
+open import Cat.Monoidal.Braided
+open import Cat.Monoidal.Functor
+open import Cat.Monoidal.Reverse
+open import Cat.Diagram.Monad
+open import Cat.Monoidal.Base
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Monoidal.Strength.Monad where
+```
+
+# Strong monads {defines="strong-monad monad-strength left-monad-strength right-monad-strength"}
+
+Recall that a (left) [[strength]] for an endofunctor $M : \cC \to
+\cC$ on a [[monoidal category]] consists of a natural transformation
+$A \otimes MB \to M (A \otimes B)$ allowing us to "slide" things from
+the ambient context into the functor. If $M$ is equipped with the
+structure of a [[monad]], then it is natural to refine this notion to be
+compatible with the monad, yielding the notion of a (left/right-)
+**strong monad**.
+
+<!--
+```agda
+module _ {o ℓ} {C : Precategory o ℓ} (Cᵐ : Monoidal-category C) (monad : Monad C) where
+  open Cat.Reasoning C
+  open Monoidal-category Cᵐ
+  open Monad monad
+```
+-->
+
+```agda
+  record Left-monad-strength : Type (o ⊔ ℓ) where
+    field
+      functor-strength : Left-strength Cᵐ M
+
+    open Left-strength functor-strength public
+
+    field
+      left-strength-η : ∀ {A B} → σ ∘ (id ⊗₁ η B) ≡ η (A ⊗ B)
+      left-strength-μ : ∀ {A B} → σ ∘ (id ⊗₁ μ B) ≡ μ (A ⊗ B) ∘ M₁ σ ∘ σ
+
+  record Right-monad-strength : Type (o ⊔ ℓ) where
+    field
+      functor-strength : Right-strength Cᵐ M
+
+    open Right-strength functor-strength public
+
+    field
+      right-strength-η : ∀ {A B} → τ ∘ (η A ⊗₁ id) ≡ η (A ⊗ B)
+      right-strength-μ : ∀ {A B} → τ ∘ (μ A ⊗₁ id) ≡ μ (A ⊗ B) ∘ M₁ τ ∘ τ
+
+  record Monad-strength : Type (o ⊔ ℓ) where
+    field
+      strength-left : Left-monad-strength
+      strength-right : Right-monad-strength
+
+    open Left-monad-strength strength-left hiding (functor-strength) public
+    open Right-monad-strength strength-right hiding (functor-strength) public
+
+    field
+      strength-α→ : ∀ {A B C}
+        → M₁ (α→ A B C) ∘ τ ∘ (σ ⊗₁ id) ≡ σ ∘ (id ⊗₁ τ) ∘ α→ A (M₀ B) C
+```
+
+Strong monads are of particular importance in the semantics of effectful
+programming languages: while monads are used to model effects, they do
+not capture the fact that monadic computations can make use of
+information from the *context*; for example, consider the following
+pseudo-Haskell program (in `do` notation, then in two possible
+desugared forms):
+
+<div class="mathpar">
+```haskell
+do
+  a ← ma ∷ M A
+  b ← mb ∷ M B
+  pure (a , b)
+```
+
+$=$
+
+```haskell
+ma >>= λ a →
+  mb >>= λ b →
+    pure (a , b)
+```
+
+$=$
+
+```haskell
+join (fmap (λ a →
+  fmap (λ b →
+    (a , b)) mb) ma)
+```
+</div>
+
+Notice that `mb`, and then `a`, are available *under*
+$\lambda$-*abstractions*: this is no problem in a functional programming
+language like Haskell, because monads are automatically *enriched* in
+the sense that the functorial action `fmap` is an *internal* morphism;
+in other words, [[$\Sets$-monads are strong]]. But the
+mathematical denotation of the above program in a general monoidal
+category makes crucial use of the strengths, as we will see below.
+
+With this perspective in mind, the additional coherences imposed on a
+*monad* strength are quite natural: using the strength to slide into a
+"pure" computation (that is, one in the image of the unit) should yield
+a pure computation, and using the strength twice before multiplying
+should be the same as using it once after multiplying: they express a
+sort of "internal naturality" condition for the unit and multiplication
+with respect to the enrichment induced by the strength.
+
+<!--
+```agda
+    functor-strength : Strength Cᵐ M
+    functor-strength .Strength.strength-left = strength-left .Left-monad-strength.functor-strength
+    functor-strength .Strength.strength-right = strength-right .Right-monad-strength.functor-strength
+    functor-strength .Strength.strength-α→ = strength-α→
+
+  private unquoteDecl left-eqv = declare-record-iso left-eqv (quote Left-monad-strength)
+  Left-monad-strength-path
+    : ∀ {a b}
+    → a .Left-monad-strength.functor-strength ≡ b .Left-monad-strength.functor-strength
+    → a ≡ b
+  Left-monad-strength-path p = Iso.injective left-eqv (Σ-prop-path (λ _ → hlevel 1) p)
+
+  private unquoteDecl right-eqv = declare-record-iso right-eqv (quote Right-monad-strength)
+  Right-monad-strength-path
+    : ∀ {a b}
+    → a .Right-monad-strength.functor-strength ≡ b .Right-monad-strength.functor-strength
+    → a ≡ b
+  Right-monad-strength-path p = Iso.injective right-eqv (Σ-prop-path (λ _ → hlevel 1) p)
+
+  private unquoteDecl strength-eqv = declare-record-iso strength-eqv (quote Monad-strength)
+  Monad-strength-path
+    : ∀ {a b}
+    → a .Monad-strength.strength-left ≡ b .Monad-strength.strength-left
+    → a .Monad-strength.strength-right ≡ b .Monad-strength.strength-right
+    → a ≡ b
+  Monad-strength-path p q = Iso.injective strength-eqv (Σ-pathp p (Σ-prop-pathp (λ _ _ → hlevel 1) q))
+```
+-->
+
+## Monoidal functors from strong monads {defines="monoidal-functors-from-strong-monads"}
+
+<!--
+```agda
+module _ {o ℓ}
+  {C : Precategory o ℓ} {Cᵐ : Monoidal-category C}
+  {monad : Monad C}
+  where
+  open Cat.Reasoning C
+  open Monoidal-category Cᵐ
+  open Monad monad
+  private
+    module M = Cat.Functor.Reasoning M
+  open is-iso
+
+  module _ (s : Monad-strength Cᵐ monad) where
+    open Monad-strength s
+    open Lax-monoidal-functor-on
+```
+-->
+
+The above program wasn't picked at random -- it witnesses the common
+functional programming wisdom that "every monad is an applicative
+functor[^applicative]", whose theoretical underpinning is that, given a
+*strong* monad $M$, we can equip $M$ with the structure of a [[lax monoidal
+functor]].
+
+[^applicative]: Applicative functors, or *idioms*, are usually defined
+as [[lax monoidal functors]] equipped with a compatible strength (not to
+be confused with [[strong monoidal functors]]).
+
+In fact, we can do so in *two* different ways, corresponding to
+sequencing the effects from left to right or from right to left:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  & {M (A \otimes MB)} & {M^2 (A \otimes B)} \\
+  {MA \otimes MB} &&& {M (A \otimes B)} \\
+  & {M (MA \otimes B)} & {M^2 (A \otimes B)}
+  \arrow["\tau", from=2-1, to=1-2]
+  \arrow["M\sigma", from=1-2, to=1-3]
+  \arrow["\mu", from=1-3, to=2-4]
+  \arrow["\sigma"', from=2-1, to=3-2]
+  \arrow["M\tau"', from=3-2, to=3-3]
+  \arrow["\mu"', from=3-3, to=2-4]
+\end{tikzcd}\]
+~~~
+
+```agda
+    left-φ right-φ : -⊗- F∘ (M F× M) => M F∘ -⊗-
+
+    left-φ = (mult ◂ -⊗-) ∘nt nat-assoc-to (M ▸ left-strength) ∘nt right-strength'
+      where
+        unquoteDecl right-strength' =
+          cohere-into right-strength' (-⊗- F∘ (M F× M) => M F∘ -⊗- F∘ (Id F× M))
+            (right-strength ◂ (Id F× M))
+
+    right-φ = (mult ◂ -⊗-) ∘nt nat-assoc-to (M ▸ right-strength) ∘nt left-strength'
+      where
+        unquoteDecl left-strength' =
+          cohere-into left-strength' (-⊗- F∘ (M F× M) => M F∘ -⊗- F∘ (M F× Id))
+            (left-strength ◂ (M F× Id))
+```
+
+::: {.definition #commutative-monad alias="commutative-strength"}
+If the two ways are the same (thus if the above diagram commutes), we say
+that the monad (or the strength) is **commutative**.
+:::
+
+```agda
+    is-commutative-strength : Type (o ⊔ ℓ)
+    is-commutative-strength = right-φ ≡ left-φ
+```
+
+<details>
+<summary>
+We now complete the definition of the *left-to-right* monoidal structure,
+which requires a bit of work. For the unit, we pick $\eta_1$, the unit
+of the monad.
+
+```agda
+    strength→monoidal : Lax-monoidal-functor-on Cᵐ Cᵐ M
+    strength→monoidal .ε = η Unit
+    strength→monoidal .F-mult = left-φ
+```
+</summary>
+
+The associator coherence is witnessed by the following ~~monstrosity~~
+commutative diagram.
+
+~~~{.quiver}
+\[\begin{tikzcd}[column sep=0.4em]
+  {(MA\otimes MB)\otimes MC} &&&& {MA\otimes(MB\otimes MC)} \\
+  {M(A\otimes MB)\otimes MC} & {M((A\otimes MB)\otimes MC)} & {M(A\otimes (MB\otimes MC))} && {MA\otimes M(B\otimes MC)} \\
+  {M^2(A\otimes B)\otimes MC} & {M(M(A\otimes B)\otimes MC)} & {M(A\otimes M(B\otimes MC))} & {M(A\otimes M^2(B\otimes C))} & {MA\otimes M^2(B\otimes C)} \\
+  {M(A\otimes B)\otimes MC} & {M^2((A\otimes B)\otimes MC)} & {M^2(A\otimes(B\otimes MC))} & {M^2(A\otimes M(B\otimes C))} & {MA\otimes M(B\otimes C)} \\
+  {M((A\otimes B)\otimes MC)} && {M(A\otimes (B\otimes MC))} & {M^3(A\otimes (B\otimes C))} & {M(A\otimes M(B\otimes C))} \\
+  && {M(A\otimes M(B\otimes C))} \\
+  {M^2((A\otimes B)\otimes C)} &&&& {M^2(A\otimes (B\otimes C))} \\
+  {M((A\otimes B)\otimes C)} &&&& {M(A\otimes (B\otimes C))}
+  \arrow[from=1-1, to=1-5]
+  \arrow[from=1-1, to=2-1]
+  \arrow[from=2-1, to=3-1]
+  \arrow[from=3-1, to=4-1]
+  \arrow[from=4-1, to=5-1]
+  \arrow[from=5-1, to=7-1]
+  \arrow[from=7-1, to=8-1]
+  \arrow[from=8-1, to=8-5]
+  \arrow[from=1-5, to=2-5]
+  \arrow[from=2-5, to=3-5]
+  \arrow[from=3-5, to=4-5]
+  \arrow[from=4-5, to=5-5]
+  \arrow[from=5-5, to=7-5]
+  \arrow[from=7-5, to=8-5]
+  \arrow[from=2-1, to=2-2]
+  \arrow[from=1-5, to=2-3]
+  \arrow[from=2-2, to=2-3]
+  \arrow[from=2-5, to=3-3]
+  \arrow[from=2-3, to=3-3]
+  \arrow[from=3-5, to=3-4]
+  \arrow[from=3-3, to=3-4]
+  \arrow[from=3-4, to=5-5]
+  \arrow[from=2-2, to=3-2]
+  \arrow[from=3-1, to=3-2]
+  \arrow[from=3-3, to=4-3]
+  \arrow[from=3-2, to=4-2]
+  \arrow[from=4-2, to=4-3]
+  \arrow[from=4-2, to=5-1]
+  \arrow[from=5-1, to=5-3]
+  \arrow[from=4-3, to=5-3]
+  \arrow[from=7-1, to=7-5]
+  \arrow[from=4-3, to=4-4]
+  \arrow[from=3-4, to=4-4]
+  \arrow[from=5-3, to=6-3]
+  \arrow[from=6-3, to=7-5]
+  \arrow[from=4-4, to=5-4]
+  \arrow["\mu"', curve={height=6pt}, from=5-4, to=7-5]
+  \arrow[from=4-4, to=6-3]
+  \arrow["M\mu", curve={height=-6pt}, from=5-4, to=7-5]
+\end{tikzcd}\]
+~~~
+
+```agda
+    strength→monoidal .F-α→ =
+      M₁ (α→ _ _ _) ∘ (μ _ ∘ M₁ σ ∘ τ) ∘ ((μ _ ∘ M₁ σ ∘ τ) ⊗₁ id)                                    ≡⟨ pulll (extendl (sym (mult.is-natural _ _ _))) ⟩
+      (μ _ ∘ M₁ (M₁ (α→ _ _ _)) ∘ M₁ σ ∘ τ) ∘ ((μ _ ∘ M₁ σ ∘ τ) ⊗₁ id)                               ≡⟨ pullr (pullr (pullr refl)) ⟩
+      μ _ ∘ M₁ (M₁ (α→ _ _ _)) ∘ M₁ σ ∘ τ ∘ ((μ _ ∘ M₁ σ ∘ τ) ⊗₁ id)                                 ≡⟨ refl⟩∘⟨ M.pulll left-strength-α→ ⟩
+      μ _ ∘ M₁ (σ ∘ (id ⊗₁ σ) ∘ α→ _ _ _) ∘ τ ∘ ((μ _ ∘ M₁ σ ∘ τ) ⊗₁ id)                             ≡⟨ refl⟩∘⟨ refl⟩∘⟨ ◀.popl right-strength-μ ⟩
+      μ _ ∘ M₁ (σ ∘ (id ⊗₁ σ) ∘ α→ _ _ _) ∘ (μ _ ∘ M₁ τ ∘ τ) ∘ ((M₁ σ ∘ τ) ⊗₁ id)                    ≡⟨ refl⟩∘⟨ refl⟩∘⟨ pullr (pullr (◀.popl (τ.is-natural _ _ _))) ⟩
+      μ _ ∘ M₁ (σ ∘ (id ⊗₁ σ) ∘ α→ _ _ _) ∘ μ _ ∘ M₁ τ ∘ (M₁ (σ ⊗₁ id) ∘ τ) ∘ (τ ⊗₁ id)              ≡⟨ refl⟩∘⟨ M.popr (M.popr (pulll (sym (mult.is-natural _ _ _)))) ⟩
+      μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ σ) ∘ (μ _ ∘ M₁ (M₁ (α→ _ _ _))) ∘ M₁ τ ∘ (M₁ (σ ⊗₁ id) ∘ τ) ∘ (τ ⊗₁ id) ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ pullr (refl⟩∘⟨ refl⟩∘⟨ pullr refl) ⟩
+      μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ σ) ∘ μ _ ∘ M₁ (M₁ (α→ _ _ _)) ∘ M₁ τ ∘ M₁ (σ ⊗₁ id) ∘ τ ∘ (τ ⊗₁ id)     ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.pulll3 strength-α→ ⟩
+      μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ σ) ∘ μ _ ∘ M₁ (σ ∘ (id ⊗₁ τ) ∘ α→ _ _ _) ∘ τ ∘ (τ ⊗₁ id)                ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.popr (M.popr (sym right-strength-α→)) ⟩
+      μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ σ) ∘ μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ τ) ∘ τ ∘ α→ _ _ _                           ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ extendl (τ.is-natural _ _ _) ⟩
+      μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ σ) ∘ μ _ ∘ M₁ σ ∘ τ ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _                           ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ extendl (mult.is-natural _ _ _) ⟩
+      μ _ ∘ M₁ σ ∘ μ _ ∘ M₁ (M₁ (id ⊗₁ σ)) ∘ M₁ σ ∘ τ ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _                      ≡˘⟨ refl⟩∘⟨ extendl (mult.is-natural _ _ _) ⟩
+      μ _ ∘ μ _ ∘ M₁ (M₁ σ) ∘ M₁ (M₁ (id ⊗₁ σ)) ∘ M₁ σ ∘ τ ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _                 ≡˘⟨ extendl mult-assoc ⟩
+      μ _ ∘ M₁ (μ _) ∘ M₁ (M₁ σ) ∘ M₁ (M₁ (id ⊗₁ σ)) ∘ M₁ σ ∘ τ ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _            ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ M.extendl (σ.is-natural _ _ _) ⟩
+      μ _ ∘ M₁ (μ _) ∘ M₁ (M₁ σ) ∘ M₁ σ ∘ M₁ (id ⊗₁ M₁ σ) ∘ τ ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _              ≡⟨ refl⟩∘⟨ M.pulll3 (sym left-strength-μ) ⟩
+      μ _ ∘ M₁ (σ ∘ (id ⊗₁ μ _)) ∘ M₁ (id ⊗₁ M₁ σ) ∘ τ ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _                     ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ extendl (τ.is-natural _ _ _) ⟩
+      μ _ ∘ M₁ (σ ∘ (id ⊗₁ μ _)) ∘ τ ∘ (M₁ id ⊗₁ M₁ σ) ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _                     ≡⟨ refl⟩∘⟨ M.popr (extendl (sym (τ.is-natural _ _ _))) ⟩
+      μ _ ∘ M₁ σ ∘ τ ∘ (M₁ id ⊗₁ μ _) ∘ (M₁ id ⊗₁ M₁ σ) ∘ (M₁ id ⊗₁ τ) ∘ α→ _ _ _                    ≡⟨ pushr (pushr (refl⟩∘⟨ ⊗.pulll3 ((refl⟩∘⟨ M.annihilate (idl _)) ∙ M.eliml refl ,ₚ refl))) ⟩
+      (μ _ ∘ M₁ σ ∘ τ) ∘ (id ⊗₁ (μ _ ∘ M₁ σ ∘ τ)) ∘ α→ _ _ _                                         ∎
+```
+
+The unitor coherences are relatively easy to prove.
+
+```agda
+    strength→monoidal .F-λ← =
+      M₁ λ← ∘ (μ _ ∘ M₁ σ ∘ τ) ∘ (η _ ⊗₁ id) ≡⟨ refl⟩∘⟨ pullr (pullr right-strength-η) ⟩
+      M₁ λ← ∘ μ _ ∘ M₁ σ ∘ η _               ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ unit.is-natural _ _ _ ⟩
+      M₁ λ← ∘ μ _ ∘ η _ ∘ σ                  ≡⟨ refl⟩∘⟨ cancell right-ident ⟩
+      M₁ λ← ∘ σ                              ≡⟨ left-strength-λ← ⟩
+      λ←                                     ∎
+    strength→monoidal .F-ρ← =
+      M₁ ρ← ∘ (μ _ ∘ M₁ σ ∘ τ) ∘ (⌜ id ⌝ ⊗₁ η _) ≡˘⟨ ap¡ M-id ⟩
+      M₁ ρ← ∘ (μ _ ∘ M₁ σ ∘ τ) ∘ (M₁ id ⊗₁ η _)  ≡⟨ refl⟩∘⟨ pullr (pullr (τ.is-natural _ _ _)) ⟩
+      M₁ ρ← ∘ μ _ ∘ M₁ σ ∘ M₁ (id ⊗₁ η _) ∘ τ    ≡⟨ refl⟩∘⟨ refl⟩∘⟨ M.pulll left-strength-η ⟩
+      M₁ ρ← ∘ μ _ ∘ M₁ (η _) ∘ τ                 ≡⟨ refl⟩∘⟨ cancell left-ident ⟩
+      M₁ ρ← ∘ τ                                  ≡⟨ right-strength-ρ← ⟩
+      ρ←                                         ∎
+```
+</details>
+
+## Symmetry
+
+In a [[braided monoidal category]], we unsurprisingly say that a monad
+strength is *symmetric* if the underlying functor [[strength]] is: a
+strength with this property is equivalent to the data of a left (or
+right) strength, with the other one obtained by the braiding.
+
+```agda
+  module _ (Cᵇ : Braided-monoidal Cᵐ) where
+    is-symmetric-monad-strength : Monad-strength Cᵐ monad → Type (o ⊔ ℓ)
+    is-symmetric-monad-strength s =
+      is-symmetric-strength Cᵐ M Cᵇ functor-strength
+      where open Monad-strength s
+```
+
+## Duality
+
+Just as with functor strengths, the definitions of left and right monad
+strengths are completely dual up to [[reversing|reverse monoidal
+category]] the tensor product.
+
+```agda
+  monad-strength^rev
+    : Left-monad-strength (Cᵐ ^rev) monad ≃ Right-monad-strength Cᵐ monad
+  monad-strength^rev = Iso→Equiv is where
+    is : Iso _ _
+    is .fst l = record
+      { functor-strength = strength^rev Cᵐ M .fst functor-strength
+      ; right-strength-η = left-strength-η
+      ; right-strength-μ = left-strength-μ
+      } where open Left-monad-strength l
+    is .snd .inv r = record
+      { functor-strength = Equiv.from (strength^rev Cᵐ M) functor-strength
+      ; left-strength-η = right-strength-η
+      ; left-strength-μ = right-strength-μ
+      } where open Right-monad-strength r
+    is .snd .rinv _ = Right-monad-strength-path Cᵐ monad
+      (Equiv.ε (strength^rev Cᵐ M) _)
+    is .snd .linv _ = Left-monad-strength-path (Cᵐ ^rev) monad
+      (Equiv.η (strength^rev Cᵐ M) _)
+```
+
+## Sets-monads are strong {defines="sets-monads-are-strong"}
+
+<!--
+```agda
+module _ {ℓ} (monad : Monad (Sets ℓ)) where
+  open Monad monad
+  open Left-monad-strength
+```
+-->
+
+The fact that [[$\Sets$-endofunctors are strong]] straightforwardly
+extends to the fact that $\Sets$-*monads* are strong, by naturality of
+the unit and multiplication.
+
+```agda
+  Sets-monad-strength : Left-monad-strength Setsₓ monad
+  Sets-monad-strength .functor-strength = Sets-strength M
+  Sets-monad-strength .left-strength-η = ext λ a b →
+    sym (unit.is-natural _ _ (a ,_) $ₚ _)
+  Sets-monad-strength .left-strength-μ = ext λ a mmb →
+    sym (mult.is-natural _ _ (a ,_) $ₚ _) ∙ ap (μ _) (M-∘ _ _ $ₚ _)
+```

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -102,6 +102,13 @@ module _ (abc≡d : a ∘ b ∘ c ≡ d) where abstract
     (a ∘ b ∘ c) ∘ f ≡⟨ ap (_∘ f) abc≡d ⟩
     d ∘ f           ∎
 
+  pullr3 : ((f ∘ a) ∘ b) ∘ c ≡ f ∘ d
+  pullr3 {f = f} =
+    ((f ∘ a) ∘ b) ∘ c ≡˘⟨ assoc _ _ _ ⟩
+    (f ∘ a) ∘ b ∘ c   ≡˘⟨ assoc _ _ _ ⟩
+    f ∘ a ∘ b ∘ c     ≡⟨ ap (f ∘_) abc≡d ⟩
+    f ∘ d ∎
+
 module _ (c≡ab : c ≡ a ∘ b) where abstract
   pushl : c ∘ f ≡ a ∘ (b ∘ f)
   pushl = sym (pulll (sym c≡ab))
@@ -115,6 +122,9 @@ module _ (c≡ab : c ≡ a ∘ b) where abstract
 module _ (d≡abc : d ≡ a ∘ b ∘ c) where abstract
   pushl3 : d ∘ f ≡ a ∘ (b ∘ (c ∘ f))
   pushl3 = sym (pulll3 (sym d≡abc))
+
+  pushr3 : f ∘ d ≡ ((f ∘ a) ∘ b) ∘ c
+  pushr3 = sym (pullr3 (sym d≡abc))
 
 module _ (p : f ∘ h ≡ g ∘ i) where abstract
   extendl : f ∘ (h ∘ b) ≡ g ∘ (i ∘ b)
@@ -137,6 +147,9 @@ module _ (p : f ∘ h ≡ g ∘ i) where abstract
 module _ (p : a ∘ b ∘ c ≡ d ∘ f ∘ g) where abstract
   extendl3 : a ∘ (b ∘ (c ∘ h)) ≡ d ∘ (f ∘ (g ∘ h))
   extendl3 = pulll3 p ∙ sym (pulll3 refl)
+
+  extendr3 : ((h ∘ a) ∘ b) ∘ c ≡ ((h ∘ d) ∘ f) ∘ g
+  extendr3 = pullr3 p ∙ sym (pullr3 refl)
 ```
 
 We also define some useful combinators for performing repeated pulls/pushes.
@@ -199,6 +212,19 @@ module _ (inv : h ∘ i ≡ id) where abstract
 
   deletel : h ∘ (i ∘ f) ∘ g ≡ f ∘ g
   deletel = pulll cancell
+
+module _ (inv : g ∘ h ∘ i ≡ id) where abstract
+  cancell3 : g ∘ (h ∘ (i ∘ f)) ≡ f
+  cancell3 {f = f} = pulll3 inv ∙ idl f
+
+  cancelr3 : ((f ∘ g) ∘ h) ∘ i ≡ f
+  cancelr3 {f = f} = pullr3 inv ∙ idr f
+
+  insertl3 : f ≡ g ∘ (h ∘ (i ∘ f))
+  insertl3 = sym cancell3
+
+  insertr3 : f ≡ ((f ∘ g) ∘ h) ∘ i
+  insertr3 = sym cancelr3
 ```
 
 We also have combinators which combine expanding on one side with a

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -218,3 +218,13 @@
   url = {https://www.sciencedirect.com/science/article/pii/0021869364900183},
   author = {G.M Kelly}
 }
+
+@article{Kock:monoidal-monads,
+  title={Strong functors and monoidal monads},
+  author={Anders Bredahl Kock},
+  journal={Archiv der Mathematik},
+  year={1972},
+  volume={23},
+  pages={113-120},
+  url={https://doi.org/10.1007/BF01304852}
+}

--- a/support/shake/app/Shake/LinkGraph.hs
+++ b/support/shake/app/Shake/LinkGraph.hs
@@ -89,6 +89,7 @@ getInternalLinks mod = foldMap go where
                    | otherwise -> Just target
           [] | "/" `isPrefixOf` uriPath uri -> Just "index.html"
              | not ("#fn" `isPrefixOf` uriFragment uri)
+             , not ("#cb" `isPrefixOf` uriFragment uri)
              , not ("#ref-" `isPrefixOf` uriFragment uri) -> Just (mod <.> "html")
           _ -> Nothing
   go _ = mempty

--- a/support/web/css/default.scss
+++ b/support/web/css/default.scss
@@ -293,6 +293,7 @@ div.diagram-container {
   img.diagram {
     margin: auto;
     display: block;
+    max-width: 100%;
 
     overflow-x: auto;
   }

--- a/support/web/css/default.scss
+++ b/support/web/css/default.scss
@@ -293,7 +293,6 @@ div.diagram-container {
   img.diagram {
     margin: auto;
     display: block;
-    max-width: 100%;
 
     overflow-x: auto;
   }


### PR DESCRIPTION
# Description

A small pile of definitions and results about monads, culminating in the equivalence between (symmetric) monoidal monads and (symmetric) commutative monads.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
