### PR TITLE
defn: generic elim!/rec!

### DIFF
--- a/src/1Lab/Counterexamples/GlobalChoice.lagda.md
+++ b/src/1Lab/Counterexamples/GlobalChoice.lagda.md
@@ -76,7 +76,7 @@ double negation elimination is false:
 
 ```agda
 ¬DNE∞ : (∀ {ℓ} (A : Type ℓ) → ¬ ¬ A → A) → ⊥
-¬DNE∞ dne∞ = ¬global-choice λ A a → dne∞ A (λ ¬A → ∥-∥-rec! ¬A a)
+¬DNE∞ dne∞ = ¬global-choice λ A a → dne∞ A (λ ¬A → rec! ¬A a)
 ```
 
 Thus $\rm{LEM}_\infty$, which is equivalent to $\rm{DNE}_\infty$, also fails:

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -4,6 +4,7 @@ open import 1Lab.Function.Embedding
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HIT.Truncation
 open import 1Lab.HLevel.Closure
+open import 1Lab.Inductive
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path

--- a/src/1Lab/HIT/Truncation.lagda.md
+++ b/src/1Lab/HIT/Truncation.lagda.md
@@ -10,6 +10,7 @@ open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Closure
 open import 1Lab.Path.Reasoning
 open import 1Lab.Type.Sigma
+open import 1Lab.Inductive
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
@@ -102,18 +103,18 @@ whenever it is a family of propositions, by providing a case for
          → (x : ∥ A ∥) (y : ∥ B ∥) → P
 ∥-∥-rec₂ pprop = ∥-∥-elim₂ (λ _ _ → pprop)
 
-∥-∥-elim!
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : ∥ A ∥ → Type ℓ'} ⦃ _ : ∀ {x} → H-Level (P x) 1 ⦄
-  → (∀ x → P (inc x)) → ∀ x → P x
-∥-∥-elim! = ∥-∥-elim (λ _ → hlevel 1)
-
-∥-∥-rec!
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : Type ℓ'} ⦃ _ : H-Level P 1 ⦄
-  → (A → P) → (x : ∥ A ∥) → P
-∥-∥-rec! = ∥-∥-elim (λ _ → hlevel 1)
-
 ∥-∥-out! : ∀ {ℓ} {A : Type ℓ} ⦃ _ : H-Level A 1 ⦄ → ∥ A ∥ → A
 ∥-∥-out! = ∥-∥-out (hlevel 1)
+
+instance
+  Inductive-∥∥
+    : ∀ {ℓ ℓ' ℓm} {A : Type ℓ} {P : ∥ A ∥ → Type ℓ'} ⦃ i : Inductive (∀ x → P (inc x)) ℓm ⦄
+    → ⦃ _ : ∀ {x} → H-Level (P x) 1 ⦄
+    → Inductive (∀ x → P x) ℓm
+  Inductive-∥∥ ⦃ i ⦄ = record
+    { methods = i .Inductive.methods
+    ; from    = λ f → ∥-∥-elim (λ x → hlevel 1) (i .Inductive.from f)
+    }
 ```
 -->
 

--- a/src/1Lab/Inductive.agda
+++ b/src/1Lab/Inductive.agda
@@ -1,0 +1,66 @@
+module 1Lab.Inductive where
+
+open import 1Lab.Reflection
+open import 1Lab.Equiv
+open import 1Lab.Type hiding (case_of_ ; case_return_of_)
+
+{-
+Automation for induction principles
+===================================
+-}
+
+record Inductive {ℓ} (A : Type ℓ) ℓm : Type (ℓ ⊔ lsuc ℓm) where
+  field
+    methods : Type ℓm
+    from    : methods → A
+
+open Inductive
+
+private variable
+  ℓ ℓ' ℓ'' ℓm : Level
+  A B C : Type ℓ
+  P Q R : A → Type ℓ
+
+instance
+  Inductive-default : Inductive A (level-of A)
+  Inductive-default .methods = _
+  Inductive-default .from x  = x
+
+  {-# INCOHERENT Inductive-default #-}
+
+  Inductive-Π
+    : ⦃ _ : {x : A} → Inductive (P x) ℓm ⦄
+    → Inductive (∀ x → P x) (level-of A ⊔ ℓm)
+  Inductive-Π ⦃ r ⦄ .methods  = ∀ x → r {x} .methods
+  Inductive-Π ⦃ r ⦄ .from f x = r .from (f x)
+
+  {-# OVERLAPPABLE Inductive-Π #-}
+
+  Inductive-Σ
+    : ∀ {A : Type ℓ} {B : A → Type ℓ'} {C : (x : A) → B x → Type ℓ''}
+    → ⦃ _ : Inductive ((x : A) (y : B x) → C x y) ℓm ⦄
+    → Inductive ((x : Σ A B) → C (x .fst) (x .snd)) ℓm
+  Inductive-Σ ⦃ r ⦄ .methods        = r .methods
+  Inductive-Σ ⦃ r ⦄ .from f (x , y) = r .from f x y
+
+  Inductive-≃
+    : {C : A ≃ B → Type ℓ''}
+    → Inductive (∀ x → C x) _
+  Inductive-≃ = Inductive-default
+
+  {-# OVERLAPPING Inductive-≃ #-}
+
+rec! : ⦃ r : Inductive (A → B) ℓm ⦄ → r .methods → A → B
+rec! ⦃ r ⦄ = r .from
+
+elim! : ⦃ r : Inductive (∀ x → P x) ℓm ⦄ → r .methods → ∀ x → P x
+elim! ⦃ r ⦄ = r .from
+
+case_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} ⦃ r : Inductive (A → B) ℓm ⦄ → A → r .methods → B
+case x of f = rec! f x
+
+case_return_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} (x : A) (B : A → Type ℓ') ⦃ r : Inductive (∀ x → B x) ℓm ⦄ (f : r .methods) → B x
+case x return P of f = elim! f x
+
+{-# INLINE case_of_        #-}
+{-# INLINE case_return_of_ #-}

--- a/src/1Lab/Prelude.agda
+++ b/src/1Lab/Prelude.agda
@@ -4,7 +4,7 @@
 module 1Lab.Prelude where
 
 open import 1Lab.Type
-  hiding (Σ-syntax)
+  hiding (Σ-syntax ; case_of_ ; case_return_of_)
   public
 
 open import 1Lab.Path public
@@ -54,5 +54,6 @@ open import 1Lab.Resizing public
 open import 1Lab.Underlying public
 open import 1Lab.Membership public
 open import 1Lab.Extensionality public
+open import 1Lab.Inductive public
 
 open import Data.Id.Base public

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -129,14 +129,14 @@ hlevel-proj A want goal = do
   want ← quoteTC want >>= normalise
 
   def head args ← reduce =<< quoteTC A
-    where ty → typeError [ "H-Level: I do not know how to show that\n  " , termErr ty , "\nhas h-level\n", termErr want ]
+    where ty → typeError [ "H-Level: I do not know how to show that\n  " , termErr ty , "\nhas h-level\n  ", termErr want ]
   debugPrint "tactic.hlevel" 30 [ "H-Level: trying projections for term:\n  " , termErr (def head args), "\nwith head symbol ", nameErr head ]
 
   projection ← resetting do
     (mv , _) ← new-meta' (def (quote hlevel-projection) (argN (lit (name head)) ∷ []))
     get-instances mv >>= λ where
       [] → typeError
-        [ "H-Level: There are no hints for treating the name" , nameErr head , "as a projection."
+        [ "H-Level: There are no hints for treating the name " , nameErr head , " as a projection.\n"
         , "When showing that the type\n " , termErr (def head args)
         , "\nhas h-level " , termErr want , ".\n"
         ]

--- a/src/1Lab/Resizing.lagda.md
+++ b/src/1Lab/Resizing.lagda.md
@@ -8,6 +8,7 @@ open import 1Lab.HIT.Truncation
 open import 1Lab.HLevel.Closure
 open import 1Lab.Reflection using (arg ; typeError)
 open import 1Lab.Univalence
+open import 1Lab.Inductive
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
@@ -138,25 +139,24 @@ elΩ T .is-tr = squash
 □-elim pprop go (squash x y i) =
   is-prop→pathp (λ i → pprop (squash x y i)) (□-elim pprop go x) (□-elim pprop go y) i
 
-□-elim!
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {P : □ A → Type ℓ'} ⦃ _ : ∀ {x} → H-Level (P x) 1 ⦄
-  → (∀ x → P (inc x))
-  → ∀ x → P x
-□-elim! = □-elim (λ _ → hlevel 1)
-
-□-rec!
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
-  → ⦃ _ : H-Level B 1 ⦄
-  → (A → B) → □ A → B
-□-rec! = □-rec (hlevel 1)
+instance
+  Inductive-□
+    : ∀ {ℓ ℓ' ℓm} {A : Type ℓ} {P : □ A → Type ℓ'} ⦃ i : Inductive (∀ x → P (inc x)) ℓm ⦄
+    → ⦃ _ : ∀ {x} → H-Level (P x) 1 ⦄
+    → Inductive (∀ x → P x) ℓm
+  Inductive-□ ⦃ i ⦄ = record
+    { methods = i .Inductive.methods
+    ; from    = λ f → □-elim (λ x → hlevel 1) (i .Inductive.from f)
+    }
 
 □-out : ∀ {ℓ} {A : Type ℓ} → is-prop A → □ A → A
 □-out ap = □-rec ap (λ x → x)
 
-out! : ∀ {ℓ} {A : Type ℓ}
-     → ⦃ _ : H-Level A 1 ⦄
-     → □ A → A
-out! = □-rec! λ x → x
+□-out!
+  : ∀ {ℓ} {A : Type ℓ}
+  → ⦃ _ : H-Level A 1 ⦄
+  → □ A → A
+□-out! = rec! λ x → x
 
 □-rec-set
   : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
@@ -290,6 +290,6 @@ module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) where
 
   opaque
     Ω-corestriction-is-surjective : is-surjective Ω-corestriction
-    Ω-corestriction-is-surjective (b , p) = □-rec! (λ (a , p) → inc (a , Σ-prop-path! p)) p
+    Ω-corestriction-is-surjective = elim! λ y x fx=y → pure (x , Σ-prop-path! fx=y)
 ```
 -->

--- a/src/Algebra/Group/Ab/Abelianisation.lagda.md
+++ b/src/Algebra/Group/Ab/Abelianisation.lagda.md
@@ -109,7 +109,7 @@ bit tedious, but it follows from `ab-comm`: $xy = 1xy = 1yx = yx$.
 
 ```agda
   ab*-comm : ∀ x y → x ab* y ≡ y ab* x
-  ab*-comm = Coeq-elim-prop₂ (λ _ _ → squash _ _) l1 where abstract
+  ab*-comm = elim! l1 where abstract
     l1 : ∀ x y → inc^ab (x ⋆ y) ≡ inc^ab (y ⋆ x)
     l1 x y =
       inc^ab (x ⋆ y)        ≡⟨ ap inc^ab (ap₂ _⋆_ (sym G.idl) refl ∙ sym G.associative) ⟩
@@ -127,7 +127,7 @@ tedious algebra:
 
 ```agda
   abinv : G^ab → G^ab
-  abinv = Coeq-rec squash (λ x → inc^ab (x ⁻¹)) l1 where abstract
+  abinv = Coeq-rec (λ x → inc^ab (x ⁻¹)) l1 where abstract
     l1 : ((x , y , z) : G × G × G)
         → inc^ab ((x ⋆ y ⋆ z) ⁻¹) ≡ inc^ab ((x ⋆ z ⋆ y) ⁻¹)
     l1 (x , y , z) =
