### PR TITLE
def: macros for creating copattern definitions

### DIFF
--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -201,6 +201,10 @@ under-abs (lam v (abs nm _)) m = extend-context nm (arg (arginfo v (modality rel
 under-abs (pi a (abs nm _))  m = extend-context nm a m
 under-abs _ m = m
 
+extend-context* : ∀ {a} {A : Type a} → Telescope → TC A → TC A
+extend-context* [] a = a
+extend-context* ((nm , tm) ∷ xs) a = extend-context nm tm (extend-context* xs a)
+
 new-meta : Term → TC Term
 new-meta ty = do
   mv ← check-type unknown ty

--- a/src/1Lab/Reflection/Copattern.agda
+++ b/src/1Lab/Reflection/Copattern.agda
@@ -3,12 +3,6 @@ open import 1Lab.Reflection
 open import 1Lab.Path
 open import 1Lab.Type
 
-open import Meta.Foldable
-open import Meta.Append
-
-import Prim.Data.Sigma as S
-import Prim.Data.Nat as N
-
 module 1Lab.Reflection.Copattern where
 
 -- Create a copattern clause for a field.

--- a/src/1Lab/Reflection/Copattern.agda
+++ b/src/1Lab/Reflection/Copattern.agda
@@ -142,19 +142,6 @@ The `define-eta-expansion` macro will automatically construct a function
 `R p → R q` that eta-expands the first record out into a copattern definition.
 -}
 
-make-eta-expansion : Name → Maybe Name → TC Term → TC ⊤
-make-eta-expansion nm lemma? make-tp = do
-  tp ← make-tp
-  -- Get the type of the predeclared binding.
-  -- Next, grab the telescope, and use it to construct a function
-  -- that simply returns the last argument with the provided
-  -- lemma applied.
-  let tele , _ = pi-view tp
-  let tm = case lemma? of λ where
-    (just lemma) → tel→lam tele (def lemma (argN (var 0 []) ∷ []))
-    nothing → tel→lam tele (var 0 [])
-  make-copattern false nm tm tp
-
 define-eta-expansion : Name → TC ⊤
 define-eta-expansion nm = do
   tp ← reduce =<< infer-type (def nm [])

--- a/src/1Lab/Reflection/Copattern.agda
+++ b/src/1Lab/Reflection/Copattern.agda
@@ -1,0 +1,105 @@
+open import 1Lab.Reflection.Signature
+open import 1Lab.Reflection
+open import 1Lab.Path
+open import 1Lab.Type
+
+open import Meta.Foldable
+open import Meta.Append
+
+import Prim.Data.Sigma as S
+import Prim.Data.Nat as N
+
+module 1Lab.Reflection.Copattern where
+
+-- Create a copattern clause for a field.
+make-copattern-clause : List (Arg Term) → Term → Arg Name → TC Clause
+make-copattern-clause params tm (arg field-info field-name) = do
+  -- Infer the type of the field with all known arguments instantiated.
+  field-tp ← infer-type (def field-name (map hide params ++ argN tm ∷ []))
+  -- Agda will insert implicits when defining copatterns even
+  -- with 'withExpandLast true', so we need to do implicit instantiation
+  -- by hand.
+  -- First, we strip off all leading implicits from the field type.
+  let (implicit-tele , tp) = pi-impl-view field-tp
+
+  -- Construct the pattern portion of the clause, making sure to bind
+  -- all implicit variables.
+  -- Note that copattern projections are always visible.
+  let pat = arg (set-visibility visible field-info) (proj field-name) ∷ tel→pats 0 implicit-tele
+
+  -- Construct the body of the clause, making sure to instantiate
+  -- all implicit arguments.
+  let body = def field-name (argN tm ∷ tel→args 0 implicit-tele)
+
+  pure $ clause implicit-tele pat body
+
+
+-- Make a top-level copattern binding for a record.
+make-copattern : ∀ {ℓ} {A : Type ℓ} → Bool → Name → A → TC ⊤
+make-copattern declare? def-name x = do
+  -- Infer the type of the provided term, and ensure that it is a record type.
+  tm ← quoteTC x
+  def rec-name params ← infer-type tm
+    where tp → typeError ("Expected an element of a record type, yet " ∷ termErr tm ∷ " has type " ∷ termErr tp ∷ [])
+
+  -- Construct copattern clauses for each field.
+  ctor , fields ← get-record-type rec-name
+  clauses ← traverse (make-copattern-clause params tm) fields
+
+  -- Define a copattern binding, and predeclare its type if required.
+  case declare? of λ where
+    true → declare (argN def-name) (def rec-name params)
+    false → pure tt
+  define-function def-name clauses
+
+{-
+Usage:
+Write the following in a module:
+>  unquoteDecl copat = declare-copattern copat thing-to-be-expanded
+
+If you wish to give the binding a type annotation, you can also use
+
+>  copat : Your-type
+>  unquoteDecl copat = declare-copattern copat thing-to-be-expanded
+
+All features of non-recursive records are supported, including instance
+fields and fields with implicit arguments.
+-}
+
+declare-copattern : ∀ {ℓ} {A : Type ℓ} → Name → A → TC ⊤
+declare-copattern = make-copattern true
+
+define-copattern : ∀ {ℓ} {A : Type ℓ} → Name → A → TC ⊤
+define-copattern = make-copattern false
+
+-- Tests
+private module Test where
+  -- Record type that uses all interesting features.
+  record Record {ℓ} (A : Type ℓ) : Type ℓ where
+    no-eta-equality
+    constructor mk
+    field
+      ⦃ c ⦄ : A
+      { f } : A → A
+      const : ∀ {x} → f x ≡ c
+
+  -- Record created via a constructor.
+  via-ctor : Record Nat
+  via-ctor = mk ⦃ c = 0 ⦄ {f = λ _ → 0} refl
+
+  -- Both macros work.
+  unquoteDecl copat-decl-via-ctor = declare-copattern copat-decl-via-ctor via-ctor
+
+  copat-def-via-ctor : Record Nat
+  unquoteDef copat-def-via-ctor = define-copattern copat-def-via-ctor via-ctor
+
+  -- Record created by a function.
+  module _ (r : Record Nat) where
+    open Record r
+    via-function : Record Nat
+    via-function .c = suc c
+    via-function .f = suc ∘ f
+    via-function .const = ap suc const
+
+  -- Also works when applied to the result of a function.
+  unquoteDecl copat-decl-via-function = declare-copattern copat-decl-via-function (via-function via-ctor)

--- a/src/1Lab/Reflection/Copattern.agda
+++ b/src/1Lab/Reflection/Copattern.agda
@@ -9,61 +9,78 @@ module 1Lab.Reflection.Copattern where
 --------------------------------------------------------------------------------
 -- Macros for manipulating copattern definitions.
 
--- Create a copattern clause for a field.
-make-copattern-clause : Telescope → Term → Arg Name → TC Clause
-make-copattern-clause arg-tele tm (arg field-info field-name) = do
-  -- Infer the type of the field with all known arguments instantiated.
-  -- This needs to be performed in an extended context so that we can
-  -- fully saturate the function that returns our record.
-  field-tp ← in-context (reverse arg-tele) $
-    infer-type (def field-name (argN (apply-tm* tm (tel→args 0 arg-tele)) ∷ []))
-
-  -- Agda will insert implicits when defining copatterns even
-  -- with 'withExpandLast true', so we need to do implicit instantiation
-  -- by hand.
-
-  -- First, we strip off all leading implicits from the field type.
-  let (implicit-tele , tp) = pi-impl-view field-tp
-  let nimplicits = length implicit-tele
-
-  -- Construct the pattern portion of the clause, making sure to bind
-  -- all implicit variables.
-  -- Note that copattern projections are always visible.
-  let pat =
-        tel→pats nimplicits arg-tele ++
-        arg (set-visibility visible field-info) (proj field-name) ∷
-        tel→pats 0 implicit-tele
-
-  -- Construct the body of the clause, making sure to apply all arguments
-  -- bound outside the copattern match, and instantiate all implicit arguments.
-  -- We also need to apply all of the arguments to 'tm'.
-  let inst-tm = apply-tm* tm (tel→args nimplicits arg-tele)
-  let body = def field-name (argN inst-tm ∷ tel→args 0 implicit-tele)
-
-  -- Construct the final clause.
-  pure $ clause (arg-tele ++ implicit-tele) pat body
-
-
--- Make a top-level copattern binding for a record.
-make-copattern : Bool → Name → TC Term → (Term → TC Term) → TC ⊤
-make-copattern declare? def-name make-term make-type = do
-  -- Infer the type of the provided term, and ensure that its codomain a record type.
-  tm ← make-term
-  tp ← make-type tm
+-- Make a top-level copattern binding for an existing record.
+make-copattern : Bool → Name → Term → Term → TC ⊤
+make-copattern declare? def-name tm tp = do
+  -- Ensure that codomain is a record type.
   let tele , cod-tp = pi-view tp
   def rec-name params ← pure cod-tp
     where _ → typeError [ "make-copattern: codomain of " , termErr tp , " is not a record type." ]
 
+  let inst-tm = apply-tm* tm (tel→args 0 tele)
+
   -- Construct copattern clauses for each field.
   ctor , fields ← get-record-type rec-name
-  clauses ← traverse (make-copattern-clause tele tm) fields
+  clauses ←
+    in-context (reverse tele) $
+    for fields λ  (arg field-info field-name) → do
+      -- Infer the type of the field with all known arguments instantiated.
+      field-tp ← infer-type (def field-name (argN inst-tm ∷ []))
+
+      -- Agda will insert implicits when defining copatterns even
+      -- with 'withExpandLast true', so we need to do implicit instantiation
+      -- by hand. First, we strip off all leading implicits from the field type.
+      let (implicit-tele , tp) = pi-impl-view field-tp
+      let nimplicits = length implicit-tele
+      let clause-tele = tele ++ implicit-tele
+
+      -- Construct the pattern portion of the clause, making sure to bind
+      -- all implicit variables. Note that copattern projections are always visible.
+      let pat =
+            tel→pats nimplicits tele ++
+            arg (set-visibility visible field-info) (proj field-name) ∷
+            tel→pats 0 implicit-tele
+
+      -- Construct the body of the clause, making sure to apply all arguments
+      -- bound outside the copattern match, and instantiate all implicit arguments.
+      -- We also need to apply all of the implicit arguments to 'tm'.
+      body ←
+        in-context (reverse clause-tele) $
+        reduce (def field-name (argN (raise nimplicits inst-tm) ∷ tel→args 0 implicit-tele))
+
+      -- Construct the final clause.
+      pure $ clause clause-tele pat body
 
   -- Define a copattern binding, and predeclare its type if required.
   case declare? of λ where
     true → declare (argN def-name) tp
     false → pure tt
 
+  -- Construct the final copattern.
   define-function def-name clauses
+
+-- Repack a record type.
+-- Will also accept functions into record types like `A → Record`,
+-- and will perform a pointwise repacking.
+repack-record : Term → Term → TC Term
+repack-record tm tp = do
+  -- Ensure that codomain is a record type.
+  tele , cod-tp ← pi-view <$> reduce tp
+  def rec-name params ← pure cod-tp
+    where _ → typeError [ "repack-record: codomain of " , termErr tp , " is not a record type." ]
+
+  -- Instantiate the term with all telescope arguments to saturate it.
+  let inst-tm = apply-tm* tm (tel→args 0 tele)
+
+  -- Construct fields for each projection.
+  ctor , fields ← get-record-type rec-name
+  args ←
+    in-context (reverse tele) $
+    for fields λ (arg field-info field-name) →
+      argN <$> reduce (def field-name (argN inst-tm ∷ []))
+
+  -- Builld a pointwise repacking.
+  pure (tel→lam tele (con ctor args))
 
 --------------------------------------------------------------------------------
 -- Usage
@@ -87,10 +104,16 @@ bind all implicits using a lambda before quotation!
 -}
 
 declare-copattern : ∀ {ℓ} {A : Type ℓ} → Name → A → TC ⊤
-declare-copattern {A = A} nm x = make-copattern true nm (quoteTC x) (λ _ → quoteTC A)
+declare-copattern {A = A} nm x = do
+  `x ← quoteTC x
+  `A ← quoteTC A
+  make-copattern true nm `x `A
 
 define-copattern : ∀ {ℓ} {A : Type ℓ} → Name → A → TC ⊤
-define-copattern {A = A} nm x = make-copattern false nm (quoteTC x) (λ _ → quoteTC A)
+define-copattern {A = A} nm x = do
+  `x ← quoteTC x
+  `A ← quoteTC A
+  make-copattern false nm `x `A
 
 {-
 There is a slight caveat with level-polymorphic defintions, as
@@ -99,10 +122,18 @@ we also provide a pair of macros that work over `Typeω` instead.
 -}
 
 declare-copattern-levels : ∀ {U : Typeω} → Name → U → TC ⊤
-declare-copattern-levels nm U = make-copattern true nm (quoteωTC U) infer-type
+declare-copattern-levels nm A = do
+  `A ← quoteωTC A
+  -- Cannot quote things in type Typeω, but we can infer their type.
+  `U ← infer-type `A
+  make-copattern true nm `A `U
 
 define-copattern-levels : ∀ {U : Typeω} → Name → U → TC ⊤
-define-copattern-levels nm U = make-copattern false nm (quoteωTC U) infer-type
+define-copattern-levels nm A = do
+  `A ← quoteωTC A
+  -- Cannot quote things in type Typeω, but we can infer their type.
+  `U ← infer-type `A
+  make-copattern false nm `A `U
 
 {-
 Another common pattern is that two records `r : R p` and `s : R q` may contain
@@ -111,10 +142,10 @@ The `define-eta-expansion` macro will automatically construct a function
 `R p → R q` that eta-expands the first record out into a copattern definition.
 -}
 
-make-eta-expansion : Name → Maybe Name → TC ⊤
-make-eta-expansion nm lemma? = do
+make-eta-expansion : Name → Maybe Name → TC Term → TC ⊤
+make-eta-expansion nm lemma? make-tp = do
+  tp ← make-tp
   -- Get the type of the predeclared binding.
-  tp ← reduce =<< infer-type (def nm [])
   -- Next, grab the telescope, and use it to construct a function
   -- that simply returns the last argument with the provided
   -- lemma applied.
@@ -122,13 +153,14 @@ make-eta-expansion nm lemma? = do
   let tm = case lemma? of λ where
     (just lemma) → tel→lam tele (def lemma (argN (var 0 []) ∷ []))
     nothing → tel→lam tele (var 0 [])
-  make-copattern false nm (pure tm) λ _ → pure tp
+  make-copattern false nm tm tp
 
 define-eta-expansion : Name → TC ⊤
-define-eta-expansion nm = make-eta-expansion nm nothing
-
-define-eta-expansion-with : Name → Name → TC ⊤
-define-eta-expansion-with nm lemma = make-eta-expansion nm (just lemma)
+define-eta-expansion nm = do
+  tp ← reduce =<< infer-type (def nm [])
+  let tele , _ = pi-view tp
+  let tm = tel→lam tele (var 0 [])
+  make-copattern false nm tm tp
 
 --------------------------------------------------------------------------------
 -- Tests

--- a/src/1Lab/Reflection/Signature.agda
+++ b/src/1Lab/Reflection/Signature.agda
@@ -211,6 +211,18 @@ helper-function def-nm suf ty cls = do
     _  → define-function nm cls
   pure nm
 
+-- Given a well-typed `val : ty`, return a definitionally-equal atomic
+-- term equal to `val`, potentially by lifting it into the signature.
+-- See 'helper-function' for the naming scheme.
+define-abbrev : Name → String → Term → Term → TC Term
+define-abbrev def-nm suf ty val with is-atomic-tree? val
+... | true  = pure val
+... | false = do
+  let (tel , _) = pi-impl-view ty
+  nm ← helper-function def-nm suf ty
+    [ clause tel (tel→pats 0 tel) (apply-tm* val (tel→args 0 tel)) ]
+  pure (def₀ nm)
+
 private
   make-args : Nat → List (Arg Nat) → List (Arg Term)
   make-args n xs = reverse $ map (λ (arg ai i) → arg ai (var (n - i - 1) [])) xs

--- a/src/1Lab/Reflection/Subst.agda
+++ b/src/1Lab/Reflection/Subst.agda
@@ -142,7 +142,7 @@ subst-tm ρ (agda-sort s) with s
 subst-tel ρ []                    = []
 subst-tel ρ ((x , arg ai t) ∷ xs) = (x , arg ai (subst-tm ρ t)) ∷ subst-tel (liftS 1 ρ) xs
 
-subst-clause σ (clause tel ps t)      = clause (subst-tel σ tel) ps (subst-tm (wkS (length tel) σ) t)
+subst-clause σ (clause tel ps t)      = clause (subst-tel σ tel) ps (subst-tm (liftS (length tel) σ) t)
 subst-clause σ (absurd-clause tel ps) = absurd-clause (subst-tel σ tel) ps
 
 _<#>_ : Term → Arg Term → Term

--- a/src/Cat/Abelian/Images.lagda.md
+++ b/src/Cat/Abelian/Images.lagda.md
@@ -53,8 +53,8 @@ images : ∀ {A B} (f : Hom A B) → Image C f
 images f = im where
   the-img : ↓Obj (const! (cut f)) Forget-full-subcat
   the-img .x = tt
-  the-img .y .object = cut (Ker.kernel (Coker.coeq f))
-  the-img .y .witness {c} = kernels-are-subobjects C ∅ _ (Ker.has-is-kernel _)
+  the-img .y .fst = cut (Ker.kernel (Coker.coeq f))
+  the-img .y .snd {c} = kernels-are-subobjects C ∅ _ (Ker.has-is-kernel _)
 ```
 
 Break $f$ down as an epi $p : A \epi \ker (\coker f)$ followed by a mono
@@ -128,7 +128,7 @@ a (unique) map $\coker (\ker f) \to X$ s.t. the triangle above commutes!
       where abstract
         path : other .map .map ∘ 0m ≡ other .map .map ∘ kernel f .Kernel.kernel
         path =
-          other .y .witness _ _ $ sym $
+          other .y .snd _ _ $ sym $
                 pulll (other .map .commutes)
             ·· Ker.equal f
             ·· ∅.zero-∘r _
@@ -154,14 +154,14 @@ is the image of $f$.
                           (coker-ker≃ker-coker f .is-invertible.invr))) refl
               ∙ pullr (Coker.factors _) ∙ other .map .commutes)
         (sym (decompose f .snd ∙ assoc _ _ _))
-    factor .sq = /-Hom-path $ sym $ other .y .witness _ _ $
+    factor .sq = /-Hom-path $ sym $ other .y .snd _ _ $
       pulll (factor .β .commutes)
       ∙ the-img .map .commutes
       ·· sym (other .map .commutes)
-      ·· ap (other .y .object .map ∘_) (intror refl)
+      ·· ap (other .y .fst .map ∘_) (intror refl)
 
     unique : ∀ x → factor ≡ x
-    unique x = ↓Hom-path _ _ refl $ /-Hom-path $ other .y .witness _ _ $
+    unique x = ↓Hom-path _ _ refl $ /-Hom-path $ other .y .snd _ _ $
       sym (x .β .commutes ∙ sym (factor .β .commutes))
 ```
 </details>

--- a/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
+++ b/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
@@ -43,7 +43,7 @@ is an [[equaliser]] of some pair of arrows $g, h : b \to c$.
       {c}       : Ob
       arr₁ arr₂ : Hom b c
       has-is-eq : is-equaliser C arr₁ arr₂ f
-  
+
     open is-equaliser has-is-eq public
 ```
 
@@ -53,7 +53,7 @@ are in fact monomorphisms:
 ```agda
     is-regular-mono→is-mono : is-monic f
     is-regular-mono→is-mono = is-equaliser→is-monic _ has-is-eq
-  
+
   open is-regular-mono using (is-regular-mono→is-mono) public
 ```
 
@@ -126,7 +126,7 @@ $\phi \circ i_2 = \rm{arr_2}$.
 ```agda
     phi : Hom f⊔f.coapex reg.c
     phi = f⊔f.universal reg.equal
-  
+
     open is-effective-mono
     mon : is-effective-mono C f
     mon .cokernel = f⊔f.coapex
@@ -201,12 +201,12 @@ the code below demonstrates.
     → M-image C (is-regular-mono C , is-regular-mono→is-mono) f
   is-effective-mono→image {f = f} mon = im where
     module eff = is-effective-mono mon
-  
+
     itself : ↓Obj _ _
     itself .x = tt
-    itself .y = restrict (cut f) eff.is-effective-mono→is-regular-mono
+    itself .y = cut f , eff.is-effective-mono→is-regular-mono
     itself .map = record { map = id ; commutes = idr _ }
-  
+
     im : Initial _
     im .bot = itself
     im .has⊥ other = contr hom unique where
@@ -214,7 +214,7 @@ the code below demonstrates.
       hom .α = tt
       hom .β = other .map
       hom .sq = trivial!
-  
+
       unique : ∀ x → hom ≡ x
       unique x = ↓Hom-path _ _ refl
         (ext (intror refl ∙ ap map (x .sq) ∙ elimr refl))

--- a/src/Cat/Diagram/Image.lagda.md
+++ b/src/Cat/Diagram/Image.lagda.md
@@ -124,10 +124,10 @@ is the image object, and $m$ is the inclusion map:
 
 ```agda
     Im : Ob
-    Im = im .bot .y .object .domain
+    Im = im .bot .y .fst .domain
 
     Im→codomain : Hom Im b
-    Im→codomain = im .bot .y .object .map
+    Im→codomain = im .bot .y .fst .map
 ```
 
 Furthermore, this map is both an inclusion (since $M$ is a class of
@@ -135,7 +135,7 @@ monomorphisms), and an $M$-inclusion at that:
 
 ```agda
     Im→codomain-is-M : M .fst Im→codomain
-    Im→codomain-is-M = im .bot .y .witness
+    Im→codomain-is-M = im .bot .y .snd
 
     Im→codomain-is-monic : is-monic Im→codomain
     Im→codomain-is-monic = M .snd Im→codomain-is-M
@@ -175,7 +175,7 @@ through $k$:
     universal m M i p = im .has⊥ obj .centre .β .map where
       obj : ↓Obj _ _
       obj .x = tt
-      obj .y = restrict (cut m) M
+      obj .y = cut m , M
       obj .map = record { map = i ; commutes = p }
 
     universal-factors

--- a/src/Cat/Functor/Algebra.lagda.md
+++ b/src/Cat/Functor/Algebra.lagda.md
@@ -603,7 +603,7 @@ forms a full subcategory of $\cC$.
   private module Free-algebras = Cat.Reasoning Free-algebras
   module Free-alg (α : Free-algebras.Ob) where
     -- Rexport stuff in a more user-friendly format
-    open Free-object (α .witness) public
+    open Free-object (α .snd) public
 
     ob : Ob
     ob = free .fst

--- a/src/Cat/Functor/Coherence.agda
+++ b/src/Cat/Functor/Coherence.agda
@@ -1,5 +1,5 @@
-open import 1Lab.Reflection.Signature
 open import 1Lab.Reflection.Copattern
+open import 1Lab.Reflection.Signature
 open import 1Lab.Reflection
 
 open import Cat.Prelude
@@ -62,6 +62,10 @@ cohere-dualise is-dual tm hole = do
     pure (argN t)
 
   unify hole (con c args)
+
+macro
+  cohere!  = cohere-dualise false
+  dualise! = cohere-dualise true
 
 nat-assoc-to    : f ⇒ g ⊗ h ⊗ i → f ⇒ (g ⊗ h) ⊗ i
 nat-assoc-from  : f ⊗ g ⊗ h ⇒ i → (f ⊗ g) ⊗ h ⇒ i

--- a/src/Cat/Functor/Coherence.agda
+++ b/src/Cat/Functor/Coherence.agda
@@ -41,39 +41,62 @@ instance
   Dualises-nat-trans .dualiser = quote _=>_.op
 
 private
-  get-dual : Bool → Term → TC (Term → Term)
-  get-dual false _ = pure (λ t → t)
-  get-dual true T = resetting do
+  get-dual : Term → TC Name
+  get-dual T = resetting do
     (mv , _) ← new-meta' (def (quote Dualises) [ argN T ])
     (qn ∷ []) ← get-instances mv
       where _ → typeError [ "Don't know how to dualise type " , termErr T ]
-    du ← normalise (def (quote dualiser) [ argN qn ])
-      >>= unquoteTC {A = Name}
-    pure λ t → def du [ argN t ]
+    unquoteTC =<< normalise (def (quote dualiser) [ argN qn ])
 
-cohere-dualise : Bool → ∀ {ℓ} {S : Type ℓ} → S → Term → TC ⊤
-cohere-dualise is-dual tm hole = do
+make-cohere : ∀ {ℓ} {S : Type ℓ} → S → Term → TC ⊤
+make-cohere tm hole = do
   `tm ← quoteTC tm
   `T ← infer-type hole
-  (c , fs) ← get-record `T
-  dual ← get-dual is-dual `T
-  args ← for fs λ (arg ai prj) → do
-    t ← reduce $ def prj [ argN (dual `tm) ]
-    pure (argN t)
+  `R ← repack-record `tm `T
+  unify hole `R
 
