### PR TITLE
defn: equivalences over

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -165,7 +165,7 @@ module _ {ℓ} {A : Type ℓ} {a b : A} {p : a ≡ b} where private
   right-endpoint = refl
 ```
 
-## Dependent paths
+## Dependent paths {defines="dependent-path path-over"}
 
 Since we're working in dependent type theory, a sensible question to ask
 is whether we can extend the idea that paths are functions $\bI \to A$

--- a/src/1Lab/Prelude.agda
+++ b/src/1Lab/Prelude.agda
@@ -33,7 +33,9 @@ open import 1Lab.Equiv.HalfAdjoint public
 open import 1Lab.Function.Surjection public
 
 open import 1Lab.Univalence public
-open import 1Lab.Univalence.SIP public
+open import 1Lab.Univalence.SIP
+  renaming (_≃[_]_ to _≃[_]s_)
+  public
 
 open import 1Lab.Type.Pi public
 open import 1Lab.Type.Sigma public

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -2,6 +2,7 @@ open import 1Lab.Reflection.Signature
 open import 1Lab.Function.Embedding
 open import 1Lab.Reflection.Record
 open import 1Lab.Reflection.Subst
+open import 1Lab.Equiv.Fibrewise
 open import 1Lab.HLevel.Universe
 open import 1Lab.HLevel.Closure
 open import 1Lab.Reflection
@@ -235,6 +236,7 @@ private module _ {ℓ} {A : n-Type ℓ 2} {B : ∣ A ∣ → n-Type ℓ 3} where
 private variable
   ℓ ℓ' : Level
   A B C : Type ℓ
+  P Q : A → Type ℓ
 
 {-
 In addition to the top-level 'hlevel' entry point, there are quite a few
@@ -258,6 +260,15 @@ prop-ext!
   → (A → B) → (B → A)
   → A ≃ B
 prop-ext! = prop-ext (hlevel 1) (hlevel 1)
+
+prop-over-ext!
+  : (e : A ≃ B) (let module e = Equiv e)
+  → ⦃ ∀ {a} → H-Level (P a) 1 ⦄
+  → ⦃ ∀ {b} → H-Level (Q b) 1 ⦄
+  → (∀ (a : A) → P a → Q (e.to a))
+  → (∀ (b : B) → Q b → P (e.from b))
+  → P ≃[ e ] Q
+prop-over-ext! e = prop-over-ext e (hlevel 1) (hlevel 1)
 
 Σ-prop-path!
   : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}

--- a/src/Algebra/Group/Ab.lagda.md
+++ b/src/Algebra/Group/Ab.lagda.md
@@ -38,6 +38,9 @@ private variable
 
 Group-on-is-abelian : Group-on G → Type _
 Group-on-is-abelian G = ∀ x y → Group-on._⋆_ G x y ≡ Group-on._⋆_ G y x
+
+Group-on-is-abelian-is-prop : (g : Group-on G) → is-prop (Group-on-is-abelian g)
+Group-on-is-abelian-is-prop g = Π-is-hlevel² 1 λ _ _ → g .Group-on.has-is-set _ _
 ```
 -->
 
@@ -60,7 +63,7 @@ instance
   H-Level-is-abelian-group
     : ∀ {n} {* : G → G → G} → H-Level (is-abelian-group *) (suc n)
   H-Level-is-abelian-group = prop-instance $ Iso→is-hlevel 1 eqv $
-    Σ-is-hlevel 1 (hlevel 1) λ x → Π-is-hlevel' 1 λ _ → Π-is-hlevel' 1 λ _ →
+    Σ-is-hlevel 1 (hlevel 1) λ x → Π-is-hlevel²' 1 λ _ _ →
       is-group.has-is-set x _ _
 ```
 -->

--- a/src/Algebra/Group/Concrete.lagda.md
+++ b/src/Algebra/Group/Concrete.lagda.md
@@ -120,7 +120,7 @@ opaque
 S¹-concrete : ConcreteGroup lzero
 S¹-concrete .B = S¹∙
 S¹-concrete .has-is-connected = S¹-is-connected
-S¹-concrete .has-is-groupoid = hlevel 3
+S¹-concrete .has-is-groupoid = S¹-is-groupoid
 ```
 
 ## The category of concrete groups
