### PR TITLE
def: lexical sum of posets

### DIFF
--- a/src/Order/Displayed.lagda.md
+++ b/src/Order/Displayed.lagda.md
@@ -118,5 +118,5 @@ an order embedding.
   fibre-injᵖ-is-order-embedding x =
     prop-ext (D.≤-thin' P.≤-refl) (∫ .Poset.≤-thin)
       (fibre-injᵖ x .pres-≤)
-      λ { (p , p') → subst (λ p → D.Rel[ p ] _ _) (P.≤-thin p _) p' }
+      (λ (p , p') → subst (λ p → D.Rel[ p ] _ _) (P.≤-thin p _) p')
 ```

--- a/src/Order/Instances/Disjoint.lagda.md
+++ b/src/Order/Instances/Disjoint.lagda.md
@@ -71,9 +71,7 @@ module _ {ℓ ℓₐ ℓᵣ} {I : Set ℓ} {F : ⌞ I ⌟ → Poset ℓₐ ℓ�
 
 ```agda
   injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Disjoint I F)
-  injᵖ i .hom    x   = i , x
-  injᵖ i .pres-≤ x≤y = reflᵢ , λ p →
-    subst (_≤ _) (substᵢ-filler-set ⌞F⌟ (hlevel 2) p _) x≤y
+  injᵖ = lexical-sum-injᵖ
 ```
 
 The name `Disjoint`{.Agda} is justified by the observation that each of
@@ -83,7 +81,8 @@ identifies each factor $F_i$ with its image in $\Sigma F$.
 ```agda
   injᵖ-is-order-embedding
     : ∀ i → is-order-embedding (F i) (Disjoint I F) (apply (injᵖ i))
-  injᵖ-is-order-embedding i = prop-ext! (injᵖ i .pres-≤) λ { (_ , q) → q reflᵢ }
+  injᵖ-is-order-embedding =
+    lexical-sum-injᵖ-is-order-embedding {I = Discᵢ I} {F = F}
 ```
 
 To complete the construction of the coproduct, we have the following

--- a/src/Order/Instances/Disjoint.lagda.md
+++ b/src/Order/Instances/Disjoint.lagda.md
@@ -8,6 +8,7 @@ open import Data.Id.Base
 open import Data.Bool
 open import Data.Sum
 
+open import Order.Instances.LexicalSum
 open import Order.Instances.Coproduct renaming (matchᵖ to match⊎ᵖ)
 open import Order.Instances.Discrete
 open import Order.Displayed
@@ -34,8 +35,6 @@ then we can equip the $\Sigma$-type $\Sigma_{(i : I)} F_i$ with a
 "fibrewise" partial order: this is the [[coproduct]] of these orders in
 the category of posets.
 
-[partially ordered sets]: Order.Base.html
-
 <!--
 ```agda
 private module D = Displayed
@@ -49,60 +48,18 @@ module _ {ℓ ℓₐ ℓᵣ} (I : Set ℓ) (F : ⌞ I ⌟ → Poset ℓₐ ℓ�
 ```
 -->
 
-Since the indices $i, j : I$ are drawn from completely arbitrary sets,
-we can't exactly define the order by pattern matching, as in the
-[[binary coproduct of posets]]. Instead, we must define what it means to
-compare two totally arbitrary pairs $(i, x) \le (j, y)$^[where $x : F_x$
-and $y : F_j$].
-
-Considering that we only know how to compare elements in the same fibre,
-the natural solution is to require, as part of proving $(i, x) \le (j,
-y)$, some evidence $p : i = j$. We can then transport $x$ across $p$ to
-obtain a value in $F_j$, which can be compared against $y : F_j$.
-
-The concerns of defining the ordering in each fibre, and then defining
-the ordering on the entire total space, are mostly orthogonal. Indeed,
-these can be handled in a modular way: the construction we're interested
-in naturally arises as the [[total (thin) category|total category]] of a
-particular [[displayed order]] --- over the [[discrete partial order]]
-on the index set $I$.
-
-```agda
-  _≤[_]'_ : {i j : ⌞ I ⌟} → ⌞F⌟ i → i ≡ᵢ j → ⌞F⌟ j → Type ℓᵣ
-  x ≤[ p ]' y = substᵢ ⌞F⌟ p x ≤ y
-
-  substᵖ : ∀ {i j} → i ≡ᵢ j → Monotone (F i) (F j)
-  substᵖ reflᵢ .hom    x   = x
-  substᵖ reflᵢ .pres-≤ x≤y = x≤y
-
-  Disjoint-over : Displayed _ _ (Discᵢ I)
-  Disjoint-over .D.Ob[_]        = ⌞F⌟
-  Disjoint-over .D.Rel[_] p x y = x ≤[ p ]' y
-  Disjoint-over .D.≤-thin' _  = hlevel 1
-  Disjoint-over .D.≤-refl'    = F.≤-refl
-  Disjoint-over .D.≤-antisym' = F.≤-antisym
-  Disjoint-over .D.≤-trans' {f = reflᵢ} {g = reflᵢ} =
-    F.≤-trans
-```
-
-To differentiate from the binary coproducts, we refer to the indexed
-coproduct of a family as **disjoint** coproducts, or `Disjoint`{.Agda}
-for short.
+The indexed coproduct is a special case of the [[lexicographic
+sum|lexicographic sum of posets]] where the base poset is [[discrete|
+discrete-partial-order]]. It means that there is no non-trivial
+relationship across fibres.
 
 ```agda
   Disjoint : Poset _ _
-  Disjoint = ∫ Disjoint-over
+  Disjoint = Lexical-sum (Discᵢ I) F
 ```
 
 <!--
 ```agda
-_≤[_]_
-  : ∀ {ℓ ℓₐ ℓᵣ} {I : Set ℓ} {F : ⌞ I ⌟ → Poset ℓₐ ℓᵣ} {i j : ⌞ I ⌟}
-  → ⌞ F i ⌟ → i ≡ᵢ j → ⌞ F j ⌟
-  → Type ℓᵣ
-_≤[_]_ {I = I} {F = F} x p y = _≤[_]'_ I F x p y
-{-# DISPLAY _≤[_]'_ I F x p y = x ≤[ p ] y #-}
-
 module _ {ℓ ℓₐ ℓᵣ} {I : Set ℓ} {F : ⌞ I ⌟ → Poset ℓₐ ℓᵣ} where
   private
     open module F {i : ⌞ I ⌟} = Pr (F i)
@@ -115,7 +72,8 @@ module _ {ℓ ℓₐ ℓᵣ} {I : Set ℓ} {F : ⌞ I ⌟ → Poset ℓₐ ℓ�
 ```agda
   injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Disjoint I F)
   injᵖ i .hom    x   = i , x
-  injᵖ i .pres-≤ x≤y = reflᵢ , x≤y
+  injᵖ i .pres-≤ x≤y = reflᵢ , λ p →
+    subst (_≤ _) (substᵢ-filler-set ⌞F⌟ (hlevel 2) p _) x≤y
 ```
 
 The name `Disjoint`{.Agda} is justified by the observation that each of
@@ -125,10 +83,7 @@ identifies each factor $F_i$ with its image in $\Sigma F$.
 ```agda
   injᵖ-is-order-embedding
     : ∀ i → is-order-embedding (F i) (Disjoint I F) (apply (injᵖ i))
-  injᵖ-is-order-embedding i .fst = injᵖ i .pres-≤
-  injᵖ-is-order-embedding i .snd = biimp-is-equiv!
-    (injᵖ i .pres-≤)
-    λ { (p , q) → ≤-trans (≤-refl' (substᵢ-filler-set _ (hlevel 2) p _)) q }
+  injᵖ-is-order-embedding i = prop-ext! (injᵖ i .pres-≤) λ { (_ , q) → q reflᵢ }
 ```
 
 To complete the construction of the coproduct, we have the following
@@ -141,7 +96,7 @@ function for mapping _out_, by cases:
     → Monotone (Disjoint I F) R
   matchᵖ cases .hom    (i , x)       = cases i # x
   matchᵖ cases .pres-≤ (reflᵢ , x≤y) =
-    cases _ .pres-≤ x≤y
+    cases _ .pres-≤ (x≤y reflᵢ)
 ```
 
 Straightforward calculations finish the proof that $\Pos$ has all

--- a/src/Order/Instances/Disjoint.lagda.md
+++ b/src/Order/Instances/Disjoint.lagda.md
@@ -4,7 +4,6 @@ open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Morphism
 open import Cat.Prelude
 
-open import Data.Id.Base
 open import Data.Bool
 open import Data.Sum
 
@@ -71,7 +70,7 @@ module _ {ℓ ℓₐ ℓᵣ} {I : Set ℓ} {F : ⌞ I ⌟ → Poset ℓₐ ℓ�
 
 ```agda
   injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Disjoint I F)
-  injᵖ = lexical-sum-injᵖ
+  injᵖ = lexical-sum-injᵖ {I = Discᵢ I} {F = F}
 ```
 
 The name `Disjoint`{.Agda} is justified by the observation that each of

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -55,7 +55,7 @@ settings.
 :::
 
 Given the dependency of $F$ on $I$, the comparison between $x : F_i$
-and $y : F_j$ only make sense when they lie in the same fibre, that is,
+and $y : F_j$ only makes sense when they lie in the same fibre, that is,
 when there is evidence $p : i = j$. We can then transport $x$ across
 $p$ to obtain a value in $F_j$, which can then be compared against
 $y : F_j$.

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -50,7 +50,7 @@ $$
 
 The reason is that $i < j$ naturally involves $i \neq j$ when we take
 the non-strict order $i \leq j$ as the primitive notion. Negated types
-carry little information and usually do not work well in constructive
+carry little information and usually work less well in constructive
 settings.
 :::
 

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -122,9 +122,9 @@ compensate for the differences.
       (λ x≤y p → subst (F._≤ _) (substᵢ-filler-set ⌞F⌟ (hlevel 2) p _) x≤y)
 ```
 
-We can also define injections from $F_i$, which are essentially
+We can also define injections from $F_i$, which are the generic injections
 `fibre-injᵖ`{.Agda} (for general displayed posets) precomposed with the
-inverse of `lexical-sum-fibre-equiv`{.Agda}.
+inverse of the above equivalence `lexical-sum-fibre-equiv`{.Agda}.
 
 ```agda
   lexical-sum-injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Lexical-sum I F)

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -132,14 +132,18 @@ lexical sum such that it commutes with $\sigma$.
     → Monotone (∫ G) (Lexical-sum I F)
   splitᵖ G cases .hom    (i , x)     = i , cases i # x
   splitᵖ G cases .pres-≤ (i≤j , x≤y) =
-    i≤j , λ p → lemma p i≤j x≤y
+    i≤j , λ i=ᵢj → lemma-pres-≤ i=ᵢj i≤j x≤y
+```
+<!--
+```agda
     where
       module G = D G
 
-      lemma
+      lemma-pres-≤
         : ∀ {i j} (p : i ≡ᵢ j) (i≤j : i I.≤ j) {x y}
         → G.Rel[ i≤j ] x y
         → substᵢ ⌞F⌟ p (cases i .hom x) F.≤ (cases j .hom y)
-      lemma {i = i} reflᵢ i≤j x≤y =
+      lemma-pres-≤ {i = i} reflᵢ i≤j x≤y =
         cases i .pres-≤ $ subst (λ q → G.Rel[ q ] _ _) (I.≤-thin i≤j I.≤-refl) x≤y
 ```
+-->

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -139,7 +139,7 @@ inverse of `lexical-sum-fibre-equiv`{.Agda}.
 ```
 
 The name `Lexical-sum`{.Agda} is justified by the observation that it
-is the _maximal_ poset with the given index $I$ and fibres $F$. Its
+is the _maximum_ poset with the given index $I$ and fibres $F$. Its
 mapping-in universal property is: given another poset $G$ displayed
 over $I$ and a collection a fibrewise map $\sigma_{i\in I} : G_i \to
 F_i$, there exists a (unique!) index-preserving map from the total

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -48,9 +48,10 @@ $$
   (i, x) < (j, y) \iff i < j \vee i = j \wedge x < y
 $$
 
-The reason is that $i < j$ naturally involves $i \neq j$ as we take
+The reason is that $i < j$ naturally involves $i \neq j$ when we take
 the non-strict order $i \leq j$ as the primitive notion. Negated types
-carry little information and do not work well in constructive settings.
+carry little information and usually do not work well in constructive
+settings.
 :::
 
 Given the dependency of $F$ on $I$, the comparison between $x : F_i$
@@ -103,7 +104,7 @@ module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} {I : Poset ℓₐ ℓᵣ} {F : ⌞ I �
 -->
 
 By construction, the fiber in a lexical sum over $i : I$ is essentially
-$F_i$, which is witnessed by the coprojections from $F_i$ that are order
+$F_i$, which is witnessed by the injections from $F_i$ that are order
 embeddings:
 
 ```agda
@@ -120,9 +121,9 @@ embeddings:
 
 The name `Lexical-sum`{.Agda} is justified by its mapping-in universal
 property: given another poset $G$ displayed over $I$ and a collection
-of fibrewise maps $\sigma_{i\in I} : G_i \to F_i$, there exists a
+a fibrewise map $\sigma_{i\in I} : G_i \to F_i$, there exists a
 (unique!) index-preserving map from the total space of $G$ into the
-lexical sum such that it commutes with all $\sigma_i$.
+lexical sum such that it commutes with $\sigma$.
 
 ```agda
   splitᵖ

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -103,9 +103,29 @@ module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} {I : Poset ℓₐ ℓᵣ} {F : ⌞ I �
 ```
 -->
 
-By construction, the fiber in a lexical sum over $i : I$ is essentially
-$F_i$, which is witnessed by the injections from $F_i$ that are order
-embeddings:
+The fibre in a lexical sum over $i : I$ is essentially $F_i$. In fact,
+their underlying types are judgementally equal in the current
+construction. We do not express the sameness using isomorphisms in the
+category of posets (`Posets`{.Agda}) due to technical reasons: their
+universe levels do not match and we would need ugly lifting to
+compensate for the differences.
+
+```agda
+  lexical-sum-fibre-equiv
+    : (i : ⌞ I ⌟) → ⌞ Fibre (Lexical-sum-over I F) i ⌟ ≃ ⌞ F i ⌟
+  lexical-sum-fibre-equiv i = _ , id-equiv
+
+  lexical-sum-fibre-equiv-is-order-embedding
+    : ∀ i → is-order-embedding (Fibre (Lexical-sum-over I F) i) (F i) (λ x → x)
+  lexical-sum-fibre-equiv-is-order-embedding i =
+    prop-ext!
+      (λ x≤y → x≤y reflᵢ)
+      (λ x≤y p → subst (F._≤ _) (substᵢ-filler-set ⌞F⌟ (hlevel 2) p _) x≤y)
+```
+
+We can also define injections from $F_i$, which are essentially
+`Order.Displayed.fibre-injᵖ`{.Agda} precomposed with the inverse of
+`lexical-sum-fibre-equiv`{.Agda}.
 
 ```agda
   lexical-sum-injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Lexical-sum I F)
@@ -116,7 +136,7 @@ embeddings:
   lexical-sum-injᵖ-is-order-embedding
     : ∀ i → is-order-embedding (F i) (Lexical-sum I F) (apply (lexical-sum-injᵖ i))
   lexical-sum-injᵖ-is-order-embedding i =
-    prop-ext! (lexical-sum-injᵖ i .pres-≤) λ { (_ , q) → q reflᵢ }
+    prop-ext! (lexical-sum-injᵖ i .pres-≤) λ (_ , q) → q reflᵢ
 ```
 
 The name `Lexical-sum`{.Agda} is justified by its mapping-in universal

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -43,9 +43,11 @@ $$
 
 ::: note
 We avoid the more traditional formulation that uses the strict order:
+
 $$
   (i, x) < (j, y) \iff i < j \vee i = j \wedge x < y
 $$
+
 The reason is that $i < j$ naturally involves $i \neq j$ as we take
 the non-strict order $i \leq j$ as the primitive notion. Negated types
 carry little information and do not work well in constructive settings.

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -50,7 +50,7 @@ $$
 
 The reason is that $i < j$ naturally involves $i \neq j$ when we take
 the non-strict order $i \leq j$ as the primitive notion. Negated types
-carry little information and usually work less well in constructive
+carry less information and usually work less well in constructive
 settings.
 :::
 

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -1,0 +1,140 @@
+<!--
+```agda
+open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Morphism
+open import Cat.Prelude
+
+open import Data.Id.Base
+open import Data.Bool
+open import Data.Sum
+
+open import Order.Instances.Coproduct renaming (matchᵖ to match⊎ᵖ)
+open import Order.Instances.Discrete
+open import Order.Displayed
+open import Order.Univalent
+open import Order.Morphism
+open import Order.Base
+
+import Order.Reasoning as Pr
+
+open is-indexed-coproduct
+open Indexed-coproduct
+open Inverses
+```
+-->
+
+```agda
+module Order.Instances.LexicalSum where
+```
+
+# Lexicographic sum of posets {defines="lexicographic-sum-of-posets lexical-sum-of-posets"}
+
+<!--
+```agda
+private module D = Displayed
+
+module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} (I : Poset ℓₐ ℓᵣ) (F : ⌞ I ⌟ → Poset ℓₐ' ℓᵣ') where
+  private
+    module I = Pr I
+    module F {i : ⌞ I ⌟} = Pr (F i)
+
+    ⌞F⌟ : ⌞ I ⌟ → Type ℓₐ'
+    ⌞F⌟ e = ⌞ F e ⌟
+```
+-->
+
+Let $I$ be a [[partial order]] and $F_i$ be a family of [[partial
+orders]] indexed by the underlying set of $I$.We can equip the
+$\Sigma$-type $\Sigma_{(i : I)} F_i$ with a lexicographic partial
+order:
+
+$$
+  (i, x) \leq (j, y) \iff i \leq j \wedge (i = j \implies x \leq y)
+$$
+
+::: note
+The above formulation intentionally avoids the conventional strict
+order:
+
+$$
+  (i, x) < (j, y) \iff i < j \vee i = j \wedge x < y
+$$
+
+The reason is that $i < j$ naturally involves $i \neq j$ as we take
+the non-strict order $i \leq j$ as the primitive notion. Negated types
+carry little information and do not work well in constructive settings.
+:::
+
+Given the dependency of $F$ on $I$, the comparison between $x : F_i$
+and $y : F_j$ only make sense when they lie in the same fibre, that is,
+when there is evidence $p : i = j$. We can then transport $x$ across
+$p$ to obtain a value in $F_j$, which can then be compared against
+$y : F_j$.
+
+The concerns of defining the ordering in each fibre, and then defining
+the ordering on the entire total space, are mostly orthogonal. Indeed,
+these can be handled in a modular way: the construction we're interested
+in naturally arises as the [[total (thin) category|total category]] of a
+particular [[displayed order]] over the base poset $I$.
+
+```agda
+  Lexical-sum-over : Displayed _ _ I
+  Lexical-sum-over .D.Ob[_]      = ⌞F⌟
+  Lexical-sum-over .D.Rel[_] {i} {j} _ x y =
+    (p : i ≡ᵢ j) → substᵢ ⌞F⌟ p x F.≤ y
+```
+<!--
+```agda
+  Lexical-sum-over .D.≤-thin' _  = hlevel 1
+  Lexical-sum-over .D.≤-refl' p  = F.≤-refl' $ sym $ substᵢ-filler-set ⌞F⌟ (hlevel 2) p _
+  Lexical-sum-over .D.≤-antisym' x≤'y y≤'x = F.≤-antisym (x≤'y reflᵢ) (y≤'x reflᵢ)
+  Lexical-sum-over .D.≤-trans' {f = i≤j} {g = j≤i} x≤'y y≤'z reflᵢ =
+    let i=ᵢj = Id≃path.from $ I.≤-antisym i≤j j≤i in
+    lemma i=ᵢj (x≤'y i=ᵢj) (y≤'z (symᵢ i=ᵢj))
+    where
+      lemma : ∀ {i j} (p : i ≡ᵢ j) {x y z} → substᵢ ⌞F⌟ p x F.≤ y → substᵢ ⌞F⌟ (symᵢ p) y F.≤ z → x F.≤ z
+      lemma reflᵢ = F.≤-trans
+```
+-->
+
+```agda
+  Lexical-sum : Poset _ _
+  Lexical-sum = ∫ Lexical-sum-over
+```
+
+<!--
+```agda
+module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} {I : Poset ℓₐ ℓᵣ} {F : ⌞ I ⌟ → Poset ℓₐ' ℓᵣ'} where
+  private
+    module I = Pr I
+    module F {i : ⌞ I ⌟} = Pr (F i)
+
+    ⌞F⌟ : ⌞ I ⌟ → Type ℓₐ'
+    ⌞F⌟ e = ⌞ F e ⌟
+```
+-->
+
+The name `Lexical-sum`{.Agda} is justified by its mapping-in universal
+property: given another poset $G$ displayed over $I$ and a collection
+of fibrewise maps $\sigma_{i\in I} : G_i \to F_i$, there exists a
+(unique!) index-preserving map from the total space of $G$ into the
+lexical sum such that it commutes with all $\sigma_i$.
+
+```agda
+  splitᵖ
+    : ∀ {o ℓ} (G : Displayed o ℓ I)
+    → (∀ i → Monotone (Fibre G i) (F i))
+    → Monotone (∫ G) (Lexical-sum I F)
+  splitᵖ G cases .hom    (i , x)     = i , cases i # x
+  splitᵖ G cases .pres-≤ (i≤j , x≤y) =
+    i≤j , λ p → lemma p i≤j x≤y
+    where
+      module G = D G
+
+      lemma
+        : ∀ {i j} (p : i ≡ᵢ j) (i≤j : i I.≤ j) {x y}
+        → G.Rel[ i≤j ] x y
+        → substᵢ ⌞F⌟ p (cases i .hom x) F.≤ (cases j .hom y)
+      lemma {i = i} reflᵢ i≤j x≤y =
+        cases i .pres-≤ $ subst (λ q → G.Rel[ q ] _ _) (I.≤-thin i≤j I.≤-refl) x≤y
+```

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -1,25 +1,13 @@
 <!--
 ```agda
-open import Cat.Diagram.Coproduct.Indexed
-open import Cat.Morphism
 open import Cat.Prelude
 
 open import Data.Id.Base
-open import Data.Bool
-open import Data.Sum
 
-open import Order.Instances.Coproduct renaming (matchᵖ to match⊎ᵖ)
-open import Order.Instances.Discrete
 open import Order.Displayed
-open import Order.Univalent
-open import Order.Morphism
 open import Order.Base
 
 import Order.Reasoning as Pr
-
-open is-indexed-coproduct
-open Indexed-coproduct
-open Inverses
 ```
 -->
 

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -5,6 +5,7 @@ open import Cat.Prelude
 open import Data.Id.Base
 
 open import Order.Displayed
+open import Order.Morphism
 open import Order.Base
 
 import Order.Reasoning as Pr
@@ -41,13 +42,10 @@ $$
 $$
 
 ::: note
-The above formulation intentionally avoids the conventional strict
-order:
-
+We avoid the more traditional formulation that uses the strict order:
 $$
   (i, x) < (j, y) \iff i < j \vee i = j \wedge x < y
 $$
-
 The reason is that $i < j$ naturally involves $i \neq j$ as we take
 the non-strict order $i \leq j$ as the primitive notion. Negated types
 carry little information and do not work well in constructive settings.
@@ -101,6 +99,22 @@ module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} {I : Poset ℓₐ ℓᵣ} {F : ⌞ I �
     ⌞F⌟ e = ⌞ F e ⌟
 ```
 -->
+
+By construction, the fiber in a lexical sum over $i : I$ is essentially
+$F_i$, which is witnessed by the coprojections from $F_i$ that are order
+embeddings:
+
+```agda
+  lexical-sum-injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Lexical-sum I F)
+  lexical-sum-injᵖ i .hom    x   = i , x
+  lexical-sum-injᵖ i .pres-≤ x≤y = I.≤-refl , λ p →
+    subst (F._≤ _) (substᵢ-filler-set ⌞F⌟ (hlevel 2) p _) x≤y
+
+  lexical-sum-injᵖ-is-order-embedding
+    : ∀ i → is-order-embedding (F i) (Lexical-sum I F) (apply (lexical-sum-injᵖ i))
+  lexical-sum-injᵖ-is-order-embedding i =
+    prop-ext! (lexical-sum-injᵖ i .pres-≤) λ { (_ , q) → q reflᵢ }
+```
 
 The name `Lexical-sum`{.Agda} is justified by its mapping-in universal
 property: given another poset $G$ displayed over $I$ and a collection

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -131,8 +131,7 @@ lexical sum such that it commutes with $\sigma$.
     → (∀ i → Monotone (Fibre G i) (F i))
     → Monotone (∫ G) (Lexical-sum I F)
   splitᵖ G cases .hom    (i , x)     = i , cases i # x
-  splitᵖ G cases .pres-≤ (i≤j , x≤y) =
-    i≤j , λ i=ᵢj → lemma-pres-≤ i=ᵢj i≤j x≤y
+  splitᵖ G cases .pres-≤ (i≤j , x≤y) = i≤j , λ i=ᵢj → lemma-pres-≤ i=ᵢj i≤j x≤y
 ```
 <!--
 ```agda

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -33,7 +33,7 @@ module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} (I : Poset ℓₐ ℓᵣ) (F : ⌞ I �
 -->
 
 Let $I$ be a [[partial order]] and $F_i$ be a family of [[partial
-orders]] indexed by the underlying set of $I$.We can equip the
+orders]] indexed by the underlying set of $I$. We can equip the
 $\Sigma$-type $\Sigma_{(i : I)} F_i$ with a lexicographic partial
 order:
 

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -45,7 +45,7 @@ $$
 We avoid the more traditional formulation that uses the strict order:
 
 $$
-  (i, x) < (j, y) \iff i < j \vee i = j \wedge x < y
+  (i, x) < (j, y) \iff i < j \vee (i = j \wedge x < y)
 $$
 
 The reason is that $i < j$ naturally involves $i \neq j$ when we take

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -68,14 +68,13 @@ particular [[displayed order]] over the base poset $I$.
 
 ```agda
   Lexical-sum-over : Displayed _ _ I
-  Lexical-sum-over .D.Ob[_]      = ⌞F⌟
-  Lexical-sum-over .D.Rel[_] {i} {j} _ x y =
-    (p : i ≡ᵢ j) → substᵢ ⌞F⌟ p x F.≤ y
+  Lexical-sum-over .D.Ob[_]                = ⌞F⌟
+  Lexical-sum-over .D.Rel[_] {i} {j} _ x y = (p : i ≡ᵢ j) → substᵢ ⌞F⌟ p x F.≤ y
 ```
 <!--
 ```agda
-  Lexical-sum-over .D.≤-thin' _  = hlevel 1
-  Lexical-sum-over .D.≤-refl' p  = F.≤-refl' $ sym $ substᵢ-filler-set ⌞F⌟ (hlevel 2) p _
+  Lexical-sum-over .D.≤-thin' _ = hlevel 1
+  Lexical-sum-over .D.≤-refl' p = F.≤-refl' $ sym $ substᵢ-filler-set ⌞F⌟ (hlevel 2) p _
   Lexical-sum-over .D.≤-antisym' x≤'y y≤'x = F.≤-antisym (x≤'y reflᵢ) (y≤'x reflᵢ)
   Lexical-sum-over .D.≤-trans' {f = i≤j} {g = j≤i} x≤'y y≤'z reflᵢ =
     let i=ᵢj = Id≃path.from $ I.≤-antisym i≤j j≤i in

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -32,9 +32,9 @@ module _ {ℓₐ ℓᵣ ℓₐ' ℓᵣ'} (I : Poset ℓₐ ℓᵣ) (F : ⌞ I �
 ```
 -->
 
-Let $I$ be a [[partial order]] and $F_i$ be a family of [[partial
-orders]] indexed by the underlying set of $I$. We can equip the
-$\Sigma$-type $\Sigma_{(i : I)} F_i$ with a lexicographic partial
+Let $I$ be a [[partial order]] and $F_{i\in I}$ be a family of
+[[partial orders]] indexed by the underlying set of $I$. We can equip
+the $\Sigma$-type $\Sigma_{(i : I)} F_i$ with a lexicographic partial
 order:
 
 $$
@@ -124,8 +124,8 @@ compensate for the differences.
 ```
 
 We can also define injections from $F_i$, which are essentially
-`Order.Displayed.fibre-injᵖ`{.Agda} precomposed with the inverse of
-`lexical-sum-fibre-equiv`{.Agda}.
+`fibre-injᵖ`{.Agda} (for general displayed posets) precomposed with the
+inverse of `lexical-sum-fibre-equiv`{.Agda}.
 
 ```agda
   lexical-sum-injᵖ : (i : ⌞ I ⌟) → Monotone (F i) (Lexical-sum I F)
@@ -139,11 +139,12 @@ We can also define injections from $F_i$, which are essentially
     prop-ext! (lexical-sum-injᵖ i .pres-≤) λ (_ , q) → q reflᵢ
 ```
 
-The name `Lexical-sum`{.Agda} is justified by its mapping-in universal
-property: given another poset $G$ displayed over $I$ and a collection
-a fibrewise map $\sigma_{i\in I} : G_i \to F_i$, there exists a
-(unique!) index-preserving map from the total space of $G$ into the
-lexical sum such that it commutes with $\sigma$.
+The name `Lexical-sum`{.Agda} is justified by the observation that it
+is the _maximal_ poset with the given index $I$ and fibres $F$. Its
+mapping-in universal property is: given another poset $G$ displayed
+over $I$ and a collection a fibrewise map $\sigma_{i\in I} : G_i \to
+F_i$, there exists a (unique!) index-preserving map from the total
+space of $G$ into the lexical sum such that it commutes with $\sigma$.
 
 ```agda
   splitᵖ

--- a/src/Order/Instances/LexicalSum.lagda.md
+++ b/src/Order/Instances/LexicalSum.lagda.md
@@ -146,3 +146,9 @@ lexical sum such that it commutes with $\sigma$.
         cases i .pres-≤ $ subst (λ q → G.Rel[ q ] _ _) (I.≤-thin i≤j I.≤-refl) x≤y
 ```
 -->
+
+::: source
+The categorical definition of lexicographic sums is given by Reinhard
+Börger, Walter Tholen and Anna Tozzi in their paper [Lexicographic sums
+and fibre-faithful maps](https://doi.org/10.1007/BF00872986).
+:::


### PR DESCRIPTION
# Description

Define the lexicographic sum of posets and redefine the disjoint sum as a special case.

This PR is built upon #390 and #391.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.