@@ -160,8 +160,7 @@ inherited from $G$!
 
 ```agda
   ab*-associative : ∀ x y z → x ab* (y ab* z) ≡ (x ab* y) ab* z
-  ab*-associative = Coeq-elim-prop₃ (λ _ _ _ → squash _ _)
-    λ _ _ _ → ap inc^ab associative
+  ab*-associative = elim! λ _ _ _ → ap inc^ab associative
 
   open make-abelian-group
   Abelian-group-on-G^ab : make-abelian-group G^ab
@@ -170,10 +169,8 @@ inherited from $G$!
   Abelian-group-on-G^ab .mul = _ab*_
   Abelian-group-on-G^ab .inv = abinv
   Abelian-group-on-G^ab .assoc = ab*-associative
-  Abelian-group-on-G^ab .invl =
-    Coeq-elim-prop (λ _ → squash _ _) (λ _ → ap inc^ab G.inversel)
-  Abelian-group-on-G^ab .idl =
-    Coeq-elim-prop (λ _ → squash _ _) (λ _ → ap inc^ab G.idl)
+  Abelian-group-on-G^ab .invl = elim! λ _ → ap inc^ab G.inversel
+  Abelian-group-on-G^ab .idl = elim! λ _ → ap inc^ab G.idl
   Abelian-group-on-G^ab .comm = ab*-comm
 
   Abelianise : Abelian-group ℓ
@@ -221,7 +218,7 @@ make-free-abelian G .fold {H} f .hom =
       f # a H.* f # (c G.⋆ b)     ≡˘⟨ pres-⋆ _ _ ⟩
       f # (a G.⋆ (c G.⋆ b))       ∎
 make-free-abelian G .fold {H} f .preserves .is-group-hom.pres-⋆ =
-  Coeq-elim-prop₂ (λ _ _ → hlevel 1) λ _ _ → f .preserves .is-group-hom.pres-⋆ _ _
+  elim! λ _ _ → f .preserves .is-group-hom.pres-⋆ _ _
 make-free-abelian G .commute = trivial!
 make-free-abelian G .unique f p = ext (p #ₚ_)
 ```

--- a/src/Algebra/Group/Ab/Free.lagda.md
+++ b/src/Algebra/Group/Ab/Free.lagda.md
@@ -66,6 +66,6 @@ module _ {ℓ} (T : Type ℓ) (t-set : is-set T) where
 
     morp : Ab.Hom (Free-abelian T) G
     morp .hom = go
-    morp .preserves .pres-⋆ = Coeq-elim-prop₂ (λ x y → G.has-is-set _ _) λ x y → refl
+    morp .preserves .pres-⋆ = elim! λ x y → refl
 ```
 -->

--- a/src/Algebra/Group/Homotopy.lagda.md
+++ b/src/Algebra/Group/Homotopy.lagda.md
@@ -64,13 +64,9 @@ group operation is `path concatenation`{.Agda ident=_∙_}, and the
 inverses are given by `inverting paths`{.Agda ident=sym}.
 
 ```agda
-  omega .make-group.assoc =
-    ∥-∥₀-elim₃ (λ _ _ _ → is-prop→is-set (squash _ _))
-      λ x y z i → inc (∙-assoc x y z i)
-  omega .make-group.invl =
-    ∥-∥₀-elim (λ _ → is-prop→is-set (squash _ _)) λ x i → inc (∙-invl x i)
-  omega .make-group.idl =
-    ∥-∥₀-elim (λ _ → is-prop→is-set (squash _ _)) λ x i → inc (∙-idl x i)
+  omega .make-group.assoc = elim! λ x y z i → inc (∙-assoc x y z i)
+  omega .make-group.invl = elim! λ x i → inc (∙-invl x i)
+  omega .make-group.idl = elim! λ x i → inc (∙-idl x i)
 ```
 
 A direct cubical transcription of the Eckmann-Hilton argument tells us
@@ -140,8 +136,7 @@ $\pi_{n+2}$ is an [[Abelian group]]:
 πₙ₊₂-is-abelian-group : ∀ {ℓ} {A : Type∙ ℓ} (n : Nat)
                       → Group-on-is-abelian (πₙ₊₁ (1 + n) A .snd)
 πₙ₊₂-is-abelian-group {A = A} n =
-  ∥-∥₀-elim₂ (λ x y → is-prop→is-set (squash _ _))
-             (λ x y i → inc (Ωⁿ⁺²-is-abelian-group n x y i))
+  elim! λ x y i → inc (Ωⁿ⁺²-is-abelian-group n x y i)
 ```
 
 We can give an alternative construction of the fundamental group $\pi_1$ for types

--- a/src/Algebra/Group/Homotopy/BAut.lagda.md
+++ b/src/Algebra/Group/Homotopy/BAut.lagda.md
@@ -36,11 +36,9 @@ of its interesting information is in its (higher) path spaces:
 
 ```agda
   connected : (x : BAut) → ∥ x ≡ base ∥
-  connected (b , x) =
-    ∥-∥-elim! {P = λ x → ∥ (b , x) ≡ base ∥} (λ e → inc (p _ _)) x
-    where
-      p : ∀ b e → (b , inc e) ≡ base
-      p _ = EquivJ (λ B e → (B , inc e) ≡ base) refl
+  connected = elim! λ b e → inc (p b e) where
+    p : ∀ b e → (b , inc e) ≡ base
+    p _ = EquivJ (λ B e → (B , inc e) ≡ base) refl
 ```
 
 We now turn to proving that $\pi_1(\baut(X)) \simeq (X \simeq X)$. We

--- a/src/Algebra/Group/Subgroup.lagda.md
+++ b/src/Algebra/Group/Subgroup.lagda.md
@@ -474,7 +474,7 @@ $(x - y) \in H$, we also have $(x\inv - y) \in H$.
 ```agda
     inverse : G/H → G/H
     inverse =
-      Coeq-rec squash (λ x → inc (inv x)) λ { (x , y , r) → quot (p x y r) }
+      Coeq-rec (λ x → inc (inv x)) λ { (x , y , r) → quot (p x y r) }
       where abstract
         p : ∀ x y → (x — y) ∈ H → (inv x — inv y) ∈ H
         p x y r = has-comm (subst (_∈ H) inv-comm (has-inv r))
@@ -491,13 +491,9 @@ rather directly:
     Group-on-G/H .make-group.unit = inc unit
     Group-on-G/H .make-group.mul = op
     Group-on-G/H .make-group.inv = inverse
-    Group-on-G/H .make-group.assoc =
-      Coeq-elim-prop₃ (λ _ _ _ → squash _ _) λ x y z i →
-        inc (associative {x = x} {y} {z} i)
-    Group-on-G/H .make-group.invl =
-      Coeq-elim-prop (λ _ → squash _ _) λ x i → inc (inversel {x = x} i)
-    Group-on-G/H .make-group.idl =
-      Coeq-elim-prop (λ _ → squash _ _) λ x i → inc (idl {x = x} i)
+    Group-on-G/H .make-group.assoc = elim! λ x y z → ap Coeq.inc associative
+    Group-on-G/H .make-group.invl  = elim! λ x → ap Coeq.inc inversel
+    Group-on-G/H .make-group.idl   = elim! λ x → ap Coeq.inc idl
 
   _/ᴳ_ : Group _
   _/ᴳ_ = to-group Group-on-G/H

--- a/src/Algebra/Ring.lagda.md
+++ b/src/Algebra/Ring.lagda.md
@@ -224,21 +224,21 @@ record make-ring {ℓ} (R : Type ℓ) : Type ℓ where
     0R      : R
     _+_     : R → R → R
     -_      : R → R
-    +-idl   : ∀ {x} → 0R + x ≡ x
-    +-invr  : ∀ {x} → x + (- x) ≡ 0R
-    +-assoc : ∀ {x y z} → x + (y + z) ≡ (x + y) + z
-    +-comm  : ∀ {x y} → x + y ≡ y + x
+    +-idl   : ∀ x → 0R + x ≡ x
+    +-invr  : ∀ x → x + (- x) ≡ 0R
+    +-assoc : ∀ x y z → x + (y + z) ≡ (x + y) + z
+    +-comm  : ∀ x y → x + y ≡ y + x
 
     -- R is a commutative monoid:
     1R      : R
     _*_     : R → R → R
-    *-idl   : ∀ {x} → 1R * x ≡ x
-    *-idr   : ∀ {x} → x * 1R ≡ x
-    *-assoc : ∀ {x y z} → x * (y * z) ≡ (x * y) * z
+    *-idl   : ∀ x → 1R * x ≡ x
+    *-idr   : ∀ x → x * 1R ≡ x
+    *-assoc : ∀ x y z → x * (y * z) ≡ (x * y) * z
 
     -- Multiplication is bilinear:
-    *-distribl : ∀ {x y z} → x * (y + z) ≡ (x * y) + (x * z)
-    *-distribr : ∀ {x y z} → (y + z) * x ≡ (y * x) + (z * x)
+    *-distribl : ∀ x y z → x * (y + z) ≡ (x * y) + (x * z)
+    *-distribr : ∀ x y z → (y + z) * x ≡ (y * x) + (z * x)
 ```
 
 <!--
@@ -253,20 +253,20 @@ record make-ring {ℓ} (R : Type ℓ) : Type ℓ where
     ring .Ring-on._*_ = _*_
     ring .Ring-on._+_ = _+_
     ring .Ring-on.has-is-ring .*-monoid .has-is-semigroup .is-semigroup.has-is-magma = record { has-is-set = ring-is-set }
-    ring .Ring-on.has-is-ring .*-monoid .has-is-semigroup .is-semigroup.associative = *-assoc
-    ring .Ring-on.has-is-ring .*-monoid .idl = *-idl
-    ring .Ring-on.has-is-ring .*-monoid .idr = *-idr
+    ring .Ring-on.has-is-ring .*-monoid .has-is-semigroup .is-semigroup.associative = *-assoc _ _ _
+    ring .Ring-on.has-is-ring .*-monoid .idl = *-idl _
+    ring .Ring-on.has-is-ring .*-monoid .idr = *-idr _
     ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.unit = 0R
     ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .has-is-semigroup .has-is-magma = record { has-is-set = ring-is-set }
-    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .has-is-semigroup .associative = +-assoc
-    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .idl = +-idl
-    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .idr = +-comm ∙ +-idl
+    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .has-is-semigroup .associative = +-assoc _ _ _
+    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .idl = +-idl _
+    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.has-is-monoid .idr = +-comm _ _ ∙ +-idl _
     ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.inverse = -_
-    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.inversel = +-comm ∙ +-invr
-    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.inverser = +-invr
-    ring .Ring-on.has-is-ring .+-group .is-abelian-group.commutes = +-comm
-    ring .Ring-on.has-is-ring .is-ring.*-distribl = *-distribl
-    ring .Ring-on.has-is-ring .is-ring.*-distribr = *-distribr
+    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.inversel = +-comm _ _ ∙ +-invr _
+    ring .Ring-on.has-is-ring .+-group .is-abelian-group.has-is-group .is-group.inverser = +-invr _
+    ring .Ring-on.has-is-ring .+-group .is-abelian-group.commutes = +-comm _ _
+    ring .Ring-on.has-is-ring .is-ring.*-distribl = *-distribl _ _ _
+    ring .Ring-on.has-is-ring .is-ring.*-distribr = *-distribr _ _ _
 
   to-ring : Ring ℓ
   to-ring .fst = el R ring-is-set
@@ -295,20 +295,20 @@ the ring $\{*\}$ the _One Ring_, which would be objectively cooler.
 Zero-ring : Ring lzero
 Zero-ring = to-ring {R = ⊤} λ where
   .make-ring.ring-is-set _ _ _ _ _ _ → tt
