### PR TITLE
chore: use "Id", not "id", for identity functor

### DIFF
--- a/src/Cat/Bi/Diagram/Monad.lagda.md
+++ b/src/Cat/Bi/Diagram/Monad.lagda.md
@@ -24,7 +24,7 @@ module _ {o ℓ ℓ'} (B : Prebicategory o ℓ ℓ') where
 # Monads in a bicategory {defines="monad-in"}
 
 Recall that a [monad] _on_ a category $\cC$ consists of a functor $M :
-\cC \to \cC$ and natural transformations $\mu : MM \To M$, $\eta : \id
+\cC \to \cC$ and natural transformations $\mu : MM \To M$, $\eta : \Id
 \To M$. While the words "functor" and "natural transformation" are
 specific to the setup where $\cC$ is a category, if we replace those
 with "1-cell" and "2-cell", then the definition works in any


### PR DESCRIPTION
# Description

Following [this comment,](https://github.com/plt-amy/1lab/pull/381#issuecomment-2150094026) I suppose this notation is better. 

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.