-  unify hole (con c args)
+make-dualise : ∀ {ℓ} {S : Type ℓ} → S → Term → TC ⊤
+make-dualise tm hole = do
+  `tm ← quoteTC tm
+  `T ← infer-type hole
+  dual ← get-dual `T
+  -- Repack using the duality lemma.
+  `R ← repack-record (def dual [ argN `tm ]) `T
+  unify hole `R
 
 macro
-  cohere!  = cohere-dualise false
-  dualise! = cohere-dualise true
+  cohere!  = make-cohere
+  dualise! = make-dualise
+
+cohere-into : ∀ {ℓ ℓ'} {S : Type ℓ'} → Name → (T : Type ℓ) → S → TC ⊤
+cohere-into nm T s = do
+  `s ← quoteTC s
+  `T ← quoteTC T
+  make-copattern true nm `s `T
+
+dualise-into : ∀ {ℓ ℓ'} {S : Type ℓ'} → Name → (T : Type ℓ) → ⦃ Dualises T ⦄ → S → TC ⊤
+dualise-into nm T ⦃ dual ⦄ s = do
+  `s ← quoteTC s
+  `T ← quoteTC T
+  make-copattern true nm (def (dual .dualiser) (argN `s ∷ [])) `T
+
+define-coherence : Name → TC ⊤
+define-coherence nm = define-eta-expansion nm
+
+define-dualiser : Name → TC ⊤
+define-dualiser nm  = do
+  tp ← infer-type (def nm [])
+  let (tele , cod-tp) = pi-view tp
+  -- Find the appropriate duality lemma, and construct a copattern using that lemma.
+  dual ← in-context (reverse tele) (get-dual cod-tp)
+  let tm = tel→lam tele (def dual (argN (var 0 []) ∷ []))
+  make-copattern false nm tm tp
 
 nat-assoc-to    : f ⇒ g ⊗ h ⊗ i → f ⇒ (g ⊗ h) ⊗ i
 nat-assoc-from  : f ⊗ g ⊗ h ⇒ i → (f ⊗ g) ⊗ h ⇒ i
 op-compose-into : f ⇒ Functor.op (g ⊗ h) → f ⇒ Functor.op g ⊗ Functor.op h
-nat-assoc-to-op : f ⇒ g ⊗ h ⊗ i → (Functor.op g ⊗ Functor.op h) ⊗ Functor.op i ⇒ Functor.op f
 
-unquoteDef nat-assoc-to nat-assoc-from op-compose-into nat-assoc-to-op = do
+unquoteDef nat-assoc-to nat-assoc-from op-compose-into = do
   define-eta-expansion nat-assoc-to
   define-eta-expansion nat-assoc-from
   define-eta-expansion op-compose-into
-  define-eta-expansion-with nat-assoc-to-op (quote _=>_.op)

--- a/src/Cat/Instances/Sheaves.lagda.md
+++ b/src/Cat/Instances/Sheaves.lagda.md
@@ -9,6 +9,7 @@ open import Cat.Instances.Sets.Cocomplete
 open import Cat.Instances.Functor.Limits
 open import Cat.Instances.Sheaves.Limits
 open import Cat.Functor.Adjoint.Monadic
+open import Cat.Functor.FullSubcategory
 open import Cat.Instances.Sets.Complete
 open import Cat.Diagram.Limit.Product
 open import Cat.Diagram.Colimit.Base

--- a/src/Cat/Monoidal/Diagram/Monoid/Representable.lagda.md
+++ b/src/Cat/Monoidal/Diagram/Monoid/Representable.lagda.md
@@ -257,8 +257,8 @@ homomorphism $f : M \to N$ is a natural transformation $\hom(-, M) \to
 
 ```agda
   Mon→RepPShMon : Functor Mon[C] RepPShMon