-  .make-ring.0R → tt
-  .make-ring._+_ _ _ → tt
-  .make-ring.-_  _ → tt
-  .make-ring.+-idl _ → tt
-  .make-ring.+-invr _ → tt
-  .make-ring.+-assoc _ → tt
-  .make-ring.+-comm _ → tt
-  .make-ring.1R → tt
-  .make-ring._*_ _ _ → tt
-  .make-ring.*-idl _ → tt
-  .make-ring.*-idr _ → tt
-  .make-ring.*-assoc _ → tt
-  .make-ring.*-distribl _ → tt
-  .make-ring.*-distribr _ → tt
+  .make-ring.0R                      → tt
+  .make-ring._+_ _ _                 → tt
+  .make-ring.-_  _                   → tt
+  .make-ring.+-idl  _ _              → tt
+  .make-ring.+-invr _ _              → tt
+  .make-ring.+-assoc _ _ _ _         → tt
+  .make-ring.+-comm _ _ _            → tt
+  .make-ring.1R                      → tt
+  .make-ring._*_ _ _                 → tt
+  .make-ring.*-idl _ _               → tt
+  .make-ring.*-idr _ _               → tt
+  .make-ring.*-assoc _ _ _ _         → tt
+  .make-ring.*-distribl _ _ _ _      → tt
+  .make-ring.*-distribr _ _ _ _      → tt
 ```
 
 Rings, unlike other categories of algebraic structures (like that of
@@ -327,18 +327,18 @@ homomorphism $h : 0 \to R$ unless $0 = h(0) = h(1) = 1$ in $R$.
 ℤ : Ring lzero
 ℤ = to-ring {R = Int} λ where
   .make-ring.ring-is-set → hlevel 2
-  .make-ring.0R → 0
-  .make-ring._+_ → _+ℤ_
-  .make-ring.-_ → negℤ
-  .make-ring.+-idl      → +ℤ-zerol _
-  .make-ring.+-invr {x} → +ℤ-invr x
-  .make-ring.+-assoc {x} {y} {z} → +ℤ-assoc x y z
-  .make-ring.+-comm {x} {y} → +ℤ-commutative x y
-  .make-ring.1R    → 1
-  .make-ring._*_   → _*ℤ_
-  .make-ring.*-idl → *ℤ-onel _
-  .make-ring.*-idr → *ℤ-oner _
-  .make-ring.*-assoc    {x} {y} {z} → *ℤ-associative x y z
-  .make-ring.*-distribl {x} {y} {z} → *ℤ-distribl x y z
-  .make-ring.*-distribr {x} {y} {z} → *ℤ-distribr x y z
+  .make-ring.1R         → 1
+  .make-ring.0R         → 0
+  .make-ring._+_        → _+ℤ_
+  .make-ring.-_         → negℤ
+  .make-ring._*_        → _*ℤ_
+  .make-ring.+-idl      → +ℤ-zerol
+  .make-ring.+-invr     → +ℤ-invr
+  .make-ring.+-assoc    → +ℤ-assoc
+  .make-ring.+-comm     → +ℤ-commutative
+  .make-ring.*-idl      → *ℤ-onel
+  .make-ring.*-idr      → *ℤ-oner
+  .make-ring.*-assoc    → *ℤ-associative
+  .make-ring.*-distribl → *ℤ-distribl
+  .make-ring.*-distribr → *ℤ-distribr
 ```

--- a/src/Algebra/Ring/Cat/Initial.lagda.md
+++ b/src/Algebra/Ring/Cat/Initial.lagda.md
@@ -45,15 +45,15 @@ Liftℤ = to-ring mr where
 
 <!--
 ```agda
-  mr .*-idl      {lift x}                   = ap lift $ *ℤ-idl x
-  mr .*-idr      {lift x}                   = ap lift $ *ℤ-idr x
-  mr .+-idl      {lift x}                   = ap lift $ +ℤ-zerol x
-  mr .+-invr     {lift x}                   = ap lift $ +ℤ-inverser x
-  mr .+-comm     {lift x} {lift y}          = ap lift $ +ℤ-commutative x y
-  mr .+-assoc    {lift x} {lift y} {lift z} = ap lift $ +ℤ-associative x y z
-  mr .*-assoc    {lift x} {lift y} {lift z} = ap lift $ *ℤ-associative x y z
-  mr .*-distribl {lift x} {lift y} {lift z} = ap lift $ *ℤ-distrib-+ℤ-l x y z
-  mr .*-distribr {lift x} {lift y} {lift z} = ap lift $ *ℤ-distrib-+ℤ-r x y z
+  mr .*-idl      (lift x)                   = ap lift $ *ℤ-idl x
+  mr .*-idr      (lift x)                   = ap lift $ *ℤ-idr x
+  mr .+-idl      (lift x)                   = ap lift $ +ℤ-zerol x
+  mr .+-invr     (lift x)                   = ap lift $ +ℤ-inverser x
+  mr .+-comm     (lift x) (lift y)          = ap lift $ +ℤ-commutative x y
+  mr .+-assoc    (lift x) (lift y) (lift z) = ap lift $ +ℤ-associative x y z
+  mr .*-assoc    (lift x) (lift y) (lift z) = ap lift $ *ℤ-associative x y z
+  mr .*-distribl (lift x) (lift y) (lift z) = ap lift $ *ℤ-distrib-+ℤ-l x y z
+  mr .*-distribr (lift x) (lift y) (lift z) = ap lift $ *ℤ-distrib-+ℤ-r x y z
 ```
 -->
 

--- a/src/Algebra/Ring/Quotient.lagda.md
+++ b/src/Algebra/Ring/Quotient.lagda.md
@@ -96,32 +96,17 @@ quotients into propositions, then applying $R$'s laws.</summary>
   make-R/I .0R = inc 0r
   make-R/I ._+_ = R/I._⋆_
   make-R/I .-_ = R/I.inverse
-  make-R/I .+-idl = R/I.idl
-  make-R/I .+-invr {x} = R/I.inverser {x}
-  make-R/I .+-assoc {x} {y} {z} = R/I.associative {x} {y} {z}
+  make-R/I .+-idl x = R/I.idl
+  make-R/I .+-invr x = R/I.inverser {x}
+  make-R/I .+-assoc x y z = R/I.associative {x} {y} {z}
   make-R/I .1R = inc R.1r
   make-R/I ._*_ = quot-mul
-  make-R/I .+-comm {x} {y} =
-    Coeq-elim-prop₂ {C = λ x y → x R/I.⋆ y ≡ y R/I.⋆ x} (λ x y → hlevel 1)
-      (λ x y → ap Coeq.inc R.+-commutes) x y
-  make-R/I .*-idl {x} =
-    Coeq-elim-prop {C = λ x → quot-mul (inc R.1r) x ≡ x} (λ _ → hlevel 1)
-      (λ x → ap Coeq.inc R.*-idl) x
-  make-R/I .*-idr {x} =
-    Coeq-elim-prop {C = λ x → quot-mul x (inc R.1r) ≡ x} (λ _ → hlevel 1)
-      (λ x → ap Coeq.inc R.*-idr) x
-  make-R/I .*-assoc {x} {y} {z} =
-    Coeq-elim-prop₃
-      {C = λ x y z → quot-mul x (quot-mul y z) ≡ quot-mul (quot-mul x y) z}
-      (λ _ _ _ → hlevel 1) (λ x y z → ap Coeq.inc R.*-associative) x y z
-  make-R/I .*-distribl {x} {y} {z} =
-    Coeq-elim-prop₃
-      {C = λ x y z → quot-mul x (y R/I.⋆ z) ≡ quot-mul x y R/I.⋆ quot-mul x z}
-      (λ _ _ _ → hlevel 1) (λ x y z → ap Coeq.inc R.*-distribl) x y z
-  make-R/I .*-distribr {x} {y} {z} =
-    Coeq-elim-prop₃
-      {C = λ x y z → quot-mul (y R/I.⋆ z) x ≡ quot-mul y x R/I.⋆ quot-mul z x}
-      (λ _ _ _ → hlevel 1) (λ x y z → ap Coeq.inc R.*-distribr) x y z
+  make-R/I .+-comm = elim! λ x y → ap Coeq.inc R.+-commutes
+  make-R/I .*-idl = elim! λ x → ap Coeq.inc R.*-idl
+  make-R/I .*-idr = elim! λ x → ap Coeq.inc R.*-idr
+  make-R/I .*-assoc = elim! λ x y z → ap Coeq.inc R.*-associative
+  make-R/I .*-distribl = elim! λ x y z → ap Coeq.inc R.*-distribl
+  make-R/I .*-distribr = elim! λ x y z → ap Coeq.inc R.*-distribr
 ```
 
 </details>

--- a/src/Cat/Abelian/Endo.lagda.md
+++ b/src/Cat/Abelian/Endo.lagda.md
@@ -39,15 +39,15 @@ Endo x = to-ring mr where
   mr .make-ring._+_ = A._+_
   mr .make-ring.-_ = A.Hom.inverse
   mr .make-ring._*_ = A._∘_
-  mr .+-idl = A.Hom.idl
-  mr .+-invr = A.Hom.inverser
-  mr .+-assoc = A.Hom.associative
-  mr .+-comm = A.Hom.commutes
-  mr .*-idl = A.idl _
-  mr .*-idr = A.idr _
-  mr .*-assoc = A.assoc _ _ _
-  mr .*-distribl = sym (A.∘-linear-r _ _ _)
-  mr .*-distribr = sym (A.∘-linear-l _ _ _)
+  mr .+-idl _ = A.Hom.idl
+  mr .+-invr _ = A.Hom.inverser
+  mr .+-assoc _ _ _ = A.Hom.associative
+  mr .+-comm _ _ = A.Hom.commutes
+  mr .*-idl _ = A.idl _
+  mr .*-idr _ = A.idr _
+  mr .*-assoc _ _ _ = A.assoc _ _ _
+  mr .*-distribl _ _ _ = sym (A.∘-linear-r _ _ _)
+  mr .*-distribr _ _ _ = sym (A.∘-linear-l _ _ _)
 ```
 
 This is a fantastic source of non-commutative rings, and indeed the

--- a/src/Cat/Allegory/Base.lagda.md
+++ b/src/Cat/Allegory/Base.lagda.md
@@ -220,7 +220,7 @@ y) \simeq R(a, y)$, and we're done.
 
 ```agda
 Rel ℓ .cat .idr {A} {B} R = ext λ x y → Ω-ua
-  (□-rec! (λ { (a , b , w) → subst (λ e → ∣ R e y ∣) (sym (out! b)) w }))
+  (rec! λ a b w → subst (λ e → ∣ R e y ∣) (sym b) w)
   λ w → inc (x , inc refl , w)
 ```
 
@@ -239,8 +239,8 @@ modular law is given by some pair-shuffling.
 ```agda
 Rel ℓ ._∩_ R S x y = el (∣ R x y ∣ × ∣ S x y ∣) (hlevel 1)
 Rel ℓ ._† R x y = R y x
-Rel ℓ .modular R S T x y (α , β) =
-  □-rec! (λ { (z , r , s) → inc (z , (r , inc (y , β , s)) , s) }) α
+Rel ℓ .modular R S T x y (α , β) = case α of λ where
+  z x~z z~y → inc (z , (x~z , inc (y , β , z~y)) , z~y)
 ```
 
 <details>
