### PR TITLE
chore: bump actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # we need the commit history for authors
 
       - name: Install Nix ❄️
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v26
 
       - name: Set up Cachix ♻️
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: 1lab
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
           echo "shake_version=$hash" >> "$GITHUB_ENV"
 
       - name: Cache _build ♻️
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: shake-4-${{ env.shake_version }}-${{ github.run_id }}
@@ -63,7 +63,7 @@ jobs:
             eval "$installPhase"
 
       - name: Upload site ⬆️
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: _build/site
           retention-days: 1
@@ -84,4 +84,4 @@ jobs:
     steps:
       - name: Deploy 🚀
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout ⬇️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # we need the commit history for authors
 
       - name: Install Nix ❄️
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v26
 
       - name: Set up Cachix ♻️
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@v14
         with:
           name: 1lab
           skipPush: true
@@ -36,7 +36,7 @@ jobs:
           echo "shake_version=$hash" >> "$GITHUB_ENV"
 
       - name: Cache _build ♻️
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: prose-4-${{ env.shake_version }}-${{ github.run_id }}
@@ -56,7 +56,7 @@ jobs:
             # cp -rv _build/site pr-${{ github.event.number }}
 
       - name: Archive 📦
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-preview
           path: _build/site


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, cachix/cachix-action@v12, actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.