-  Mon→RepPShMon .F₀ (m , mon) .object  = Mon→PshMon mon
-  Mon→RepPShMon .F₀ (m , mon) .witness = Mon→PshMon-rep mon
+  Mon→RepPShMon .F₀ (m , mon) .fst = Mon→PshMon mon
+  Mon→RepPShMon .F₀ (m , mon) .snd = Mon→PshMon-rep mon
 
   Mon→RepPShMon .F₁ f .η x .hom = f .hom ∘_
   Mon→RepPShMon .F₁ f .η x .preserves =
@@ -493,13 +493,12 @@ monoids isomorphic to the one we started with.
 
 ```agda
   Mon→RepPShMon-is-split-eso : is-split-eso Mon→RepPShMon
-  Mon→RepPShMon-is-split-eso P .fst =
-    P .witness .rep , RepPshMon→Mon (P .object) (P .witness)
-  Mon→RepPShMon-is-split-eso P .snd = super-iso→sub-iso _ $ to-natural-iso ni where
+  Mon→RepPShMon-is-split-eso (P , pm) .fst = pm .rep , RepPshMon→Mon P pm
+  Mon→RepPShMon-is-split-eso (P , pm) .snd = super-iso→sub-iso _ $ to-natural-iso ni where
     open make-natural-iso
-    open RepPshMon→Mon (P .object) (P .witness)
+    open RepPshMon→Mon P pm
     open PMon using (identity; _⋆_)
-    module P = Functor (P .object)
+    module P = Functor P
 ```
 
 <details>