@@ -252,14 +252,12 @@ automatic proof search: that speaks to how contentful it is.</summary>
 ```agda
 Rel ℓ .cat .Hom-set x y = hlevel 2
 Rel ℓ .cat .idl R = ext λ x y → Ω-ua
-  (□-rec! (λ { (a , b , w) → subst (λ e → ∣ R x e ∣) (out! w) b }))
+  (rec! λ z x~z z=y → subst (λ e → ∣ R x e ∣) z=y x~z)
   λ w → inc (y , w , inc refl)
 
 Rel ℓ .cat .assoc T S R = ext λ x y → Ω-ua
-  (□-rec! λ { (a , b , w) → □-rec! (λ { (c , d , x) →
-    inc (c , d , inc (a , x , w)) }) b })
-  (□-rec! λ { (a , b , w) → □-rec! (λ { (c , d , x) →
-    inc (c , inc (a , b , d) , x) }) w })
+  (rec! λ a b r s t → inc (b , r , inc (a , s , t)))
+  (rec! λ a r b s t → inc (b , inc (a , r , s) , t))
 
 Rel ℓ .≤-thin = hlevel 1
 Rel ℓ .≤-refl x y w = w

--- a/src/Cat/Allegory/Maps.lagda.md
+++ b/src/Cat/Allegory/Maps.lagda.md
@@ -76,11 +76,10 @@ Rel-map→function {x = x} {y} {rel} map elt =
   where
     module map = is-map map
     functional' : ∀ {a b c} → ∣ rel a b ∣ → ∣ rel a c ∣ → b ≡ c
-    functional' r1 r2 = out! (map.functional _ _ (inc (_ , r1 , r2)))
+    functional' r1 r2 = □-out! (map.functional _ _ (inc (_ , r1 , r2)))
 
     entire' : ∀ a → ∃ ∣ y ∣ λ b → ∣ rel a b ∣
-    entire' a =
-      □-rec! (λ { (x , y , R) → inc (x , R) }) (map.entire a a (inc refl))
+    entire' a = case map.entire a a (inc refl) of λ x _ a~x → inc (x , a~x)
 ```
 
 ## The category of maps

--- a/src/Cat/Bi/Instances/Relations.lagda.md
+++ b/src/Cat/Bi/Instances/Relations.lagda.md
@@ -375,7 +375,7 @@ Since $q$ is a strong epi, $\alpha$ is, too.
     α-is-pb = pasting-outer→left-is-pullback ([rs]t.inter .has-is-pb) rem₁ ([rs]t.inter .p₂∘universal)
 
   α-cover : is-strong-epi C α
-  α-cover = stable _ _ (out! (factor rs.it .mediate∈E)) α-is-pb
+  α-cover = stable _ _ (□-out! (factor rs.it .mediate∈E)) α-is-pb
 ```
 
 The purpose of all this calculation is the following: Postcomposing with
@@ -434,7 +434,7 @@ want to look at the formalisation.
       (r[st].inter .p₁∘universal)
 
   β-cover : is-strong-epi C β
-  β-cover = stable _ _ (out! (factor st.it .mediate∈E)) β-is-pb
+  β-cover = stable _ _ (□-out! (factor st.it .mediate∈E)) β-is-pb
 
   r[st]≅i : Im r[st].it Sub.≅ Im j
   r[st]≅i = subst (λ e → Im r[st].it Sub.≅ Im e)

--- a/src/Cat/CartesianClosed/Instances/PSh.agda
+++ b/src/Cat/CartesianClosed/Instances/PSh.agda
@@ -154,20 +154,18 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
 
     coequ : Coequaliser (PSh _ C) f g
     coequ .coapex .F₀ i = el (Coeq (f .η i) (g .η i)) squash
-    coequ .coapex .F₁ h = Coeq-rec squash (λ g → inc (Y.₁ h g)) λ x →
+    coequ .coapex .F₁ h = Coeq-rec (λ g → inc (Y.₁ h g)) λ x →
       inc (Y.₁ h (f .η _ x)) ≡˘⟨ ap incq (happly (f .is-natural _ _ h) x) ⟩
       inc (f .η _ _)         ≡⟨ glue (X.₁ h x) ⟩
       inc (g .η _ _)         ≡⟨ ap incq (happly (g .is-natural _ _ h) x) ⟩
       inc (Y.₁ h (g .η _ x)) ∎
-    coequ .coapex .F-id = funext $ Coeq-elim-prop (λ _ → squash _ _) λ _ →
-      ap incq (happly Y.F-id _)
-    coequ .coapex .F-∘ f g = funext $ Coeq-elim-prop (λ _ → squash _ _) λ _ →
-      ap incq (happly (Y.F-∘ f g) _)
+    coequ .coapex .F-id = ext λ _ → ap incq (happly Y.F-id _)
+    coequ .coapex .F-∘ f g = ext λ _ → ap incq (happly (Y.F-∘ f g) _)
     coequ .coeq .η i = incq
     coequ .coeq .is-natural x y f = refl
     coequ .has-is-coeq .coequal = ext λ i x → glue x
     coequ .has-is-coeq .universal {F = F} {e' = e'} p .η x =
-      Coeq-rec (F .F₀ x .is-tr) (e' .η x) (p ηₚ x $ₚ_)
+      Coeq-rec (e' .η x) (p ηₚ x $ₚ_)
     coequ .has-is-coeq .universal {F = F} {e' = e'} p .is-natural x y f = ext λ x →
       e' .is-natural _ _ _ $ₚ _
     coequ .has-is-coeq .factors = trivial!

--- a/src/Cat/Connected.lagda.md
+++ b/src/Cat/Connected.lagda.md
@@ -89,12 +89,8 @@ zigzags into sets:
 
 ```agda
   connected→π₀-is-contr : is-connected-cat C → is-contr (π₀ ʻ C)
-  connected→π₀-is-contr conn = ∥-∥-rec!
-    (λ x → contr (inc x)
-      (Coeq-elim-prop (λ _ → hlevel 1)
-        λ y → ∥-∥-rec! (Meander-rec-≡ (π₀ C) inc quot)
-          (conn .zigzag x y)))
-    (conn .point)
+  connected→π₀-is-contr conn = case conn .point of λ x → contr (inc x)
+    (elim! λ y → rec! (Meander-rec-≡ (π₀ C) inc quot) (conn .zigzag x y))
 ```
 
 Showing the converse implication is not as straightforward: in order to
@@ -123,15 +119,14 @@ a zigzag.
     R .symᶜ     = ∥-∥-map (reverse C)
 
     is : Iso (quotient R) (π₀ ʻ C)
-    is .fst = Coeq-rec squash inc λ (x , y , fs) →
-      ∥-∥-rec (squash _ _) (Meander-rec-≡ (π₀ C) inc quot) fs
-    is .snd .is-iso.inv = Coeq-rec squash inc λ (x , y , f) →
+    is .fst = Coeq-rec inc (elim! λ x y → Meander-rec-≡ (π₀ C) inc quot)
+    is .snd .is-iso.inv = Coeq-rec inc λ (x , y , f) →
       quot (inc (zig f []))
-    is .snd .is-iso.rinv = Coeq-elim-prop (λ _ → squash _ _) λ _ → refl
-    is .snd .is-iso.linv = Coeq-elim-prop (λ _ → squash _ _) λ _ → refl
+    is .snd .is-iso.rinv = elim! λ _ → refl
+    is .snd .is-iso.linv = elim! λ _ → refl
 
     conn : is-connected-cat C
-    conn .point = Coeq-elim-prop (λ _ → squash) inc (π₀-contr .centre)
+    conn .point = rec! inc (π₀-contr .centre)
     conn .zigzag x y = effective R
       (is-contr→is-prop (Iso→is-hlevel 0 is π₀-contr) (inc x) (inc y))
 

--- a/src/Cat/Diagram/Coend/Sets.lagda.md
+++ b/src/Cat/Diagram/Coend/Sets.lagda.md
@@ -112,7 +112,7 @@ module _ {o ℓ} {𝒞 : Precategory o ℓ} where
   Coends : Functor Cat[ 𝒞 ^op ×ᶜ 𝒞 , Sets (o ⊔ ℓ) ] (Sets (o ⊔ ℓ))
   Coends .F₀ F = el! (Coeq (dimapl F) (dimapr F))
   Coends .F₁ α =
-    Coeq-rec squash (λ ∫F → inc ((∫F .fst) , α .η _ (∫F .snd))) λ where
+    Coeq-rec (λ ∫F → inc ((∫F .fst) , α .η _ (∫F .snd))) λ where
       (X , Y , f , Fxy) →
         (ap (λ ϕ → inc (X , ϕ)) $ happly (α .is-natural (X , Y) (X , X) (id , f)) Fxy) ··
         glue (X , Y , f , α .η (X , Y) Fxy) ··

--- a/src/Cat/Diagram/Sieve.lagda.md
+++ b/src/Cat/Diagram/Sieve.lagda.md
@@ -78,7 +78,7 @@ module _ {o κ : _} (C : Precategory o κ) (c : ⌞ C ⌟) where
 
   intersect : ∀ {I : Type κ} (F : I → Sieve C c) → Sieve C c
   intersect {I = I} F .arrows h = elΩ ((x : I) → h ∈ F x)
-  intersect {I = I} F .closed g x = inc λ i → F i .closed g (out! x i)
+  intersect {I = I} F .closed g x = inc λ i → F i .closed g (□-out! x i)
 ```
 
 ## Representing subfunctors

--- a/src/Cat/Displayed/Doctrine/Frame.lagda.md
+++ b/src/Cat/Displayed/Doctrine/Frame.lagda.md
@@ -178,12 +178,11 @@ a calculation:
     lifted : Cocartesian-lift disp f g
     lifted .y' y      = exist y
     lifted .lifting i = F.⋃-inj (g i , inc (i , refl , refl))