@@ -409,7 +409,7 @@ need to bend the path into a `Square`{.Agda}:
   linv = funext∙ g≡f ptg≡ptf
 ```
 
-*Phew*. At last, `π₁F`{.Agda} is fully faithful.
+At last, `π₁F`{.Agda} is fully faithful.
 
 ```agda
 π₁F-is-ff : is-fully-faithful (π₁F {ℓ})
@@ -428,11 +428,11 @@ this lets us conclude with the desired equivalence.
   (λ {G} {H} → π₁F-is-ff {_} {G} {H})
   π₁F-is-split-eso
 
-π₁B-is-equiv : is-equiv (π₁B {ℓ})
-π₁B-is-equiv = is-cat-equivalence→equiv-on-objects
+Concrete≃Abstract : ConcreteGroup ℓ ≃ Group ℓ
+Concrete≃Abstract = _ , is-cat-equivalence→equiv-on-objects
   ConcreteGroups-is-category
   Groups-is-category
   π₁F-is-equivalence
 
-module Concrete≃Abstract {ℓ} = Equiv (_ , π₁B-is-equiv {ℓ})
+module Concrete≃Abstract {ℓ} = Equiv (Concrete≃Abstract {ℓ})
 ```

--- a/src/Algebra/Group/Concrete/Abelian.lagda.md
+++ b/src/Algebra/Group/Concrete/Abelian.lagda.md
@@ -59,30 +59,27 @@ that has equal opposite sides.
     x
 ```
 
-Still unsurprisingly, the delooping of an abelian group is abelian.
+Still unsurprisingly, the properties of being a concrete abelian group
+and being an abelian group are [[equivalent over|equivalence over]]
+the equivalence between concrete and abstract groups.
 
 ```agda
-Deloop-abelian
-  : ∀ {ℓ} {G : Group ℓ}
-  → is-commutative-group G → is-concrete-abelian (Concrete G)
-Deloop-abelian G-ab = ∙-comm _ G-ab
+abelian≃abelian
+  : ∀ {ℓ}
+  → is-concrete-abelian ≃[ Concrete≃Abstract {ℓ} ] is-commutative-group
+abelian≃abelian = prop-over-ext Concrete≃Abstract
+  (λ {G} → is-concrete-abelian-is-prop G)
+  (λ {G} → Group-on-is-abelian-is-prop (G .snd))
+  (λ G G-ab → G-ab)
+  (λ G G-ab → ∙-comm _ G-ab)
 ```
 
-The circle is another example, being the delooping of $\mathbb{Z}$.
+For example, the circle is abelian, being the delooping of $\mathbb{Z}$.
 
 ```agda
-π₁-abelian→abelian
-  : ∀ {ℓ} {G : ConcreteGroup ℓ}
-  → is-commutative-group (π₁B G) → is-concrete-abelian G
-π₁-abelian→abelian {G = G} π₁G-ab = subst is-concrete-abelian
-  (Concrete≃Abstract.η G)
-  (Deloop-abelian π₁G-ab)
-
 S¹-concrete-abelian : is-concrete-abelian S¹-concrete
-S¹-concrete-abelian = π₁-abelian→abelian {G = S¹-concrete}
-  (subst is-commutative-group
-    (sym π₁S¹≡ℤ)
-    (Abelian→Group-on-abelian (ℤ-ab .snd)))
+S¹-concrete-abelian = Equiv.from (abelian≃abelian S¹-concrete ℤ π₁S¹≡ℤ)
+  (Abelian→Group-on-abelian (ℤ-ab .snd))
 ```
 
 ## First abelian group cohomology
@@ -228,6 +225,8 @@ module _ {ℓ}
     : H¹[ Concrete G , Concrete H ] ≃ Hom (Groups ℓ) G H
   first-abelian-group-cohomology =
     first-concrete-abelian-group-cohomology
