### PR TITLE
equivalence implies identity system

### DIFF
--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -268,39 +268,16 @@ is-identity-system-is-prop {A = A} {R} {r} =
     from : (∀ x → is-contr (Σ A (R x))) → is-identity-system R r
     from x = contr→identity-system (x _)
 
-    sys : ∀ (l : ∀ x → is-contr (Σ A (R x))) a b (s : R a b) (i j : I)
-        → Partial (∂ i ∨ ~ j) (Σ A (R a))
-    sys l a b s i j (j = i0) = l a .centre
-    sys l a b s i j (i = i0) = l a .paths (a , r a) j
-    sys l a b s i j (i = i1) = l a .paths (b , s) j
-
-    square : ∀ (x : is-identity-system R r) a b (s : R a b)
-           → Square {A = Σ A (R a)}
-             (λ i → x .to-path (r a) i , x .to-path-over (r a) i)
-             (λ i → x .to-path s i , x .to-path-over s i)
-             (λ i → x .to-path s i , x .to-path-over s i)
-             refl
-    square x a b s i j = hcomp (∂ i ∨ ∂ j) λ where
-      k (k = i0) → x .to-path s j , x .to-path-over s j
-      k (i = i0) → x .to-path s j , x .to-path-over s j
-      k (i = i1) → x .to-path s j , x .to-path-over s j
-      k (j = i0) → to-path-refl-coh {R = R} {r = r} x a (~ k) i
-      k (j = i1) → b , s
-
-    sys' : ∀ (x : is-identity-system R r) a b (s : R a b) i j k
-         → Partial (∂ i ∨ ∂ j ∨ ~ k) (Σ A (R a))
-    sys' x a b s i j k (k = i0) = x .to-path (r a) i , x .to-path-over (r a) i
-    sys' x a b s i j k (i = i0) = hfill (∂ j) k (sys (to x) a b s j)
-    sys' x a b s i j k (i = i1) =
-        x .to-path (x .to-path-over s (k ∨ j)) (k ∧ j)
-      , x .to-path-over (x .to-path-over s (k ∨ j)) (k ∧ j)
-    sys' x a b s i j k (j = i0) =
-        x .to-path (r a) (k ∨ i) , x .to-path-over (r a) (k ∨ i)
-    sys' x a b s i j k (j = i1) = square x a b s i k
+    cancel'
+      : ∀ (x : is-identity-system R r) {a b} (s : R a b)
+      → PathP (λ i → (a , r a) ≡ (b , s))
+        (is-contr-ΣR (from (to x)) .paths (b , s))
+        (is-contr-ΣR x .paths (b , s))
+    cancel' x s = is-prop→squarep (λ _ _ → is-contr→is-prop (is-contr-ΣR x)) _ _ _ _
 
     cancel : is-left-inverse from to