-    lifted .cocartesian .universal {u' = u'} m h' i = F.⋃-universal _ λ (e , b) →
-      □-rec! (λ { (x , p , q) →
-        e            F.=⟨ sym q ⟩
-        g x          F.≤⟨ h' x ⟩
-        u' (m (f x)) F.=⟨ ap u' (ap m p) ⟩
-        u' (m i)     F.≤∎ }) b
+    lifted .cocartesian .universal {u' = u'} m h' i = F.⋃-universal _ $ elim! λ e x p q →
+      e            F.=˘⟨ q ⟩
+      g x          F.≤⟨ h' x ⟩
+      u' (m (f x)) F.=⟨ ap u' (ap m p) ⟩
+      u' (m i)     F.≤∎
     lifted .cocartesian .commutes m h = prop!
     lifted .cocartesian .unique   m x = prop!
 ```
@@ -233,11 +232,11 @@ distributive law in $F$:
       ⟩
       exist (λ x → α x F.∩ β (f x)) i           F.≤∎ )
     ( exist (λ x → α x F.∩ β (f x)) i           F.≤⟨
-        F.⋃-universal _ (λ (e , p) → □-rec! (λ { (x , p , q) →
+        F.⋃-universal _ (elim! λ e x p q →
           e                                         F.=⟨ sym q ⟩
           α x F.∩ β (f x)                           F.=⟨ ap (α x F.∩_) (ap β p) ⟩
           α x F.∩ β i                               F.≤⟨ F.⋃-inj (α x , inc (x , p , refl)) ⟩
-          F.⋃ {I = img α i} (λ (x , _) → x F.∩ β i) F.≤∎ }) p)
+          F.⋃ {I = img α i} (λ (x , _) → x F.∩ β i) F.≤∎)
       ⟩
       F.⋃ {I = img α i} (λ (x , _) → x F.∩ β i) F.=⟨ sym (F.⋃-distribr _ _) ⟩
       exist α i F.∩ β i                         F.≤∎)

--- a/src/Cat/Functor/Final.lagda.md
+++ b/src/Cat/Functor/Final.lagda.md
@@ -151,9 +151,8 @@ the following diagram:
         extend-const
           : ∀ d (f g : Ob (d ↙ F))
           → extend d f ≡ extend d g
-        extend-const d f g = ∥-∥-rec!
-          (Meander-rec-≡ (el! _) (extend d) (extend-const1 d))
-          (fin.zigzag d f g)
+        extend-const d f g = case fin.zigzag d f g of
+          Meander-rec-≡ (el! _) (extend d) (extend-const1 d)
 ```
 
 In order to make reasoning easier, we define the extended cocone

--- a/src/Cat/Instances/OFE/Product.lagda.md
+++ b/src/Cat/Instances/OFE/Product.lagda.md
@@ -150,7 +150,7 @@ about to get the actual inhabitant of $(1)$ that we're interested in.
   Π-OFE .has-is-ofe .limit x y wit i j = P.limit (x j) (y j) (λ n → wit' n j) i
     where
       wit' : ∀ n i → within (P i) n (x i) (y i)
-      wit' n i = out! (wit n .Lift.lower) i
+      wit' n i = □-out! (wit n .Lift.lower) i
 ```
 
 <!--
@@ -174,7 +174,7 @@ OFE-Indexed-product F .ΠF = from-ofe-on $
   Π-OFE (λ i → ∣ F i .fst ∣) (λ i → F i .snd)
 OFE-Indexed-product F .π i .hom f = f i
 OFE-Indexed-product F .π i .preserves .pres-≈ α =
-  out! ((_$ i) <$> α .Lift.lower)
+  □-out! ((_$ i) <$> α .Lift.lower)
 OFE-Indexed-product F .has-is-ip .tuple f .hom x i = f i # x
 OFE-Indexed-product F .has-is-ip .tuple f .preserves .pres-≈ wit =
   lift $ inc λ i → f i .preserves .pres-≈ wit

--- a/src/Cat/Instances/Sets/Cocomplete.lagda.md
+++ b/src/Cat/Instances/Sets/Cocomplete.lagda.md
@@ -120,7 +120,7 @@ definition.
        → sum / rel
        → ∣ A ∣
   univ {A} eps p =
-    Coeq-rec (A .is-tr)
+    Coeq-rec
       (λ { (x , p) → eps x p })
       (λ { ((X , x) , (Y , y) , f , q) → sym (p f x) ∙ ap (eps _) q})
 

--- a/src/Cat/Instances/StrictCat/Cohesive.lagda.md
+++ b/src/Cat/Instances/StrictCat/Cohesive.lagda.md
@@ -322,15 +322,13 @@ the same set we started with.
 
 ```agda
   adj .counit .η X = Quot-elim (λ _ → X .is-tr) (λ x → x) λ x y r → r
-  adj .counit .is-natural x y f =
-    funext (Coeq-elim-prop (λ _ → y .is-tr _ _) λ _ → refl)
+  adj .counit .is-natural x y f = trivial!
 ```
 
 The triangle identities are again straightforwardly checked.
 
 ```agda
-  adj .zig {x} = funext (Coeq-elim-prop (λ _ → squash _ _) λ x → refl)
-
+  adj .zig {x} = trivial!
   adj .zag = Functor-path (λ x → refl) λ f → refl
 ```
 
@@ -366,13 +364,8 @@ This map has an inverse given by joining up the pairs:
     (λ a (x , y , r) i → glue ((a , x) , (a , y) , Precategory.id C , r) i)
     a b
 
-  isom .rinv (a , b) = Coeq-elim-prop₂
-    {C = λ x y → f (isom .inv (x , y)) ≡ (x , y)}
-    (λ _ _ → ×-is-hlevel 2 squash squash _ _)
-    (λ _ _ → refl)
-    a b
-
-  isom .linv = Coeq-elim-prop (λ _ → squash _ _) λ _ → refl
+  isom .rinv = elim! λ x y → refl
+  isom .linv = elim! λ x y → refl
 ```
 
 ## Pieces have points
@@ -387,5 +380,5 @@ Points→Pieces .η _ x = inc x
 Points→Pieces .is-natural x y f i o = inc (f .F₀ o)
 
 pieces-have-points : ∀ {x} → is-surjective (Points→Pieces {ℓ} .η x)
-pieces-have-points = Coeq-elim-prop (λ _ → squash) λ x → inc (x , refl)
+pieces-have-points = elim! λ x → inc (x , refl)
 ```

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -75,7 +75,7 @@ latter two names have a placeholder for the morphism we are factoring.
     im[ f ] = factor f .Factorisation.mediating
 
     im[_]↪b : ∀ {a b} (f : C.Hom a b) → im[ f ] C.↪ b
-    im[ f ]↪b = record { monic = out! (factor f .Factorisation.forget∈M) }
+    im[ f ]↪b = record { monic = □-out! (factor f .Factorisation.forget∈M) }
 
     a↠im[_] : ∀ {a b} (f : C.Hom a b) → C.Hom a im[ f ]
     a↠im[ f ] = factor f .Factorisation.mediate
@@ -96,10 +96,10 @@ latter two names have a placeholder for the morphism we are factoring.
       rem₁ : f ≡ r.im[ f ]↪b .C.mor C.∘ r.a↠im[ f ]
       rem₁ = r.factor f .factors
 
-      p = out! (r.factor f .mediate∈E) .snd (record { monic = x })
+      p = □-out! (r.factor f .mediate∈E) .snd (record { monic = x })
         (sym (r.factor f .factors) ∙ sym (C.idr _))
       res = C.make-invertible (p .centre .fst)
-        (out! (r.factor f .mediate∈E) .fst _ _
+        (□-out! (r.factor f .mediate∈E) .fst _ _
           (C.pullr (p .centre .snd .fst) ∙ C.id-comm))
         (p .centre .snd .fst)
 ```
@@ -263,7 +263,7 @@ obtaining
 
 ```agda
       g-monic : C.is-monic g
-      g-monic {e} k l w' = out! dgh.forget∈M _ _ rem₈ where
+      g-monic {e} k l w' = □-out! dgh.forget∈M _ _ rem₈ where
         d×d = ×-functor .F₁ (d , d)
         module pb = Pullback (r.lex.pullbacks ⟨ k , l ⟩ d×d)
           renaming (p₁ to p ; apex to P ; p₂ to mn ; square to sq'-)
@@ -317,7 +317,7 @@ skip it.
         open is-pullback
 
         rem₂ : is-strong-epi 𝒞 (×-functor .F₁ (d , id))
-        rem₂ = r.stable d π₁ {p2 = π₁} (out! dgh.mediate∈E) λ where
+        rem₂ = r.stable d π₁ {p2 = π₁} (□-out! dgh.mediate∈E) λ where
           .square → π₁∘⟨⟩
           .universal {p₁' = p₁'} {p₂'} p → ⟨ p₂' , π₂ ∘ p₁' ⟩
           .p₁∘universal {p₁' = p₁'} {p₂'} {p = p} → ⟨⟩∘ _
@@ -328,7 +328,7 @@ skip it.
             ap (π₂ ∘_) (sym q) ∙ pulll π₂∘⟨⟩ ∙ ap (_∘ lim') (idl _)
 
         rem₃ : is-strong-epi 𝒞 (×-functor .F₁ (id , d))
-        rem₃ = r.stable d π₂ {p2 = π₂} (out! dgh.mediate∈E) λ where
+        rem₃ = r.stable d π₂ {p2 = π₂} (□-out! dgh.mediate∈E) λ where
           .square → π₂∘⟨⟩
           .universal {p₁' = p₁'} {p₂'} p → ⟨ π₁ ∘ p₁' , p₂' ⟩
           .p₁∘universal {p = p} → ⟨⟩∘ _
@@ -382,7 +382,7 @@ we do below.
 ```agda
       g-iso : is-invertible g
       g-iso = make-invertible (p .centre .fst) (p .centre .snd .snd)
-        (out! dgh.mediate∈E .fst _ _
+        (□-out! dgh.mediate∈E .fst _ _
           ( pullr (pullr (sym dgh.factors) ∙ π₁∘⟨⟩)
           ∙ p .centre .snd .fst ∙ introl refl))
         module g-ortho where

--- a/src/Cat/Regular/Image.lagda.md
+++ b/src/Cat/Regular/Image.lagda.md
@@ -49,7 +49,7 @@ $\im f$ whenever $f : x \to y$.
 Im : ∀ {x y} (f : Hom x y) → Subobject y
 Im f .domain = _
 Im f .map    = factor f .forget
-Im f .monic  = out! (factor f .forget∈M)
+Im f .monic  = □-out! (factor f .forget∈M)
 ```
 
 We may then use this to rephrase the universal property of $\im f$ as
@@ -62,7 +62,7 @@ Im-universal
   → f ≡ m .map ∘ e
   → Im f ≤ₘ m
 Im-universal f m {e = e} p = r where
-  the-lift = out! (factor f .mediate∈E) .snd
+  the-lift = □-out! (factor f .mediate∈E) .snd
     record { Subobject m } (sym (factor f .factors) ∙ p)
 
   r : _ ≤ₘ _
@@ -95,10 +95,10 @@ image-pre-cover {a = a} {b} {c} f g g-covers = Sub-antisym imf≤imfg imfg≤imf
     (≤ₘ→mono imfg≤imf)
     {factor (f ∘ g) .mediate}
     {factor f .mediate}
-    (out! (factor f .forget∈M) _ _ (sym (pulll (sym (imfg≤imf .sq) ∙ idl _) ∙ sym (factor (f ∘ g) .factors) ∙ pushl (factor f .factors)))) .centre
+    (□-out! (factor f .forget∈M) _ _ (sym (pulll (sym (imfg≤imf .sq) ∙ idl _) ∙ sym (factor (f ∘ g) .factors) ∙ pushl (factor f .factors)))) .centre
 
   inverse : is-invertible (imfg≤imf .map)
-  inverse = is-strong-epi→is-extremal-epi C (out! (factor f .mediate∈E))
+  inverse = is-strong-epi→is-extremal-epi C (□-out! (factor f .mediate∈E))
     (≤ₘ→mono imfg≤imf) (the-lift .fst) (sym (the-lift .snd .snd))
 
   imf≤imfg : Im f ≤ₘ Im (f ∘ g)

--- a/src/Cat/Regular/Slice.lagda.md
+++ b/src/Cat/Regular/Slice.lagda.md
@@ -162,7 +162,7 @@ slice-is-regular .factor {a} {b} f = fact' where
   fact' .mediate∈E = do
     c ← f.mediate∈E
     pure (reflect-cover (fact' .mediate) c)
-  fact' .forget∈M = inc λ g h p → ext $ out! f.forget∈M (g .map) (h .map) (ap map p)
+  fact' .forget∈M = inc λ g h p → ext $ □-out! f.forget∈M (g .map) (h .map) (ap map p)
   fact' .factors = ext f.factors
 
 slice-is-regular .stable {B = B} f g {p1} {p2} cover is-pb =

--- a/src/Data/Dec/Base.lagda.md
+++ b/src/Data/Dec/Base.lagda.md
@@ -159,5 +159,12 @@ infix 0 ifᵈ_then_else_
 ifᵈ_then_else_ : Dec A → B → B → B
 ifᵈ yes a then y else n = y
 ifᵈ no ¬a then y else n = n
+
+is-yes : ∀ {ℓ} {A : Type ℓ} → Dec A → Type
+is-yes (yes x) = ⊤
+is-yes (no _)  = ⊥
+
+decide! : ∀ {ℓ} {A : Type ℓ} ⦃ d : Dec A ⦄ {_ : is-yes d} → A
+decide! ⦃ yes x ⦄ = x
 ```
 -->

--- a/src/Data/Fin/Finite.lagda.md
+++ b/src/Data/Fin/Finite.lagda.md
@@ -116,7 +116,7 @@ instance opaque
       (x .enumeration) (y .enumeration) i
 
 Finite→Discrete : ∀ {ℓ} {A : Type ℓ} → ⦃ Finite A ⦄ → Discrete A
-Finite→Discrete {A = A} ⦃ f ⦄ {x} {y} = ∥-∥-rec! go (f .enumeration) where
+Finite→Discrete {A = A} ⦃ f ⦄ {x} {y} = rec! go (f .enumeration) where
   open Finite f using (Finite→H-Level)
   go : A ≃ Fin (f .cardinality) → Dec (x ≡ y)
   go e with Equiv.to e x ≡? Equiv.to e y
@@ -264,6 +264,6 @@ Finite-Lift = Finite-≃ (Lift-≃ e⁻¹)
 <!--
 ```agda
 card-zero→empty : ∥ A ≃ Fin 0 ∥ → ¬ A
-card-zero→empty ∥e∥ a = ∥-∥-rec! (λ e → fin-absurd (Equiv.to e a)) ∥e∥
+card-zero→empty ∥e∥ a = rec! (λ e → fin-absurd (Equiv.to e a)) ∥e∥
 ```
 -->

--- a/src/Data/Fin/Finite/Listed.lagda.md
+++ b/src/Data/Fin/Finite/Listed.lagda.md
@@ -2,6 +2,7 @@
 ```agda
 open import 1Lab.HIT.Truncation
 open import 1Lab.HLevel.Closure
+open import 1Lab.Inductive
 open import 1Lab.Resizing
 open import 1Lab.HLevel
 open import 1Lab.Equiv

--- a/src/Data/Fin/Properties.lagda.md
+++ b/src/Data/Fin/Properties.lagda.md
@@ -244,11 +244,10 @@ also a bijection.
 Fin-surjection→equiv
   : ∀ {n} (f : Fin n → Fin n)
   → is-surjective f → is-equiv f
-Fin-surjection→equiv f surj = ∥-∥-rec!
-  (λ split → left-inverse→equiv (snd ∘ split)
+Fin-surjection→equiv f surj = case finite-surjection-split f surj of λ split →
+  left-inverse→equiv (snd ∘ split)
     (Fin-injection→equiv (fst ∘ split)
-      (right-inverse→injective f (snd ∘ split))))
-  (finite-surjection-split f surj)
+      (right-inverse→injective f (snd ∘ split)))
 ```
 
 ## Vector operations

--- a/src/Data/Nat/Divisible.lagda.md
+++ b/src/Data/Nat/Divisible.lagda.md
@@ -61,7 +61,7 @@ x)\inv(y)$ --- and it is logically equivalent to that type, too!
 ∣-is-truncation {zero} {y} =
   prop-ext!
     (λ p → inc (y , *-zeror y ∙ sym p))
-    (∥-∥-rec! (λ{ (x , p) → sym p ∙ *-zeror x }))
+    (rec! λ x p → sym p ∙ *-zeror x )
 ∣-is-truncation {suc x} {y} = Equiv.to is-prop≃equiv∥-∥ (∣-is-prop (suc x) y)
 
 ∣→fibre : ∀ {x y} → x ∣ y → fibre (_* x) y

--- a/src/Data/Power/Complemented.lagda.md
+++ b/src/Data/Power/Complemented.lagda.md
@@ -73,10 +73,9 @@ intersection $(p \cap p\inv)$ is empty.
 ```agda
 is-complemented→is-decidable : (p : ℙ A) → is-complemented p → is-decidable p
 is-complemented→is-decidable p (p⁻¹ , intersection , union) elt =
-  ∥-∥-rec!  (λ { (inl x∈p)   → yes x∈p
-             ; (inr x∈p⁻¹) → no λ x∈p → intersection elt (x∈p , x∈p⁻¹)
-             })
-    (union elt tt)
+  case union elt tt of λ where
+    (inl x∈p)  → yes x∈p
+    (inr x∈¬p) → no λ x∈p → intersection elt (x∈p , x∈¬p)
 ```
 
 # Decidable subobject classifiers

--- a/src/Data/Set/Material.lagda.md
+++ b/src/Data/Set/Material.lagda.md
@@ -619,8 +619,8 @@ $p$, a proof that $C$ holds of $x$.
 ```agda
   separation : ∀ a C (x : V ℓ) → (x ∈ subset a C) ≃ (x ∈ a × x ∈ C)
   separation a C x = prop-ext!
-    (∥-∥-rec! λ { ((j , w) , p) →
-      Members.contains' a (sym p) , subst (λ e → ∣ C e ∣) p w })
+    (rec! λ j w p →
+      Members.contains' a (sym p) , subst (λ e → ∣ C e ∣) p w )
     (λ { (i∈a , Ci) → inc (
       ( Members.memb.to a i∈a .fst
       , subst (λ e → ∣ C e ∣) (sym (Members.memb.to a i∈a .snd)) Ci)
@@ -735,7 +735,7 @@ m_a^*(x)$. It remains to show $m_a(k) \in i$; but this is equal to $x
         ( Members.memb.to a (i⊆a _ e∈i)
         , inc (subst (_∈ i) (sym (Members.memb.to a (i⊆a _ e∈i) .snd)) e∈i))
 
-    done = prop-ext! (∥-∥-rec! p1) p2
+    done = prop-ext! (∥-∥-rec (hlevel 1) p1) p2
 ```
 
 ## Set induction
@@ -751,5 +751,5 @@ as it holds for every $x \in a$, then $P$ holds of any material set.
     → ({a : V ℓ} → ({x : V ℓ} → x ∈ a → x ∈ P) → a ∈ P)
     → (x : V ℓ) → x ∈ P
   ∈-induction P ps = V-elim-prop (λ z → z ∈ P) (λ _ → P _ .is-tr) $ λ f i →
-    ps λ {x} → ∥-∥-rec! λ (a , p) → subst (_∈ P) p (i a)
+    ps λ {x} → rec! λ a p → subst (_∈ P) p (i a)
 ```

--- a/src/Data/Set/Truncation.lagda.md
+++ b/src/Data/Set/Truncation.lagda.md
@@ -4,6 +4,7 @@ open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Universe
 open import 1Lab.HIT.Truncation
 open import 1Lab.HLevel.Closure
+open import 1Lab.Inductive
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
@@ -53,6 +54,20 @@ map into must be a set, as required by the `squash`{.Agda} constructor.
   where go = ∥-∥₀-rec bset f
 ```
 
+<!--
+```agda
+instance
+  Inductive-∥∥₀
+    : ∀ {ℓ ℓ' ℓm} {A : Type ℓ} {P : ∥ A ∥₀ → Type ℓ'} ⦃ i : Inductive (∀ x → P (inc x)) ℓm ⦄
+    → ⦃ _ : ∀ {x} → H-Level (P x) 2 ⦄
+    → Inductive (∀ x → P x) ℓm
+  Inductive-∥∥₀ ⦃ i ⦄ = record
+    { methods = i .Inductive.methods
+    ; from    = λ f → ∥-∥₀-elim (λ x → hlevel 2) (i .Inductive.from f)
+    }
+```
+-->
+
 The most interesting result is that, since the sets form a [[reflective
 subcategory]] of types, the set-truncation is an idempotent monad.
 Indeed, as required, the counit `inc`{.Agda} is an equivalence:
@@ -98,21 +113,6 @@ using `is-set→squarep`{.Agda}.
          (λ i → ∥-∥₀-map₂ f a (p i))
          (λ i → ∥-∥₀-map₂ f a (q i))
          i j
-
-∥-∥₀-elim₂ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : ∥ A ∥₀ → ∥ B ∥₀ → Type ℓ''}
-           → (∀ x y → is-set (C x y))
-           → (∀ x y → C (inc x) (inc y))
-           → ∀ x y → C x y
-∥-∥₀-elim₂ Bset f = ∥-∥₀-elim (λ x → Π-is-hlevel 2 (Bset x))
-  λ x → ∥-∥₀-elim (Bset (inc x)) (f x)
-
-∥-∥₀-elim₃ : ∀ {ℓ ℓ' ℓ'' ℓ'''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
-               {D : ∥ A ∥₀ → ∥ B ∥₀ → ∥ C ∥₀ → Type ℓ'''}
-           → (∀ x y z → is-set (D x y z))
-           → (∀ x y z → D (inc x) (inc y) (inc z))
-           → ∀ x y z → D x y z
-∥-∥₀-elim₃ Bset f = ∥-∥₀-elim₂ (λ x y → Π-is-hlevel 2 (Bset x y))
-  λ x y → ∥-∥₀-elim (Bset (inc x) (inc y)) (f x y)
 ```
 
 # Paths in the set truncation

--- a/src/Homotopy/Connectedness.lagda.md
+++ b/src/Homotopy/Connectedness.lagda.md
@@ -89,9 +89,8 @@ is-connected∙ (X , pt) = (x : X) → ∥ x ≡ pt ∥
 module _ {ℓ} {X@(_ , pt) : Type∙ ℓ} where
   is-connected∙→is-connected : is-connected∙ X → is-connected ⌞ X ⌟
   is-connected∙→is-connected c .centre = inc pt
-  is-connected∙→is-connected c .paths =
-    ∥-∥₀-elim (λ _ → is-hlevel-suc 2 squash (inc pt) _) λ x →
-      ∥-∥-rec! (ap inc ∘ sym) (c x)
+  is-connected∙→is-connected c .paths = elim! λ x → case c x of λ
+    pt=x → ap inc (sym pt=x)
 
   is-connected→is-connected∙ : is-connected ⌞ X ⌟ → is-connected∙ X
   is-connected→is-connected∙ c x =
@@ -209,9 +208,9 @@ retract→is-n-connected 0 = _
 retract→is-n-connected 1 f g h a-conn = f <$> a-conn
 retract→is-n-connected (suc (suc n)) f g h a-conn =
   n-connected.from (suc n) $ retract→is-contr
-    (n-Tr-rec! (inc ∘ f))
-    (n-Tr-rec! (inc ∘ g))
-    (n-Tr-elim! _ λ x → ap n-Tr.inc (h x))
+    (rec! (inc ∘ f))
+    (rec! (inc ∘ g))
+    (elim! λ x → ap n-Tr.inc (h x))
     (is-n-connected-Tr (suc n) a-conn)
 ```
 
@@ -254,8 +253,8 @@ is-connected-suc
   : ∀ {ℓ} {A : Type ℓ} n
   → is-n-connected A (suc n) → is-n-connected A n
 is-connected-suc {A = A} zero _ = _
-is-connected-suc {A = A} (suc n) w = n-connected.from n $ n-Tr-elim! _
-    (λ x → contr (inc x) (n-Tr-elim! _ (rem₁ n w x)))
+is-connected-suc {A = A} (suc n) w = n-connected.from n $ elim!
+    (λ x → contr (inc x) (elim! (rem₁ n w x)))
     (is-n-connected-Tr (suc n) w .centre)
   where
     rem₁ : ∀ n → is-n-connected A (2 + n) → ∀ x y → Path (n-Tr A (suc n)) (inc x) (inc y)
@@ -311,11 +310,11 @@ is-contr-n-Tr→∥-∥ (suc n) h .snd a b = is-contr-n-Tr→∥-∥ n
 
 ∥-∥→is-contr-n-Tr
   : ∀ n → is-n-connected-∥-∥ A (suc n) → is-contr (n-Tr A (suc n))
-∥-∥→is-contr-n-Tr zero (a , _) = is-prop∙→is-contr (hlevel 1) (∥-∥-rec! inc a)
-∥-∥→is-contr-n-Tr (suc n) (a , h) = ∥-∥-rec! (λ a → is-prop∙→is-contr
-  (n-Tr-elim! _ λ a → n-Tr-elim! _ λ b →
-    Equiv.from n-Tr-path-equiv (∥-∥→is-contr-n-Tr n (h a b) .centre))
-  (inc a)) a
+∥-∥→is-contr-n-Tr zero (a , _) = is-prop∙→is-contr (hlevel 1) (rec! inc a)
+∥-∥→is-contr-n-Tr (suc n) (a , h) = case a of λ a →
+  is-prop∙→is-contr
+    (elim! λ a b → Equiv.from n-Tr-path-equiv (∥-∥→is-contr-n-Tr n (h a b) .centre))
+    (inc a)
 
 is-n-connected→∥-∥
   : ∀ n → is-n-connected A n → is-n-connected-∥-∥ A n

--- a/src/Homotopy/Truncation.lagda.md
+++ b/src/Homotopy/Truncation.lagda.md
@@ -161,6 +161,15 @@ n-Tr-elim {A = A} {n} P ptrunc pbase = go where
 
 <!--
 ```agda
+instance
+  Inductive-n-Tr
+    : ∀ {ℓ ℓ' ℓm} {A : Type ℓ} {n} {P : n-Tr A (suc n) → Type ℓ'} ⦃ i : Inductive (∀ x → P (inc x)) ℓm ⦄
+    → ⦃ _ : ∀ {x} → H-Level (P x) (suc n) ⦄
+    → Inductive (∀ x → P x) ℓm
+  Inductive-n-Tr ⦃ i ⦄ = record
+    { from = λ f → n-Tr-elim _ (λ x → hlevel _) (i .Inductive.from f)
+    }
+
 n-Tr-elim!
   : ∀ {ℓ ℓ'} {A : Type ℓ} {n}
   → (P : n-Tr A (suc n) → Type ℓ')
@@ -228,10 +237,10 @@ induction`{.Agda id=J} and the induction principle for $\|A\|_{n+2}$.
   encode' x _ = J (λ y _ → ∣ code x y ∣) (inc refl)
 
   decode' : ∀ x y → ∣ code x y ∣ → inc x ≡ y
-  decode' x = n-Tr-elim! _ λ x → n-Tr-rec! (ap inc)
+  decode' = elim! λ x y → ap inc
 
   rinv : ∀ x y → is-right-inverse (decode' x y) (encode' x y)
-  rinv x = n-Tr-elim! _ λ x → n-Tr-elim! _ λ p → ap n-Tr.inc (subst-path-right _ _ ∙ ∙-idl _)
+  rinv = elim! λ x y x=y → ap n-Tr.inc (subst-path-right _ _ ∙ ∙-idl _)
 
   linv : ∀ x y → is-left-inverse (decode' x y) (encode' x y)
   linv x _ = J (λ y p → decode' x y (encode' x y p) ≡ p)
@@ -278,10 +287,7 @@ n-Tr-product {A = A} {B} {n} = distrib , distrib-is-equiv module n-Tr-product wh
 
   distrib-is-iso : is-iso distrib
   distrib-is-iso .inv (x , y)  = pair x y
-  distrib-is-iso .rinv (x , y) = n-Tr-elim!
-    (λ x → ∀ y → distrib (pair x y) ≡ (x , y))
-    (λ x → n-Tr-elim! _ λ y → refl)
-    x y
+  distrib-is-iso .rinv = elim! λ x y → refl
   distrib-is-iso .linv = n-Tr-elim! _ λ x → refl
 
   distrib-is-equiv = is-iso→is-equiv distrib-is-iso

--- a/src/Order/DCPO/Free.lagda.md
+++ b/src/Order/DCPO/Free.lagda.md
@@ -52,9 +52,7 @@ Disc-is-dcpo {A = A} .is-dcpo.directed-lubs {Ix = Ix} f dir =
   const-inhabited-fam→lub disc-fam-const (dir .elt)
   where
     disc-fam-const : ∀ i j → f i ≡ f j
-    disc-fam-const i j =
-      ∥-∥-rec! (λ (k , p , q) → p ∙ sym q)
-        (dir .semidirected i j)
+    disc-fam-const i j = case dir .semidirected i j of λ k p q → p ∙ sym q
 
 Disc-dcpo : (A : Set ℓ) → DCPO ℓ ℓ
 Disc-dcpo A = Disc A , Disc-is-dcpo
@@ -200,10 +198,8 @@ module
 
   ⊑-lub-least
     : ∀ x → (∀ i → s i ⊑ x) → ⊑-lub s dir ⊑ x
-  ⊑-lub-least x le .implies = □-rec! λ (i , si) →
-    le i .implies si
-  ⊑-lub-least x le .refines = □-elim! λ (i , si) →
-    le i .refines si
+  ⊑-lub-least x le .implies = rec! λ i si → le i .implies si
+  ⊑-lub-least x le .refines = elim! λ i si → le i .refines si
 ```
 
 <!--
@@ -250,10 +246,8 @@ part-map-lub
   → (f : ∣ A ∣ → ∣ B ∣)
   → is-lub (Parts B) (part-map f ⊙ s) (part-map f (⊑-lub s dir))
 part-map-lub f .fam≤lub i = part-map-⊑ (⊑-lub-le i)
-part-map-lub f .least y le .implies =
-  □-rec! λ (i , si) → le i .implies si
-part-map-lub {B = B} f .least y le .refines =
-  □-elim! λ (i , si) → le i .refines si
+part-map-lub f .least y le .implies = rec! λ i si → le i .implies si
+part-map-lub {B = B} f .least y le .refines = elim! λ i si → le i .refines si
 
 Free-Pointed-dcpo : Functor (Sets ℓ) (Pointed-DCPOs ℓ ℓ)
 Free-Pointed-dcpo .F₀ A = Parts-pointed-dcpo A

--- a/src/Order/Diagram/Glb/Reasoning.lagda.md
+++ b/src/Order/Diagram/Glb/Reasoning.lagda.md
@@ -141,7 +141,7 @@ distributive law can be extended to an equality.
   ∩-distrib-nonempty-⋂-l i =
     ≤-antisym
      ∩-distrib-⋂-≤l
-     (∥-∥-rec! (λ i → ∩-universal _ (≤-trans (⋂-proj i) ∩≤l) (⋂≤⋂ λ _ → ∩≤r)) i)
+     (rec! (λ i → ∩-universal _ (≤-trans (⋂-proj i) ∩≤l) (⋂≤⋂ λ _ → ∩≤r)) i)
 ```
 
 <!--

--- a/src/Order/Diagram/Lub.lagda.md
+++ b/src/Order/Diagram/Lub.lagda.md
@@ -202,7 +202,7 @@ inhabited, then $f$ has a least upper bound.
     → ∥ I ∥
     → is-lub P F x
   const-inhabited-fam→is-lub {I = I} {F = F} {x = x} is-const =
-    ∥-∥-rec! mk-is-lub where
+    rec! mk-is-lub where
       mk-is-lub : I → is-lub P F x
       mk-is-lub i .is-lub.fam≤lub j = ≤-refl' (is-const j)
       mk-is-lub i .is-lub.least y le =
@@ -216,7 +216,7 @@ inhabited, then $f$ has a least upper bound.
     → ∥ I ∥
     → Lub P F
   const-inhabited-fam→lub {I = I} {F = F} is-const =
-    ∥-∥-rec Lub-is-prop mk-lub where
+    rec! mk-lub where
       mk-lub : I → Lub P F
       mk-lub i .Lub.lub = F i
       mk-lub i .Lub.has-lub =

--- a/src/Order/Diagram/Lub/Reasoning.lagda.md
+++ b/src/Order/Diagram/Lub/Reasoning.lagda.md
@@ -139,7 +139,7 @@ distributive law can be extended to an equality.
   ∪-distrib-nonempty-⋃-l i =
     ≤-antisym
       ∪-distrib-⋃-≤l
-      (∥-∥-rec! (λ i → ∪-universal _ (≤-trans l≤∪ (⋃-inj i)) (⋃≤⋃ λ _ → r≤∪)) i)
+      (rec! (λ i → ∪-universal _ (≤-trans l≤∪ (⋃-inj i)) (⋃≤⋃ λ _ → r≤∪)) i)
 ```
 
 <!--

--- a/src/Order/Diagram/Lub/Subset.lagda.md
+++ b/src/Order/Diagram/Lub/Subset.lagda.md
@@ -57,5 +57,5 @@ module
       : ∀ {P : ⌞ F ⌟ → Ω} {x}
       → (∀ i → i ∈ P → i ≤ x)
       → ⋃ˢ P ≤ x
-    ⋃ˢ-universal f = P.⋃-universal _ λ (i , w) → f i (out! w)
+    ⋃ˢ-universal f = P.⋃-universal _ λ (i , w) → f i (□-out! w)
 ```

--- a/src/Order/Frame.lagda.md
+++ b/src/Order/Frame.lagda.md
@@ -304,6 +304,6 @@ Power-frame A .snd .⋃ k i = ∃Ω _ (λ j → k j i)
 Power-frame A .snd .⋃-lubs k = is-lub-pointwise _ _ λ _ →
   Props-has-lubs λ i → k i _
 Power-frame A .snd .⋃-distribl x f = funext λ i → Ω-ua
-  (λ (x , i) → □-map (λ (y , z) → _ , x , z) i)
-  (λ r → □-rec! (λ { (x , y , z) → y , inc (_ , z) }) r)
+  (rec! λ xi j j~i → inc (j , xi , j~i))
+  (rec! λ j xi j~i → xi , inc (j , j~i))
 ```

--- a/src/Order/Frame/Free.lagda.md
+++ b/src/Order/Frame/Free.lagda.md
@@ -79,9 +79,9 @@ Lower-sets-frame (P , L) = Lower-sets P , L↓-frame where
   L↓-frame .is-frame.has-top = Lower-sets-top P
   L↓-frame .is-frame.⋃ k = Lower-sets-cocomplete P k .Lub.lub
   L↓-frame .is-frame.⋃-lubs k = Lower-sets-cocomplete P k .Lub.has-lub
-  L↓-frame .is-frame.⋃-distribl x f = ext λ arg →
-    Ω-ua (λ { (x , box) → □-map (λ { (i , arg∈fi) → i , x , arg∈fi }) box })
-         (□-rec! λ { (i , x , arg∈fi) → x , inc (i , arg∈fi) })
+  L↓-frame .is-frame.⋃-distribl x f = ext λ arg → Ω-ua
+    (rec! λ x≤a i fi≤a → inc (i , x≤a , fi≤a))
+    (rec! λ i x≤a fi≤a → x≤a , inc (i , fi≤a))
 ```
 
 The unit map $A \to D(A)$ sends an element of $A$ to its down-set,

--- a/src/Order/Instances/Lower.lagda.md
+++ b/src/Order/Instances/Lower.lagda.md
@@ -85,7 +85,7 @@ by arbitrarily large types:
   Lower-sets-complete F .Glb.glb .hom i = elΩ (∀ j → i ∈ F j)
   Lower-sets-complete F .Glb.glb .pres-≤ j≤i =
     □-map λ x∈Fj j → F j .pres-≤ j≤i (x∈Fj j)
-  Lower-sets-complete F .Glb.has-glb .is-glb.glb≤fam i x x∈Fj = (out! x∈Fj) i
+  Lower-sets-complete F .Glb.has-glb .is-glb.glb≤fam i x x∈Fj = □-out! x∈Fj i
   Lower-sets-complete F .Glb.has-glb .is-glb.greatest lb' lb'≤Fi x y∈lb' =
     inc (λ j → lb'≤Fi j x y∈lb')
 ```
@@ -104,7 +104,7 @@ operator automatically propositionally truncates.
   Lower-sets-cocomplete F .Lub.has-lub .is-lub.fam≤lub i x x∈Fi =
     inc (i , x∈Fi)
   Lower-sets-cocomplete F .Lub.has-lub .is-lub.least lb' lb'≤Fi x =
-    □-rec! (λ { (i , x∈Fi) → lb'≤Fi i x x∈Fi })
+    rec! λ i x∈Fi → lb'≤Fi i x x∈Fi
 ```
 
 <!--
@@ -125,7 +125,7 @@ operator automatically propositionally truncates.
   Lower-sets-joins a b .Join.has-join .is-join.l≤join x x∈a = inc (inl x∈a)
   Lower-sets-joins a b .Join.has-join .is-join.r≤join x x∈b = inc (inr x∈b)
   Lower-sets-joins a b .Join.has-join .is-join.least ub' f g x =
-    ∥-∥-rec! [ (f x) , (g x) ]
+    rec! [ f x , g x ]
 
   Lower-sets-top : Top (Lower-sets P)
   Lower-sets-top .Top.top .hom _ = ⊤Ω

--- a/src/Order/Instances/Lower/Cocompletion.lagda.md
+++ b/src/Order/Instances/Lower/Cocompletion.lagda.md
@@ -51,7 +51,7 @@ in Agda and play with it themselves!
 ```agda
   lower-set-is-lub : is-lub (Lower-sets P) diagram Ls
   lower-set-is-lub .is-lub.fam≤lub (j , j∈Ls) i □i≤j =
-    Ls .pres-≤ (out! □i≤j) j∈Ls
+    Ls .pres-≤ (□-out! □i≤j) j∈Ls
   lower-set-is-lub .is-lub.least ub' fam≤ub' i i∈Ls =
     fam≤ub' (i , i∈Ls) i (inc (P.≤-refl))
 ```
@@ -109,7 +109,7 @@ that our cocontinuous extension commutes with the "unit map" $A \to DA$.
 ```agda
   Lan↓-commutes : ∀ x → Lan↓ # (↓ A x) ≡ f # x
   Lan↓-commutes x = B.≤-antisym
-    (B-cocomplete.⋃-universal _ (λ { (i , □i≤x) → f .pres-≤ (out! □i≤x) }))
+    (B-cocomplete.⋃-universal _ (λ { (i , □i≤x) → f .pres-≤ (□-out! □i≤x) }))
     (B-cocomplete.⋃-inj (x , inc A.≤-refl))
 ```
 
@@ -121,11 +121,8 @@ establishes that the cocontinuous extension does live up to its name:
     : ∀ {I : Type o} (F : I → Lower-set A)
     → Lan↓ # Lub.lub (Lower-sets-cocomplete A F) ≡ ⋃ (λ i → Lan↓ # (F i))
   Lan↓-cocontinuous F = B.≤-antisym
-    (B-cocomplete.⋃-universal _ λ where
-      (i , i∈⋃F) →
-        □-rec! (λ { (j , i∈Fj) →
-          B.≤-trans (B-cocomplete.⋃-inj (i , i∈Fj)) (B-cocomplete.⋃-inj j)
-        }) i∈⋃F)
+    (B-cocomplete.⋃-universal _ (elim! λ x i fi≤x →
+      B.≤-trans (B-cocomplete.⋃-inj (x , fi≤x)) (B-cocomplete.⋃-inj i)))
     (B-cocomplete.⋃-universal _ λ i →
      B-cocomplete.⋃-universal _ λ where
        (j , j∈Fi) → B-cocomplete.⋃-inj (j , inc (i , j∈Fi)))

--- a/src/Order/Instances/Pointwise/Diagrams.lagda.md
+++ b/src/Order/Instances/Pointwise/Diagrams.lagda.md
@@ -142,8 +142,7 @@ Every subset is a least upper bound of singleton sets.
 subset-singleton-lub
   : ∀ {ℓ} {A : Type ℓ} (P : A → Ω)
   → is-lub (Subsets A) {I = ∫ₚ P} (singleton ⊙ fst) P
-subset-singleton-lub P .is-lub.fam≤lub (x , x∈P) y □x=y =
-  □-rec! (λ x=y → subst (_∈ P) x=y x∈P) □x=y
+subset-singleton-lub P .is-lub.fam≤lub (x , x∈P) y = rec! λ x=y → subst (_∈ P) x=y x∈P
 subset-singleton-lub P .is-lub.least ub sing≤ub x x∈P =
   sing≤ub (x , x∈P) x (inc refl)
 ```

--- a/src/Order/Instances/Props.lagda.md
+++ b/src/Order/Instances/Props.lagda.md
@@ -62,21 +62,21 @@ Props-has-bot .Bottom.has-bottom _ ()
 Props-has-joins : ∀ P Q → is-join Props P Q (P ∨Ω Q)
 Props-has-joins P Q .is-join.l≤join = pure ⊙ inl
 Props-has-joins P Q .is-join.r≤join = pure ⊙ inr
-Props-has-joins P Q .is-join.least R l r = ∥-∥-rec! [ l , r ]
+Props-has-joins P Q .is-join.least R l r = rec! [ l , r ]
 
 Props-has-meets : ∀ P Q → is-meet Props P Q (P ∧Ω Q)
 Props-has-meets P Q .is-meet.meet≤l = fst
 Props-has-meets P Q .is-meet.meet≤r = snd
-Props-has-meets P Q .is-meet.greatest R l r x = (l x) , (r x)
+Props-has-meets P Q .is-meet.greatest R l r x = l x , r x
 
 module _ {ℓ} {I : Type ℓ} (Ps : I → Ω) where
   Props-has-glbs : is-glb Props Ps (∀Ω I Ps)
-  Props-has-glbs .is-glb.glb≤fam i f = out! f i
+  Props-has-glbs .is-glb.glb≤fam i = rec! (_$ i)
   Props-has-glbs .is-glb.greatest R k x = inc (λ i → k i x)
 
   Props-has-lubs : is-lub Props Ps (∃Ω I Ps)
   Props-has-lubs .is-lub.fam≤lub i pi = inc (i , pi)
-  Props-has-lubs .is-lub.least R k = □-rec! λ { (i , pi) → k i pi }
+  Props-has-lubs .is-lub.least R k = rec! k
 ```
 
 <!--

--- a/src/Order/Semilattice/Free.lagda.md
+++ b/src/Order/Semilattice/Free.lagda.md
@@ -127,7 +127,7 @@ $[n]$.
         cover-reflects-lub surj (Finite-lubs (B .snd) (fam ⊙ g))
 
       ε' : Lub (B .fst) fam
-      ε' = □-rec! ε P-fin
+      ε' = rec! ε P-fin
 
       module ε' = Lub ε'
 ```
@@ -182,8 +182,8 @@ have to show this!
     fold-K-singleton
       : (f : ⌞ A ⌟ → ⌞ B ⌟) (x : ⌞ A ⌟) → fold-K f (singletonᵏ x) ≡ f x
     fold-K-singleton f x = B.≤-antisym
-      (ε'.least (f x) λ (y , □x=y) → □-rec!
-        (λ x=y → subst (λ ϕ → f ϕ B.≤ f x) x=y B.≤-refl) □x=y)
+      (ε'.least (f x) λ (y , □x=y) → case □x=y of λ
+        x=y → subst (λ ϕ → f ϕ B.≤ f x) x=y B.≤-refl)
       (ε'.fam≤lub (x , inc refl))
       where open fold-K f (singleton x) (singleton-is-K-finite (A .is-tr) x)
 ```

--- a/src/Order/Semilattice/Join/NAry.lagda.md
+++ b/src/Order/Semilattice/Join/NAry.lagda.md
@@ -76,10 +76,8 @@ least upper bound.
       → is-finitely-indexed I
       → (f : I → Ob)
       → Lub P f
-    Finitely-indexed-lubs {I = I} fin-indexed f =
-      □-rec! (λ cov →
-          cover-reflects-lub (cov .is-cover) (Finite-lubs (f ⊙ cov .cover)))
-        fin-indexed
+    Finitely-indexed-lubs {I = I} fin-indexed f = case fin-indexed of λ cov →
+      cover-reflects-lub (cov .is-cover) (Finite-lubs (f ⊙ cov .cover))
       where open Finite-cover
 ```
 
@@ -126,13 +124,10 @@ module
     → (x : ⌞ P ⌟)
     → is-lub P k x
     → is-lub Q (λ x → f # (k x)) (f # x)
-  pres-finite-lub I-finite k x P-lub =
-    ∥-∥-rec!
-      (λ enum →
-        cast-is-lub (enum e⁻¹) (λ _ → refl) $
-        pres-fin-lub (k ⊙ Equiv.from enum) x $
-        cast-is-lub enum (λ x → sym (ap k (Equiv.η enum x))) P-lub)
-      (I-finite .enumeration)
+  pres-finite-lub I-finite k x P-lub = case I-finite .enumeration of λ enum →
+    cast-is-lub (enum e⁻¹) (λ _ → refl) $
+    pres-fin-lub (k ⊙ Equiv.from enum) x $
+    cast-is-lub enum (λ x → sym (ap k (Equiv.η enum x))) P-lub
 ```
 
 As a corollary, join semilattice homomorphisms must also preserve joins of
@@ -146,10 +141,8 @@ finitely-indexed sets.
     → (x : ⌞ P ⌟)
     → is-lub P k x
     → is-lub Q (λ x → f # (k x)) (f # x)
-  pres-finitely-indexed-lub I-fin-indexed k x P-lub =
-    □-rec! (λ cov →
-      cover-reflects-is-lub (Finite-cover.is-cover cov) $
-      pres-fin-lub (k ⊙ Finite-cover.cover cov) x $
-      cover-preserves-is-lub (Finite-cover.is-cover cov) P-lub)
-    I-fin-indexed
+  pres-finitely-indexed-lub I-fin-indexed k x P-lub = case I-fin-indexed of λ cov →
+    cover-reflects-is-lub (Finite-cover.is-cover cov) $
+    pres-fin-lub (k ⊙ Finite-cover.cover cov) x $
+    cover-preserves-is-lub (Finite-cover.is-cover cov) P-lub
 ```

--- a/src/Order/Semilattice/Meet/NAry.lagda.md
+++ b/src/Order/Semilattice/Meet/NAry.lagda.md
@@ -73,10 +73,8 @@ meet.
       → is-finitely-indexed I
       → (f : I → Ob)
       → Glb P f
-    Finitely-indexed-glbs {I = I} fin-indexed f =
-      □-rec! (λ cov →
-          cover-reflects-glb (cov .is-cover) (Finite-glbs (f ⊙ cov .cover)))
-        fin-indexed
+    Finitely-indexed-glbs {I = I} fin-indexed f = case fin-indexed of λ cov →
+      cover-reflects-glb (cov .is-cover) (Finite-glbs (f ⊙ cov .cover))
       where open Finite-cover
 ```
 

--- a/src/Order/Total.lagda.md
+++ b/src/Order/Total.lagda.md
@@ -179,6 +179,11 @@ which we refer to as **weak totality**.
 
 <!--
 ```agda
+  from-not-≤ : ∀ {x y} → ¬ (x ≤ y) → y ≤ x
+  from-not-≤ {x} {y} ¬x≤y with compare x y
+  ... | inl x≤y = absurd (¬x≤y x≤y)
+  ... | inr y≤x = y≤x
+
 module _ {o ℓ} {P : Poset o ℓ} ⦃ _ : Discrete ⌞ P ⌟ ⦄ ⦃ _ : is-decidable-poset P ⦄ where
   open Poset P
 ```


### PR DESCRIPTION
Unifies the various `X-rec!` and `X-elim!` functions for types with a single constructor, using essentially the same method as `Extensional`  to handle nesting.