-      (Concrete G) (Concrete H) (Deloop-abelian H-ab) e⁻¹
+      (Concrete G) (Concrete H)
+      (Equiv.from (abelian≃abelian (Concrete H) H (Concrete≃Abstract.ε H)) H-ab)
+      e⁻¹
     ∙e Deloop-hom-equiv
 ```

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -220,6 +220,9 @@ $\hom(La,b) \cong \hom(a,Rb)$.
   R-adjunct-is-equiv : ∀ {a b} → is-equiv (R-adjunct {a} {b})
   R-adjunct-is-equiv = is-iso→is-equiv
     (iso L-adjunct R-L-adjunct L-R-adjunct)
+
+  adjunct-hom-equiv : ∀ {a b} → D.Hom (L.₀ a) b ≃ C.Hom a (R.₀ b)
+  adjunct-hom-equiv = L-adjunct , L-adjunct-is-equiv
 ```
 
 <!--

--- a/src/Cat/Functor/Adjoint/Hom.lagda.md
+++ b/src/Cat/Functor/Adjoint/Hom.lagda.md
@@ -182,7 +182,7 @@ module _ {o ℓ o'} {C : Precategory o ℓ} {D : Precategory o' ℓ}
     module R = Func R
 
     hom-equiv : ∀ {a b} → C.Hom (L.₀ a) b ≃ D.Hom a (R.₀ b)
-    hom-equiv = _ , L-adjunct-is-equiv adj
+    hom-equiv = adjunct-hom-equiv adj
 
   adjunct-hom-iso-from
     : ∀ a → Hom-from C (L.₀ a) ≅ⁿ Hom-from D a F∘ R

--- a/src/Cat/Monoidal/Monad.lagda.md
+++ b/src/Cat/Monoidal/Monad.lagda.md
@@ -624,10 +624,10 @@ underlying monoidal functor is [[symmetric|symmetric monoidal functor]].
       (_ , m .Monoidal-monad-on.monad-monoidal)
 ```
 
-Then, we have that, *over* the above identification between monoidal
-monads and commutative strengths, the property of being a *symmetric*
-monoidal monad is identified with the property of being a *symmetric*
-strength.
+Then, we have that, *[[over|equivalence over]]* the above equivalence
+between monoidal monads and commutative strengths, the property of being
+a *symmetric* monoidal monad is equivalent to the property of being a
+*symmetric* strength.
 
 Given a symmetric monoidal monad, we immediately see that the induced
 left and right strengths are related by the braiding.
@@ -697,15 +697,17 @@ between the *structure* of a symmetric monoidal monad and the *structure*
 of a symmetric commutative strength.
 
 ```agda
+    symmetric≃symmetric
+      : is-symmetric-monoidal-monad ≃[ monoidal≃commutative ]
+        (is-symmetric-monad-strength Cᵇ ⊙ fst)
+    symmetric≃symmetric = prop-over-ext monoidal≃commutative (hlevel 1) (hlevel 1)
+      symmetric-monoidal→symmetric-strength symmetric-strength→symmetric-monoidal
+
     symmetric-monoidal≃symmetric-commutative
       : Σ (Monoidal-monad-on Cᵐ monad) is-symmetric-monoidal-monad
       ≃ Σ (Monad-strength Cᵐ monad) (λ s →
         is-commutative-strength s × is-symmetric-monad-strength Cᵇ s)
     symmetric-monoidal≃symmetric-commutative =
-      Σ-ap monoidal≃commutative (λ m → prop-ext!
-        (symmetric-monoidal→symmetric-strength m)
-        (λ sy → subst is-symmetric-monoidal-monad (monoidal≃commutative.η m)
-          (symmetric-strength→symmetric-monoidal
-            (monoidal≃commutative.to m) sy)))
+      over→total monoidal≃commutative symmetric≃symmetric
       ∙e Σ-assoc e⁻¹
 ```


### PR DESCRIPTION
Defines "equivalences over", or displayed equivalences, along with three examples:

- an adjunction is an equivalence iff being invertible is equivalent to itself over the Hom-equivalence;
- being a symmetric monoidal monad is equivalent to being a symmetric monad strength over the equivalence between monoidal monads and commutative monads;
- being a concrete abelian group is equivalent to being an abelian group over the equivalence between concrete groups and groups.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