-    cancel x i .to-path {a} {b} s j      = hcomp (∂ i ∨ ∂ j) (sys' x a b s i j) .fst
-    cancel x i .to-path-over {a} {b} s j = hcomp (∂ i ∨ ∂ j) (sys' x a b s i j) .snd
+    cancel x i .to-path s = ap fst (cancel' x s i)
+    cancel x i .to-path-over s = ap snd (cancel' x s i)
 
 instance
   H-Level-is-identity-system

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -116,40 +116,43 @@ to-path-over-refl {a = a} ids = ap (ap snd) $ to-path-refl-coh ids a
 ```
 -->
 
+Note that for any $(R, r)$, the type of identity system data on $(R, r)$
+is a proposition. This is because it is exactly equivalent to the type
+$\sum_a (R a)$ being contractible for every $a$, which is a proposition
+by standard results.
+
+```agda
+contr→identity-system
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {R : A → A → Type ℓ'} {r : ∀ a → R a a}
+  → (∀ {a} → is-contr (Σ _ (R a)))
+  → is-identity-system R r
+contr→identity-system {R = R} {r} c = ids where
+  paths' : ∀ {a} (p : Σ _ (R a)) → (a , r a) ≡ p
+  paths' _ = is-contr→is-prop c _ _
+
+  ids : is-identity-system R r
+  ids .to-path p = ap fst (paths' (_ , p))
+  ids .to-path-over p = ap snd (paths' (_ , p))
+```
+
 If we have a relation $R$ together with reflexivity witness $r$, then
-any equivalence $f : R(a, b) \simeq (a \equiv b)$ which maps $f(r) =
-\refl$ equips $(R, r)$ with the structure of an identity system. Of
+any equivalence $f : R(a, b) \simeq (a \equiv b)$ equips $(R, r)$ with
+the structure of an identity system, by contractibility of singletons. Of
 course if we do not particularly care about the specific reflexivity
 witness, we can simply define $r$ as $f\inv(\refl)$.
 
 ```agda
 equiv-path→identity-system
   : ∀ {ℓ ℓ'} {A : Type ℓ} {R : A → A → Type ℓ'} {r : ∀ a → R a a}
-  → (eqv : ∀ {a b} → R a b ≃ (a ≡ b))
-  → (∀ a → Equiv.from eqv refl ≡ r a)
+  → (∀ {a b} → R a b ≃ (a ≡ b))
   → is-identity-system R r
-equiv-path→identity-system {R = R} {r = r} eqv pres' = ids where
-  contract : ∀ {a} → is-contr (Σ _ (R a))
-  contract = Equiv→is-hlevel 0 ((total (λ _ → eqv .fst) , equiv→total (eqv .snd)))
+equiv-path→identity-system eqv = contr→identity-system $
+  Equiv→is-hlevel 0 ((total (λ _ → eqv .fst) , equiv→total (eqv .snd)))
     (contr _ Singleton-is-contr)
-
-  pres : ∀ {a} → eqv .fst (r a) ≡ refl
-  pres {a = a} = Equiv.injective₂ (eqv e⁻¹) (Equiv.η eqv _) (pres' _)
-
-  ids : is-identity-system R r
-  ids .to-path = eqv .fst
-  ids .to-path-over {a = a} {b = b} p i =
-    is-prop→pathp
-    (λ i → is-contr→is-prop (eqv .snd .is-eqv λ j → eqv .fst p (i ∧ j)))
-    (r a , pres)
-    (p , refl)
-    i .fst
 ```
 
-Note that for any $(R, r)$, the type of identity system data on $(R, r)$
-is a proposition. This is because it is exactly equivalent to the type
-$\sum_a (R a)$ being contractible for every $a$, which is a proposition
-by standard results.
+Conversely, any identity system $(R, r)$ implies an equivalence
+$R(a, b) \simeq (a \equiv b)$.
 
 ```agda
 identity-system-gives-path

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -265,15 +265,14 @@ is-identity-system-is-prop {A = A} {R} {r} =
     to : is-identity-system R r → ∀ x → is-contr (Σ A (R x))
     to ids x = is-contr-ΣR ids
 
+    from : (∀ x → is-contr (Σ A (R x))) → is-identity-system R r
+    from x = contr→identity-system (x _)
+
     sys : ∀ (l : ∀ x → is-contr (Σ A (R x))) a b (s : R a b) (i j : I)
         → Partial (∂ i ∨ ~ j) (Σ A (R a))
     sys l a b s i j (j = i0) = l a .centre
     sys l a b s i j (i = i0) = l a .paths (a , r a) j
     sys l a b s i j (i = i1) = l a .paths (b , s) j
-
-    from : (∀ x → is-contr (Σ A (R x))) → is-identity-system R r
-    from x .to-path      {a} {b} s i = hcomp (∂ i) (sys x a b s i) .fst
-    from x .to-path-over {a} {b} s i = hcomp (∂ i) (sys x a b s i) .snd
 
     square : ∀ (x : is-identity-system R r) a b (s : R a b)
            → Square {A = Σ A (R a)}

--- a/src/1Lab/Path/IdentitySystem.lagda.md
+++ b/src/1Lab/Path/IdentitySystem.lagda.md
@@ -344,6 +344,7 @@ set-identity-system rprop rpath .to-path-over p =
 If $A$ is a type with ¬¬-stable equality, then by the theorem above, the
 pointwise double negation of its identity types is an identity system:
 and so, if a type has decidable (thus ¬¬-stable) equality, it is a set.
+This is known as **Hedberg's theorem**.
 
 ```agda
 ¬¬-stable-identity-system

--- a/src/Cat/Gaunt.lagda.md
+++ b/src/Cat/Gaunt.lagda.md
@@ -111,9 +111,7 @@ is straightforward, as $\cC$ is strict.
 ```agda
 skeletal+trivial-automorphisms→gaunt {C = C} skel trivial-aut =
   skeletal+category→gaunt skel $
-    equiv-path→identity-system
-      (Iso→Equiv path-iso)
-      (λ _ → transport-refl _)
+    equiv-path→identity-system (Iso→Equiv path-iso)
   where
     open is-gaunt
 


### PR DESCRIPTION
Remove the unnecessary hypothesis that the equivalence preserves refl.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