@@ -507,7 +506,7 @@ monoids isomorphic to the one we started with.
 expand this `<details>` element.</summary>
 
 ```agda
-    ni : make-natural-iso (Mon→PshMon (RepPshMon→Mon (P .object) (P .witness))) (P .object)
+    ni : make-natural-iso (Mon→PshMon (RepPshMon→Mon P pm)) P
     ni .eta x .hom = repr.from .η x
     ni .inv x .hom = repr.to .η x
 

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -283,7 +283,7 @@ strong-epi-mono→image f a→im (_ , str-epi) im→b mono fact = go where
 
   obj : ↓Obj (Const (cut f)) (Forget-full-subcat {P = is-monic ⊙ map})
   obj .x = tt
-  obj .y = restrict (cut im→b) mono
+  obj .y = cut im→b , mono
   obj .map = record { map = a→im ; commutes = fact }
 ```
 
@@ -300,7 +300,7 @@ in the relevant comma categories.
 
     the-lifting =
       str-epi
-        (record { monic = o.y .witness })
+        (record { monic = o.y .snd })
         {u = o.map .map}
         {v = im→b} (sym (o.map .commutes ∙ sym fact))
 

--- a/src/Cat/Site/Base.lagda.md
+++ b/src/Cat/Site/Base.lagda.md
@@ -1,5 +1,8 @@
 <!--
 ```agda
+open import 1Lab.Reflection.Copattern
+
+open import Cat.Functor.FullSubcategory
 open import Cat.Instances.Functor
 open import Cat.Diagram.Sieve
 open import Cat.Prelude hiding (glue)
@@ -561,14 +564,8 @@ $\psh(\cC)$'s good categorical properties --- we refer to it as the
   Sheaf = Σ[ p ∈ Functor (C ^op) (Sets ℓs) ] is-sheaf J p
 
   Sheaves : Precategory (o ⊔ ℓ ⊔ ℓc ⊔ lsuc ℓs) (o ⊔ ℓ ⊔ ℓs)
-  Sheaves .Ob = Sheaf
-  Sheaves .Hom (S , _) (T , _) = S => T
-  Sheaves .Hom-set _ _ = hlevel 2
-  Sheaves .id  = idnt
-  Sheaves ._∘_ = _∘nt_
-  Sheaves .idr   f     = trivial!
-  Sheaves .idl   f     = trivial!
-  Sheaves .assoc f g h = trivial!
+  unquoteDef Sheaves = define-copattern Sheaves $
+    Restrict {C = PSh ℓs C} (is-sheaf J)
 
   forget-sheaf : Functor Sheaves (PSh ℓs C)
   forget-sheaf .F₀ (S , _) = S

--- a/src/Data/Reflection/Argument.agda
+++ b/src/Data/Reflection/Argument.agda
@@ -132,6 +132,9 @@ record Has-visibility {ℓ} (A : Type ℓ) : Type ℓ where
 open Has-visibility ⦃ ... ⦄ public
 
 instance
+  Has-visibility-ArgInfo : Has-visibility ArgInfo
+  Has-visibility-ArgInfo .set-visibility v (arginfo _ m) = arginfo v m
+
   Has-visibility-Arg : ∀ {ℓ} {A : Type ℓ} → Has-visibility (Arg A)
   Has-visibility-Arg .set-visibility v (arg (arginfo _ m) x) = arg (arginfo v m) x
 

--- a/src/Data/Reflection/Term.agda
+++ b/src/Data/Reflection/Term.agda
@@ -34,7 +34,7 @@ data Term where
   pi        : (a : Arg Term) (b : Abs Term) → Term
   agda-sort : (s : Sort) → Term
   lit       : (l : Literal) → Term
-  meta      : (x : Meta) → List (Arg Term) → Term
+  meta      : (m : Meta) (args : List (Arg Term)) → Term
   unknown   : Term
 
 data Sort where
@@ -463,3 +463,21 @@ instance
 pattern con₀ v = con v []
 pattern def₀ v = def v []
 pattern var₀ v = var v []
+
+-- Test whether a term is "hereditarily atomic", i.e. it is a head
+-- application and all of its arguments are hereditarily atomic.
+is-atomic-tree? : Term → Bool
+is-atomic-args? : List (Arg Term) → Bool
+
+is-atomic-tree? (var x args)  = is-atomic-args? args
+is-atomic-tree? (con c args)  = is-atomic-args? args
+is-atomic-tree? (def f args)  = is-atomic-args? args
+is-atomic-tree? (meta m args) = is-atomic-args? args
+is-atomic-tree? (lit l)       = true
+{-# CATCHALL #-}
+is-atomic-tree? _             = false
+
+is-atomic-args? [] = true
+is-atomic-args? (arg _ x ∷ xs) with is-atomic-tree? x
+... | true  = is-atomic-args? xs
+... | false = false


### PR DESCRIPTION
# Description

There are a couple of places in the 1Lab where we manually eta-expand out copattern definitions by hand to get better goal display. This mostly comes up when dealing with things like subcategories/forgetful functors; Agda will very happily unfold your nicely named category into `Restrict Blah`, which is not particularly helpful!

Manually performing these copattern expansions is a bit of a pain, so this PR adds a small macro that performs this mechanical busywork for us. This removes the need for the `declare-concrete-category` macro in #375.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
