### PR TITLE
def: fibre posets

### DIFF
--- a/src/Order/Displayed.lagda.md
+++ b/src/Order/Displayed.lagda.md
@@ -80,6 +80,29 @@ make a new poset.
   po .Poset.≤-trans (p , p') (q , q') = P.≤-trans p q , D.≤-trans' p' q'
   po .Poset.≤-antisym (p , p') (q , q') =
     Σ-pathp (P.≤-antisym p q) (D.≤-antisym-over p' q')
+```
 
-open Displayed
+## Fibre posets {defines="fibre-posets"}
+
+Similarly, we can define **fibre posets** as a special case of [[fibre
+categories]]. Because posets are thin categories, we do not worry about
+most coherence conditions.
+
+```agda
+Fibre
+  : ∀ {ℓ ℓ' ℓₒ ℓᵣ} {P : Poset ℓₒ ℓᵣ} (D : Displayed ℓ ℓ' P) (X : ⌞ P ⌟)
+  → Poset _ _
+Fibre {P = P} D X = po where
+  module D = Displayed D
+  module P = Pr P
+
+  po : Poset _ _
+  po .Poset.Ob = D.Ob[ X ]
+  po .Poset._≤_ = D.Rel[ P.≤-refl ]
+  po .Poset.≤-thin = D.≤-thin' P.≤-refl
+  po .Poset.≤-refl = D.≤-refl'
+  po .Poset.≤-trans p q =
+    subst (λ r → D.Rel[ r ] _ _) (P.≤-thin _ _) $
+    D.≤-trans' p q
+  po .Poset.≤-antisym = D.≤-antisym'
 ```


### PR DESCRIPTION
# Description

Define fibre posets, similar to fibre categories.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.