### PR TITLE
Universal colimits

### DIFF
--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -550,6 +550,11 @@ is a proposition:
       (a .is-natural x y f)
       (b .is-natural x y f) i
 
+  Nat-path : {a b : F => G}
+           → ((x : _) → a .η x ≡ b .η x)
+           → a ≡ b
+  Nat-path = Nat-pathp refl refl
+
   _ηₚ_ : ∀ {a b : F => G} → a ≡ b → ∀ x → a .η x ≡ b .η x
   p ηₚ x = ap (λ e → e .η x) p
 
@@ -588,7 +593,7 @@ instance
     → Extensional (F => G) (o ⊔ ℓr)
   Extensional-natural-transformation ⦃ sa ⦄ .Pathᵉ f g = ∀ i → Pathᵉ sa (f .η i) (g .η i)
   Extensional-natural-transformation ⦃ sa ⦄ .reflᵉ x i = reflᵉ sa (x .η i)
-  Extensional-natural-transformation ⦃ sa ⦄ .idsᵉ .to-path x = Nat-pathp _ _ λ i →
+  Extensional-natural-transformation ⦃ sa ⦄ .idsᵉ .to-path x = Nat-path λ i →
     sa .idsᵉ .to-path (x i)
   Extensional-natural-transformation {D = D} ⦃ sa ⦄ .idsᵉ .to-path-over h =
     is-prop→pathp (λ i → Π-is-hlevel 1 λ _ → Pathᵉ-is-hlevel 1 sa (hlevel 2)) _ _

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -306,9 +306,10 @@ module Colimit
     import Cat.Reasoning J as J
     import Cat.Reasoning C as C
     module Diagram = Functor D
-    open Lan L
     open Functor
     open _=>_
+
+  open Lan L public
 ```
 -->
 
@@ -427,7 +428,7 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 
 Furthermore, if the universal map is invertible, then that means its
 domain is _also_ a colimit of the diagram. This also follows from a
-[general theorem of Kan extensions], though some golfin is required to
+[general theorem of Kan extensions], though some golfing is required to
 obtain the correct inverse definitionally.
 
 [general theorem of Kan extensions]: Cat.Functor.Kan.Unique.html#is-invertible→is-lan
@@ -539,12 +540,10 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 ```
 
 
-# Preservation of colimits
+# Preservation and reflection of colimits {defines="preserved-colimit reflected-colimit"}
 
-The definitions here are the same idea as [preservation of limits], just
-dualised.
-
-[preservation of limits]: Cat.Diagram.Limit.Base.html#preservation-of-limits
+The definitions here are the same idea as [[preservation of
+limits|preserved limit]], just dualised.
 
 <!--
 ```agda

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -116,40 +116,40 @@ is a morphism in the "shape" category $\cJ$, we require $\psi y \circ Ff
 ```
 
 The rest of the data ensures that $\psi$ is the universal family of maps
-with this property; if $\eps_j : Fj \to x$ is another natural family,
-then each $\eps_j$ factors through the coapex by a _unique_ universal
+with this property; if $\eta_j : Fj \to x$ is another natural family,
+then each $\eta_j$ factors through the coapex by a _unique_ universal
 morphism:
 
 ```agda
       universal
         : ∀ {x : C.Ob}
-        → (eps : ∀ j → C.Hom (F₀ j) x)
-        → (∀ {x y} (f : J.Hom x y) → eps y C.∘ F₁ f ≡ eps x)
+        → (eta : ∀ j → C.Hom (F₀ j) x)
+        → (∀ {x y} (f : J.Hom x y) → eta y C.∘ F₁ f ≡ eta x)
         → C.Hom coapex x
       factors
         : ∀ {j : J.Ob} {x : C.Ob}
-        → (eps : ∀ j → C.Hom (F₀ j) x)
-        → (p : ∀ {x y} (f : J.Hom x y) → eps y C.∘ F₁ f ≡ eps x)
-        → universal eps p C.∘ ψ j ≡ eps j
+        → (eta : ∀ j → C.Hom (F₀ j) x)
+        → (p : ∀ {x y} (f : J.Hom x y) → eta y C.∘ F₁ f ≡ eta x)
+        → universal eta p C.∘ ψ j ≡ eta j
       unique
         : ∀ {x : C.Ob}
-        → (eps : ∀ j → C.Hom (F₀ j) x)
-        → (p : ∀ {x y} (f : J.Hom x y) → eps y C.∘ F₁ f ≡ eps x)
+        → (eta : ∀ j → C.Hom (F₀ j) x)
+        → (p : ∀ {x y} (f : J.Hom x y) → eta y C.∘ F₁ f ≡ eta x)
         → (other : C.Hom coapex x)
-        → (∀ j → other C.∘ ψ j ≡ eps j)
-        → other ≡ universal eps p
+        → (∀ j → other C.∘ ψ j ≡ eta j)
+        → other ≡ universal eta p
 ```
 
 <!--
 ```agda
     unique₂
       : ∀ {x : C.Ob}
-      → (eps : ∀ j → C.Hom (F₀ j) x)
-      → (p : ∀ {x y} (f : J.Hom x y) → eps y C.∘ F₁ f ≡ eps x)
-      → ∀ {o1} → (∀ j → o1 C.∘ ψ j ≡ eps j)
-      → ∀ {o2} → (∀ j → o2 C.∘ ψ j ≡ eps j)
+      → (eta : ∀ j → C.Hom (F₀ j) x)
+      → (p : ∀ {x y} (f : J.Hom x y) → eta y C.∘ F₁ f ≡ eta x)
+      → ∀ {o1} → (∀ j → o1 C.∘ ψ j ≡ eta j)
+      → ∀ {o2} → (∀ j → o2 C.∘ ψ j ≡ eta j)
       → o1 ≡ o2
-    unique₂ eps p q r = unique eps p _ q ∙ sym (unique eps p _ r)
+    unique₂ eta p q r = unique eta p _ q ∙ sym (unique eta p _ r)
 ```
 -->
 
@@ -244,22 +244,22 @@ function which **un**makes a colimit.
     open make-is-colimit
     open _=>_
 
-    module _ {x} (eps : ∀ j → C.Hom (F₀ j) x)
-                 (p : ∀ {x y} (f : J.Hom x y) →  eps y C.∘ F₁ f ≡ eps x)
+    module _ {x} (eta : ∀ j → C.Hom (F₀ j) x)
+                 (p : ∀ {x y} (f : J.Hom x y) →  eta y C.∘ F₁ f ≡ eta x)
       where
 
-      eps-nt : D => const! x F∘ !F
-      eps-nt .η = eps
-      eps-nt .is-natural _ _ f = p f ∙ sym (C.idl _)
+      eta-nt : D => const! x F∘ !F
+      eta-nt .η = eta
+      eta-nt .is-natural _ _ f = p f ∙ sym (C.idl _)
 
       hom : C.Hom coapex x
-      hom = σ {M = const! x} eps-nt .η tt
+      hom = σ {M = const! x} eta-nt .η tt
 
     mc : make-is-colimit D coapex
     mc .ψ = eta.η
     mc .commutes f = eta.is-natural _ _ f ∙ C.eliml (F .Functor.F-id)
     mc .universal = hom
-    mc .factors e p = σ-comm {α = eps-nt e p} ηₚ _
+    mc .factors e p = σ-comm {α = eta-nt e p} ηₚ _
     mc .unique {x = x} eta p other q =
       sym $ σ-uniq {σ' = other-nt} (ext λ j → sym (q j)) ηₚ tt
       where
@@ -452,8 +452,8 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 
   family→cocone
     : ∀ {x}
-    → (eps : ∀ j → C.Hom (D.₀ j) x)
-    → (∀ {x y} (f : J.Hom x y) → eps y C.∘ D.₁ f ≡ eps x)
+    → (eta : ∀ j → C.Hom (D.₀ j) x)
+    → (∀ {x y} (f : J.Hom x y) → eta y C.∘ D.₁ f ≡ eta x)
     → D => Const x
   family→cocone eta p .η = eta
   family→cocone eta p .is-natural _ _ _ = p _ ∙ sym (C.idl _)
@@ -463,12 +463,12 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 ```agda
   is-invertible→is-colimitp
     : ∀ {K' : Functor ⊤Cat C} {eta : D => K' F∘ !F}
-    → (eps : ∀ j → C.Hom (D.₀ j) (K' .F₀ tt))
-    → (p : ∀ {x y} (f : J.Hom x y) → eps y C.∘ D.₁ f ≡ eps x)
-    → (∀ {j} → eps j ≡ eta .η j)
-    → C.is-invertible (Cy.universal eps p)
+    → (eta' : ∀ j → C.Hom (D.₀ j) (K' .F₀ tt))
+    → (p : ∀ {x y} (f : J.Hom x y) → eta' y C.∘ D.₁ f ≡ eta' x)
+    → (∀ {j} → eta' j ≡ eta .η j)
+    → C.is-invertible (Cy.universal eta' p)
     → is-lan !F D K' eta
-  is-invertible→is-colimitp {K' = K'} {eta = eta} eps p q invert =
+  is-invertible→is-colimitp {K' = K'} {eta = eta} eta' p q invert =
     generalize-colimitp
       (is-invertible→is-lan Cy $ invertible→invertibleⁿ _ λ _ → invert)
       q
@@ -566,8 +566,8 @@ module _ {J : Precategory o₁ h₁} {C : Precategory o₂ h₂} {D : Precategor
 
   reflects-colimit : Type _
   reflects-colimit =
-    ∀ {K : Functor ⊤Cat C} {eps : Diagram => K F∘ !F}
-    → (lan : is-lan !F (F F∘ Diagram) (F F∘ K) (nat-assoc-to (F ▸ eps)))
+    ∀ {K : Functor ⊤Cat C} {eta : Diagram => K F∘ !F}
+    → (lan : is-lan !F (F F∘ Diagram) (F F∘ K) (nat-assoc-to (F ▸ eta)))
     → reflects-lan F lan
 ```
 
@@ -589,10 +589,10 @@ module preserves-colimit
   universal
     : {x : C.Ob}
     → {K : Functor ⊤Cat C} {eta : Dia => K F∘ !F}
-    → {eps : (j : J.Ob) → C.Hom (Dia.F₀ j) x}
-    → {p : ∀ {i j} (f : J.Hom i j) → eps j C.∘ Dia.F₁ f ≡ eps i}
+    → {eta' : (j : J.Ob) → C.Hom (Dia.F₀ j) x}
+    → {p : ∀ {i j} (f : J.Hom i j) → eta' j C.∘ Dia.F₁ f ≡ eta' i}
     → (colim : is-lan !F Dia K eta)
-    → F.F₁ (is-colimit.universal colim eps p) ≡ is-colimit.universal (preserves colim) (λ j → F.F₁ (eps j)) (λ f → F.collapse (p f))
+    → F.F₁ (is-colimit.universal colim eta' p) ≡ is-colimit.universal (preserves colim) (λ j → F.F₁ (eta' j)) (λ f → F.collapse (p f))
   universal colim =
     is-colimit.unique (preserves colim) _ _ _
       (λ j → F.collapse (is-colimit.factors colim _ _))
@@ -612,13 +612,13 @@ module _ {J : Precategory o₁ h₁} {C : Precategory o₂ h₂} {D : Precategor
     : F ≅ⁿ F'
     → preserves-colimit F Dia
     → preserves-colimit F' Dia
-  natural-iso→preserves-colimits α F-preserves {K = K} {eps} colim =
+  natural-iso→preserves-colimits α F-preserves {K = K} {eta} colim =
     natural-isos→is-lan idni (α ◂ni Dia) (α ◂ni K)
       (ext λ j →
-        ⌜ F' .F₁ (K .F₁ tt) D.∘ α.to .η _ ⌝ D.∘ (F .F₁ (eps .η j) D.∘ α.from .η _) ≡⟨ ap! (eliml F' (K .F-id)) ⟩
-        α.to .η _ D.∘ (F .F₁ (eps .η j) D.∘ α.from .η _)                           ≡⟨ D.pushr (sym (α.from .is-natural _ _ _)) ⟩
-        ((α.to .η _ D.∘ α.from .η _) D.∘ F' .F₁ (eps .η j))                        ≡⟨ D.eliml (α.invl ηₚ _) ⟩
-        F' .F₁ (eps .η j) ∎)
+        ⌜ F' .F₁ (K .F₁ tt) D.∘ α.to .η _ ⌝ D.∘ (F .F₁ (eta .η j) D.∘ α.from .η _) ≡⟨ ap! (eliml F' (K .F-id)) ⟩
+        α.to .η _ D.∘ (F .F₁ (eta .η j) D.∘ α.from .η _)                           ≡⟨ D.pushr (sym (α.from .is-natural _ _ _)) ⟩
+        ((α.to .η _ D.∘ α.from .η _) D.∘ F' .F₁ (eta .η j))                        ≡⟨ D.eliml (α.invl ηₚ _) ⟩
+        F' .F₁ (eta .η j) ∎)
       (F-preserves colim)
     where
       module α = Isoⁿ α

--- a/src/Cat/Diagram/Colimit/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Colimit/Coproduct.lagda.md
@@ -68,14 +68,14 @@ module _ {I : Type ℓ'} (i-is-grpd : is-groupoid I) (F : I → Ob) where
 
   is-colimit→is-indexed-coprduct
     : ∀ {K : Functor ⊤Cat C}
-    → {eps : Disc-adjunct {iss = i-is-grpd} F => K F∘ !F}
-    → is-lan !F (Disc-adjunct F) K eps
-    → is-indexed-coproduct C F (eps .η)
-  is-colimit→is-indexed-coprduct {K = K} {eps} colim = ic where
+    → {eta : Disc-adjunct {iss = i-is-grpd} F => K F∘ !F}
+    → is-lan !F (Disc-adjunct F) K eta
+    → is-indexed-coproduct C F (eta .η)
+  is-colimit→is-indexed-coprduct {K = K} {eta} colim = ic where
     module colim = is-colimit colim
-    open is-indexed-coproduct
+    open is-indexed-coproduct hiding (eta)
 
-    ic : is-indexed-coproduct C F (eps .η)
+    ic : is-indexed-coproduct C F (eta .η)
     ic .match k =
       colim.universal k
         (J (λ j p → k j ∘ subst (Hom (F _) ⊙ F) p id ≡ k _)

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -1,10 +1,12 @@
 <!--
 ```agda
+open import Cat.Functor.Naturality.Reflection
 open import Cat.Diagram.Pullback.Properties
 open import Cat.Functor.Adjoint.Continuous
 open import Cat.Instances.Shape.Terminal
 open import Cat.CartesianClosed.Locally
 open import Cat.Instances.Slice.Colimit
+open import Cat.Functor.Kan.Reflection
 open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Limit.Finite
 open import Cat.Instances.Shape.Join
@@ -302,16 +304,7 @@ repackaging data between "obviously isomorphic" functors.
 
 ```agda
   step2→1 : step2 → has-stable-colimits
-  step2→1 u f F {K} {eta} =
-      natural-isos→is-lan idni
-        (iso→isoⁿ (λ _ → C/.id-iso) (λ _ → ext id-comm))
-        (iso→⊤-natural-iso C/.id-iso)
-        (ext λ j → eliml (eliml (ap map ((Base-change pb f F∘ K) .F-id))) ∙ idr _)
-    ⊙ u _ _ α eq
-    ⊙ natural-isos→is-lan idni
-        (iso→isoⁿ (λ j → C/.id-iso) λ f → ext id-comm)
-        (iso→⊤-natural-iso C/.id-iso)
-        (ext λ j → eliml (idl _) ∙ idr _)
+  step2→1 u f F {K} {eta} = trivial-is-lan! ⊙ u _ _ α eq ⊙ trivial-is-lan!
     where
       α : cocone/→cocone▹ (Base-change pb f F∘ cocone→cocone▹ eta)
        => cocone/→cocone▹ (cocone→cocone▹ eta)
@@ -357,10 +350,7 @@ $\cC/X \to \cC$ both preserves and reflects colimits.
       prop-ext!
         (Forget/-preserves-colimits _ (J-colims _))
         (Forget/-reflects-colimits _)
-      ∙e natural-isos→lan-equiv idni
-        (iso→isoⁿ (λ _ → id-iso) (λ _ → id-comm))
-        (iso→⊤-natural-iso id-iso)
-        (ext λ j → eliml (idl _) ∙ idr _)
+      ∙e trivial-lan-equiv!
 
     step2≃3 : step2 ≃ step3
     step2≃3 = Π-cod≃ λ F → Π-cod≃ λ G → Π-cod≃ λ α → Π-cod≃ λ eq →
@@ -379,10 +369,7 @@ retracts onto $\cJ^\triangleright$.
       ▹-retract
         : (F : Functor (J ▹) C)
         → is-colimit▹ ((F F∘ ▹-join) F∘ ▹-in) ≃ is-colimit▹ F
-      ▹-retract F = natural-isos→lan-equiv idni
-        (iso→isoⁿ (λ _ → id-iso) (λ _ → id-comm))
-        (iso→⊤-natural-iso id-iso)
-        (ext λ j → eliml (idl _) ∙ idr _)
+      ▹-retract F = trivial-lan-equiv!
 
   step4→3 : has-universal-colimits → step3
   step4→3 u F G α eq = u _ _ (α ◂ ▹-in) (◂-equifibred ▹-in α eq)

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -22,6 +22,9 @@ open import Cat.Prelude
 open import Data.Sum
 
 import Cat.Reasoning
+
+open Functor
+open _=>_
 ```
 -->
 
@@ -96,14 +99,7 @@ module _ {oj ℓj oc ℓc}
   (C : Precategory oc ℓc)
   (pb : has-pullbacks C)
   where
-  open Cat.Reasoning C
-  open Functor
-  open _=>_
-  open /-Obj
-  open /-Hom
-  open is-pullback
-  private
-    module C/ {X} = Cat.Reasoning (Slice C X)
+  open Precategory C
 ```
 -->
 
@@ -136,68 +132,70 @@ otherwise restricts to $F$.
 
 <!--
 ```agda
-  module _ {oj ℓj oc ℓc} {J : Precategory oj ℓj} {C : Precategory oc ℓc} where
-    module C = Cat.Reasoning C
+module _ {oj ℓj oc ℓc} {J : Precategory oj ℓj} {C : Precategory oc ℓc} where
+  open Cat.Reasoning C
+  open /-Obj
+  open /-Hom
 ```
 -->
 
 ```agda
-    cocone→cocone▹
-      : ∀ {X} {F : Functor J C} → F => X F∘ !F → Functor (J ▹) C
-    cocone▹→cocone
-      : (F : Functor (J ▹) C) → F F∘ ▹-in => Const (F .F₀ (inr _))
+  cocone→cocone▹
+    : ∀ {X} {F : Functor J C} → F => X F∘ !F → Functor (J ▹) C
+  cocone▹→cocone
+    : (F : Functor (J ▹) C) → F F∘ ▹-in => Const (F .F₀ (inr _))
 
-    is-colimit▹ : Functor (J ▹) C → Type _
-    is-colimit▹ F = is-colimit (F F∘ ▹-in) (F .F₀ (inr _)) (cocone▹→cocone F)
+  is-colimit▹ : Functor (J ▹) C → Type _
+  is-colimit▹ F = is-colimit (F F∘ ▹-in) (F .F₀ (inr _)) (cocone▹→cocone F)
 ```
 
 Yet another way of describing a cocone with coapex $X$ is as a functor
 $\cJ \to \cC/X$ into the [[slice category]] over $X$:
 
 ```agda
-    cocone/→cocone▹
-      : ∀ {X} → Functor J (Slice C X) → Functor (J ▹) C
-    cocone▹→cocone/
-      : (F : Functor (J ▹) C) → Functor J (Slice C (F .F₀ (inr _)))
+  cocone/→cocone▹
+    : ∀ {X} → Functor J (Slice C X) → Functor (J ▹) C
+  cocone▹→cocone/
+    : (F : Functor (J ▹) C) → Functor J (Slice C (F .F₀ (inr _)))
 ```
 
 <details>
 <summary>The proofs are by simple data repackaging.</summary>
 
 ```agda
-    cocone→cocone▹ {X} {F} α .F₀ (inl j) = F .F₀ j
-    cocone→cocone▹ {X} {F} α .F₀ (inr tt) = X .F₀ _
-    cocone→cocone▹ {X} {F} α .F₁ {inl x} {inl y} (lift f) = F .F₁ f
-    cocone→cocone▹ {X} {F} α .F₁ {inl x} {inr tt} (lift f) = α .η x
-    cocone→cocone▹ {X} {F} α .F₁ {inr tt} {inr tt} (lift tt) = C.id
-    cocone→cocone▹ {X} {F} α .F-id {inl x} = F .F-id
-    cocone→cocone▹ {X} {F} α .F-id {inr x} = refl
-    cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inl y} {inl z} f g = F .F-∘ _ _
-    cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inl y} {inr z} f g =
-      sym (α .is-natural _ _ _ ∙ C.eliml (X .F-id))
-    cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inr y} {inr z} f g = sym (C.idl _)
-    cocone→cocone▹ {X} {F} α .F-∘ {inr x} {inr y} {inr z} f g = sym (C.idl _)
+  cocone→cocone▹ {X} {F} α .F₀ (inl j) = F .F₀ j
+  cocone→cocone▹ {X} {F} α .F₀ (inr tt) = X .F₀ _
+  cocone→cocone▹ {X} {F} α .F₁ {inl x} {inl y} (lift f) = F .F₁ f
+  cocone→cocone▹ {X} {F} α .F₁ {inl x} {inr tt} (lift f) = α .η x
+  cocone→cocone▹ {X} {F} α .F₁ {inr tt} {inr tt} (lift tt) = id
+  cocone→cocone▹ {X} {F} α .F-id {inl x} = F .F-id
+  cocone→cocone▹ {X} {F} α .F-id {inr x} = refl
+  cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inl y} {inl z} f g = F .F-∘ _ _
+  cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inl y} {inr z} f g =
+    sym (α .is-natural _ _ _ ∙ eliml (X .F-id))
+  cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inr y} {inr z} f g = sym (idl _)
+  cocone→cocone▹ {X} {F} α .F-∘ {inr x} {inr y} {inr z} f g = sym (idl _)
 
-    cocone▹→cocone F .η j = F .F₁ _
-    cocone▹→cocone F .is-natural x y f = sym (F .F-∘ _ _) ∙ sym (C.idl _)
+  cocone▹→cocone F .η j = F .F₁ _
+  cocone▹→cocone F .is-natural x y f = sym (F .F-∘ _ _) ∙ sym (idl _)
 
-    cocone/→cocone▹ F .F₀ (inl x) = F .F₀ x .domain
-    cocone/→cocone▹ {X} F .F₀ (inr _) = X
-    cocone/→cocone▹ F .F₁ {inl x} {inl y} (lift f) = F .F₁ f .map
-    cocone/→cocone▹ F .F₁ {inl x} {inr _} f = F .F₀ x .map
-    cocone/→cocone▹ F .F₁ {inr _} {inr _} f = C.id
-    cocone/→cocone▹ F .F-id {inl x} = ap map (F .F-id)
-    cocone/→cocone▹ F .F-id {inr _} = refl
-    cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inl z} f g = ap map (F .F-∘ _ _)
-    cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inr z} f (lift g) = sym (F .F₁ g .commutes)
-    cocone/→cocone▹ F .F-∘ {inl x} {inr y} {inr z} f g = sym (C.idl _)
-    cocone/→cocone▹ F .F-∘ {inr x} {inr y} {inr z} f g = sym (C.idl _)
+  cocone/→cocone▹ F .F₀ (inl x) = F .F₀ x .domain
+  cocone/→cocone▹ {X} F .F₀ (inr _) = X
+  cocone/→cocone▹ F .F₁ {inl x} {inl y} (lift f) = F .F₁ f .map
+  cocone/→cocone▹ F .F₁ {inl x} {inr _} f = F .F₀ x .map
+  cocone/→cocone▹ F .F₁ {inr _} {inr _} f = id
+  cocone/→cocone▹ F .F-id {inl x} = ap map (F .F-id)
+  cocone/→cocone▹ F .F-id {inr _} = refl
+  cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inl z} f g = ap map (F .F-∘ _ _)
+  cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inr z} f (lift g) = sym (F .F₁ g .commutes)
+  cocone/→cocone▹ F .F-∘ {inl x} {inr y} {inr z} f g = sym (idl _)
+  cocone/→cocone▹ F .F-∘ {inr x} {inr y} {inr z} f g = sym (idl _)
 
-    cocone▹→cocone/ F .F₀ j = cut {domain = F .F₀ (inl j)} (F .F₁ _)
-    cocone▹→cocone/ F .F₁ f .map = F .F₁ (lift f)
-    cocone▹→cocone/ F .F₁ f .commutes = sym (F .F-∘ _ _)
-    cocone▹→cocone/ F .F-id = ext (F .F-id)
-    cocone▹→cocone/ F .F-∘ f g = ext (F .F-∘ _ _)
+  cocone▹→cocone/ F .F₀ j = cut {domain = F .F₀ (inl j)} (F .F₁ _)
+  cocone▹→cocone/ F .F₁ f .map = F .F₁ (lift f)
+  cocone▹→cocone/ F .F₁ f .commutes = sym (F .F-∘ _ _)
+  cocone▹→cocone/ F .F-id = ext (F .F-id)
+  cocone▹→cocone/ F .F-∘ f g = ext (F .F-∘ _ _)
 ```
 </details>
 
@@ -207,7 +205,17 @@ for every equifibred natural transformation $\alpha : F \To G$ between
 diagrams $\cJ^\triangleright \to \cC$, if $G$ is colimiting then $F$ is
 colimiting.
 
+<!--
 ```agda
+module _ {oj ℓj oc ℓc}
+  (J : Precategory oj ℓj)
+  (C : Precategory oc ℓc)
+  where
+```
+-->
+
+```agda
+  has-universal-colimits : Type _
   has-universal-colimits =
     ∀ (F G : Functor (J ▹) C) (α : F => G) → is-equifibred α
     → is-colimit▹ G → is-colimit▹ F
@@ -246,10 +254,26 @@ $\cJ^\triangleright \to \cC/X$) is colimiting.
 \end{tikzcd}\]
 ~~~
 
+<!--
 ```agda
-  step2 =
-    ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
-    → is-colimit▹ (cocone▹→cocone/ G) → is-colimit▹ (cocone▹→cocone/ F)
+module _ {oj ℓj oc ℓc}
+  (J : Precategory oj ℓj)
+  (C : Precategory oc ℓc)
+  (pb : has-pullbacks C)
+  where
+  open Cat.Reasoning C
+  open /-Obj
+  open /-Hom
+  open is-pullback
+  private
+    module C/ {X} = Cat.Reasoning (Slice C X)
+```
+-->
+
+```agda
+    step2 =
+      ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
+      → is-colimit▹ (cocone▹→cocone/ G) → is-colimit▹ (cocone▹→cocone/ F)
 ```
 
 In the forwards direction, we use the uniqueness of pullbacks to
@@ -258,43 +282,43 @@ construct a natural isomorphism $f^* \circ G \cong F : \cJ^\triangleright
 colimits, we get that $F$ is colimiting.
 
 ```agda
-  step1→2 : has-stable-colimits → step2
-  step1→2 u F G α eq G-colim = F-colim where
-    f = α .η (inr _)
+    step1→2 : has-stable-colimits J C pb → step2
+    step1→2 u F G α eq G-colim = F-colim where
+      f = α .η (inr _)
 
-    f*G≅F : Base-change pb f F∘ cocone▹→cocone/ G F∘ ▹-in
-          ≅ⁿ cocone▹→cocone/ F F∘ ▹-in
-    f*G≅F = iso→isoⁿ
-      (λ j → C/.invertible→iso
-        (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
-                ; commutes = eq _ .p₁∘universal })
-        (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
-          (pb _ _ .Pullback.has-is-pb))))
-      λ f → ext (unique₂ (eq _)
-        {p = sym (pb _ _ .Pullback.square) ∙ pushl (G .F-∘ _ _)}
-        (pulll (sym (F .F-∘ _ _)) ∙ eq _ .p₁∘universal)
-        (pulll (α .is-natural _ _ _) ∙ pullr (eq _ .p₂∘universal))
-        (pulll (eq _ .p₁∘universal) ∙ pb _ _ .Pullback.p₂∘universal)
-        (pulll (eq _ .p₂∘universal) ∙ pb _ _ .Pullback.p₁∘universal))
+      f*G≅F : Base-change pb f F∘ cocone▹→cocone/ G F∘ ▹-in
+            ≅ⁿ cocone▹→cocone/ F F∘ ▹-in
+      f*G≅F = iso→isoⁿ
+        (λ j → C/.invertible→iso
+          (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
+                  ; commutes = eq _ .p₁∘universal })
+          (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
+            (pb _ _ .Pullback.has-is-pb))))
+        λ f → ext (unique₂ (eq _)
+          {p = sym (pb _ _ .Pullback.square) ∙ pushl (G .F-∘ _ _)}
+          (pulll (sym (F .F-∘ _ _)) ∙ eq _ .p₁∘universal)
+          (pulll (α .is-natural _ _ _) ∙ pullr (eq _ .p₂∘universal))
+          (pulll (eq _ .p₁∘universal) ∙ pb _ _ .Pullback.p₂∘universal)
+          (pulll (eq _ .p₂∘universal) ∙ pb _ _ .Pullback.p₁∘universal))
 
-    f*G-colim : preserves-lan (Base-change pb f) G-colim
-    f*G-colim = u f _ G-colim
+      f*G-colim : preserves-lan (Base-change pb f) G-colim
+      f*G-colim = u f _ G-colim
 
-    F-colim : is-colimit▹ (cocone▹→cocone/ F)
-    F-colim = natural-isos→is-lan idni
-      f*G≅F
-      (iso→⊤-natural-iso (C/.invertible→iso
-        (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
-                ; commutes = eq _ .p₁∘universal })
-        (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
-          (pb _ _ .Pullback.has-is-pb)))))
-      (ext λ j → (idl _ ⟩∘⟨refl) ∙ unique₂ (eq _)
-        {p = eq _ .square ∙ pushl (G .F-∘ _ _)}
-        (pulll (eq _ .p₁∘universal) ·· pulll (pb _ _ .Pullback.p₂∘universal) ·· pb _ _ .Pullback.p₂∘universal)
-        (pulll (eq _ .p₂∘universal) ·· pulll (pb _ _ .Pullback.p₁∘universal) ·· pullr (pb _ _ .Pullback.p₁∘universal))
-        (sym (F .F-∘ _ _))
-        (α .is-natural _ _ _))
-      f*G-colim
+      F-colim : is-colimit▹ (cocone▹→cocone/ F)
+      F-colim = natural-isos→is-lan idni
+        f*G≅F
+        (iso→⊤-natural-iso (C/.invertible→iso
+          (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
+                  ; commutes = eq _ .p₁∘universal })
+          (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
+            (pb _ _ .Pullback.has-is-pb)))))
+        (ext λ j → (idl _ ⟩∘⟨refl) ∙ unique₂ (eq _)
+          {p = eq _ .square ∙ pushl (G .F-∘ _ _)}
+          (pulll (eq _ .p₁∘universal) ·· pulll (pb _ _ .Pullback.p₂∘universal) ·· pb _ _ .Pullback.p₂∘universal)
+          (pulll (eq _ .p₂∘universal) ·· pulll (pb _ _ .Pullback.p₁∘universal) ·· pullr (pb _ _ .Pullback.p₁∘universal))
+          (sym (F .F-∘ _ _))
+          (α .is-natural _ _ _))
+        f*G-colim
 ```
 
 For the converse direction, we build a natural transformation from the
@@ -303,27 +327,27 @@ pullback of $G$ to $G$ and show that it is equifibred using the
 repackaging data between "obviously isomorphic" functors.
 
 ```agda
-  step2→1 : step2 → has-stable-colimits
-  step2→1 u f F {K} {eta} = trivial-is-lan! ⊙ u _ _ α eq ⊙ trivial-is-lan!
-    where
-      α : cocone/→cocone▹ (Base-change pb f F∘ cocone→cocone▹ eta)
-       => cocone/→cocone▹ (cocone→cocone▹ eta)
-      α .η (inl j) = pb _ _ .Pullback.p₁
-      α .η (inr _) = f
-      α .is-natural (inl x) (inl y) g = pb _ _ .Pullback.p₁∘universal
-      α .is-natural (inl x) (inr _) g = sym (pb _ _ .Pullback.square)
-      α .is-natural (inr _) (inr _) g = id-comm
+    step2→1 : step2 → has-stable-colimits J C pb
+    step2→1 u f F {K} {eta} = trivial-is-lan! ⊙ u _ _ α eq ⊙ trivial-is-lan!
+      where
+        α : cocone/→cocone▹ (Base-change pb f F∘ cocone→cocone▹ eta)
+         => cocone/→cocone▹ (cocone→cocone▹ eta)
+        α .η (inl j) = pb _ _ .Pullback.p₁
+        α .η (inr _) = f
+        α .is-natural (inl x) (inl y) g = pb _ _ .Pullback.p₁∘universal
+        α .is-natural (inl x) (inr _) g = sym (pb _ _ .Pullback.square)
+        α .is-natural (inr _) (inr _) g = id-comm
 
-      eq : is-equifibred α
-      eq {inl x} {inl y} (lift g) = pasting-outer→left-is-pullback
-        (rotate-pullback (pb _ _ .Pullback.has-is-pb))
-        (subst₂ (λ x y → is-pullback C x f (pb _ _ .Pullback.p₁) y)
-          (sym ((Base-change pb f F∘ cocone→cocone▹ eta) .F₁ g .commutes))
-          (sym (cocone→cocone▹ eta .F₁ g .commutes))
-          (rotate-pullback (pb _ _ .Pullback.has-is-pb)))
-        (α .is-natural (inl x) (inl y) (lift g))
-      eq {inl x} {inr _} g = rotate-pullback (pb _ _ .Pullback.has-is-pb)
-      eq {inr _} {inr _} g = id-is-pullback
+        eq : is-equifibred α
+        eq {inl x} {inl y} (lift g) = pasting-outer→left-is-pullback
+          (rotate-pullback (pb _ _ .Pullback.has-is-pb))
+          (subst₂ (λ x y → is-pullback C x f (pb _ _ .Pullback.p₁) y)
+            (sym ((Base-change pb f F∘ cocone→cocone▹ eta) .F₁ g .commutes))
+            (sym (cocone→cocone▹ eta .F₁ g .commutes))
+            (rotate-pullback (pb _ _ .Pullback.has-is-pb)))
+          (α .is-natural (inl x) (inl y) (lift g))
+        eq {inl x} {inr _} g = rotate-pullback (pb _ _ .Pullback.has-is-pb)
+        eq {inr _} {inr _} g = id-is-pullback
 ```
 
 Next, we prove that this is equivalent to requiring that the top
@@ -332,9 +356,9 @@ diagram $\cJ^\triangleright \to \cC$ is colimiting, disregarding
 the $X \to Y$ part entirely.
 
 ```agda
-  step3 =
-    ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
-    → is-colimit▹ (G F∘ ▹-in) → is-colimit▹ (F F∘ ▹-in)
+    step3 =
+      ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
+      → is-colimit▹ (G F∘ ▹-in) → is-colimit▹ (F F∘ ▹-in)
 ```
 
 This follows from the characterisation of [[colimits in slice categories]]:
@@ -342,19 +366,19 @@ assuming that all $\cJ$-colimits exist in $\cC$, the forgetful functor
 $\cC/X \to \cC$ both preserves and reflects colimits.
 
 ```agda
-  module _ (J-colims : ∀ (F : Functor J C) → Colimit F) where
-    colim/≃colim
-      : (F : Functor (J ▹ ▹) C)
-      → is-colimit▹ (cocone▹→cocone/ F) ≃ is-colimit▹ (F F∘ ▹-in)
-    colim/≃colim F =
-      prop-ext!
-        (Forget/-preserves-colimits _ (J-colims _))
-        (Forget/-reflects-colimits _)
-      ∙e trivial-lan-equiv!
+    module _ (J-colims : ∀ (F : Functor J C) → Colimit F) where
+      colim/≃colim
+        : (F : Functor (J ▹ ▹) C)
+        → is-colimit▹ (cocone▹→cocone/ F) ≃ is-colimit▹ (F F∘ ▹-in)
+      colim/≃colim F =
+        prop-ext!
+          (Forget/-preserves-colimits _ (J-colims _))
+          (Forget/-reflects-colimits _)
+        ∙e trivial-lan-equiv!
 
-    step2≃3 : step2 ≃ step3
-    step2≃3 = Π-cod≃ λ F → Π-cod≃ λ G → Π-cod≃ λ α → Π-cod≃ λ eq →
-      function≃ (colim/≃colim G) (colim/≃colim F)
+      step2≃3 : step2 ≃ step3
+      step2≃3 = Π-cod≃ λ F → Π-cod≃ λ G → Π-cod≃ λ α → Π-cod≃ λ eq →
+        function≃ (colim/≃colim G) (colim/≃colim F)
 ```
 
 Finally, we show that this is equivalent to $\cC$ having universal colimits.
@@ -362,17 +386,17 @@ This follows easily by noticing that $\cJ^{\triangleright\triangleright}$
 retracts onto $\cJ^\triangleright$.
 
 ```agda
-  step3→4 : step3 → has-universal-colimits
-  step3→4 u F G α eq = Equiv.to (function≃ (▹-retract G) (▹-retract F))
-    (u _ _ (α ◂ ▹-join) (◂-equifibred ▹-join α eq))
-    where
-      ▹-retract
-        : (F : Functor (J ▹) C)
-        → is-colimit▹ ((F F∘ ▹-join) F∘ ▹-in) ≃ is-colimit▹ F
-      ▹-retract F = trivial-lan-equiv!
+    step3→4 : step3 → has-universal-colimits J C
+    step3→4 u F G α eq = Equiv.to (function≃ (▹-retract G) (▹-retract F))
+      (u _ _ (α ◂ ▹-join) (◂-equifibred ▹-join α eq))
+      where
+        ▹-retract
+          : (F : Functor (J ▹) C)
+          → is-colimit▹ ((F F∘ ▹-join) F∘ ▹-in) ≃ is-colimit▹ F
+        ▹-retract F = trivial-lan-equiv!
 
-  step4→3 : has-universal-colimits → step3
-  step4→3 u F G α eq = u _ _ (α ◂ ▹-in) (◂-equifibred ▹-in α eq)
+    step4→3 : has-universal-colimits J C → step3
+    step4→3 u F G α eq = u _ _ (α ◂ ▹-in) (◂-equifibred ▹-in α eq)
 ```
 
 This concludes our equivalence.
@@ -380,7 +404,7 @@ This concludes our equivalence.
 ```agda
   stable≃universal
     : (∀ (F : Functor J C) → Colimit F)
-    → has-stable-colimits ≃ has-universal-colimits
+    → has-stable-colimits J C pb ≃ has-universal-colimits J C
   stable≃universal J-colims =
        prop-ext! step1→2 step2→1
     ∙e step2≃3 J-colims

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -328,7 +328,7 @@ repackaging data between "obviously isomorphic" functors.
 
 ```agda
     step2→1 : step2 → has-stable-colimits J C pb
-    step2→1 u f F {K} {eta} = trivial-is-lan! ⊙ u _ _ α eq ⊙ trivial-is-lan!
+    step2→1 u f F {K} {eta} = trivial-is-colimit! ⊙ u _ _ α eq ⊙ trivial-is-colimit!
       where
         α : cocone/→cocone▹ (Base-change pb f F∘ cocone→cocone▹ eta)
          => cocone/→cocone▹ (cocone→cocone▹ eta)
@@ -374,7 +374,7 @@ $\cC/X \to \cC$ both preserves and reflects colimits.
         prop-ext!
           (Forget/-preserves-colimits _ (J-colims _))
           (Forget/-reflects-colimits _)
-        ∙e trivial-lan-equiv!
+        ∙e trivial-colimit-equiv!
 
       step2≃3 : step2 ≃ step3
       step2≃3 = Π-cod≃ λ F → Π-cod≃ λ G → Π-cod≃ λ α → Π-cod≃ λ eq →
@@ -393,7 +393,7 @@ retracts onto $\cJ^\triangleright$.
         ▹-retract
           : (F : Functor (J ▹) C)
           → is-colimit▹ ((F F∘ ▹-join) F∘ ▹-in) ≃ is-colimit▹ F
-        ▹-retract F = trivial-lan-equiv!
+        ▹-retract F = trivial-colimit-equiv!
 
     step4→3 : has-universal-colimits J C → step3
     step4→3 u F G α eq = u _ _ (α ◂ ▹-in) (◂-equifibred ▹-in α eq)

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -1,0 +1,423 @@
+<!--
+```agda
+open import Cat.Diagram.Pullback.Properties
+open import Cat.Functor.Adjoint.Continuous
+open import Cat.Instances.Shape.Terminal
+open import Cat.CartesianClosed.Locally
+open import Cat.Instances.Slice.Colimit
+open import Cat.Diagram.Colimit.Base
+open import Cat.Diagram.Limit.Finite
+open import Cat.Instances.Shape.Join
+open import Cat.Functor.Kan.Unique
+open import Cat.Functor.Naturality
+open import Cat.Diagram.Pullback
+open import Cat.Functor.Kan.Base
+open import Cat.Functor.Pullback
+open import Cat.Functor.Compose
+open import Cat.Instances.Slice
+open import Cat.Prelude
+
+open import Data.Sum
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Diagram.Colimit.Universal where
+```
+
+# Universal colimits {defines="universal-colimit pullback-stable-colimit"}
+
+A [[colimit]] in a category $\cC$ with [[pullbacks]] is said to be
+**universal**, or **stable under pullback**, if it is preserved under
+[[base change|pullback functor]].
+
+There are multiple ways to make this precise. First, we might consider
+pulling back a colimiting cocone --- say, for the sake of concreteness,
+a coproduct diagram $A \to A + B \ot B$ --- along some morphism $f : X \to A + B$:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {f^* A} & X & {f^* B} \\
+  A & {A+B} & B
+  \arrow[from=1-1, to=1-2]
+  \arrow[from=1-1, to=2-1]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-1, to=2-2]
+  \arrow["f", from=1-2, to=2-2]
+  \arrow[from=1-3, to=1-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125, rotate=-90}, draw=none, from=1-3, to=2-2]
+  \arrow[from=1-3, to=2-3]
+  \arrow[from=2-1, to=2-2]
+  \arrow[from=2-3, to=2-2]
+\end{tikzcd}\]
+~~~
+
+We say that the bottom colimit is **universal** if the top
+cocone $f^* A \to X \ot f^* B$ is also colimiting for all $f$.
+
+Alternatively, we might consider pulling back a colimiting cocone in $\cC/Y$
+along some morphism $f : X \to Y$ like so:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {f^* A} & {f^*(A + B)} & {f^* B} \\
+  & X \\
+  & Y \\
+  A & {A+B} & B
+  \arrow[from=1-1, to=1-2]
+  \arrow[from=1-1, to=2-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-1, to=3-2]
+  \arrow[from=1-1, to=4-1]
+  \arrow[from=1-2, to=2-2]
+  \arrow[from=1-3, to=1-2]
+  \arrow[from=1-3, to=2-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125, rotate=-90}, draw=none, from=1-3, to=3-2]
+  \arrow[from=1-3, to=4-3]
+  \arrow["f", from=2-2, to=3-2]
+  \arrow[from=4-1, to=3-2]
+  \arrow[from=4-1, to=4-2]
+  \arrow[from=4-2, to=3-2]
+  \arrow[from=4-3, to=3-2]
+  \arrow[from=4-3, to=4-2]
+\end{tikzcd}\]
+~~~
+
+In this case, we say that the colimit is **stable under pullback** if
+the top diagram is colimiting in $\cC/X$, which amounts to saying that every
+[[pullback functor]] $f^* : \cC/Y \to \cC/X$ preserves this colimit.
+
+<!--
+```agda
+module _ {oj ℓj oc ℓc}
+  (J : Precategory oj ℓj)
+  (C : Precategory oc ℓc)
+  (pb : has-pullbacks C)
+  where
+  open Cat.Reasoning C
+  open Functor
+  open _=>_
+  open /-Obj
+  open /-Hom
+  open is-pullback
+  private
+    module C/ {X} = Cat.Reasoning (Slice C X)
+```
+-->
+
+```agda
+  has-stable-colimits : Type _
+  has-stable-colimits =
+    ∀ {X Y} (f : Hom X Y) (F : Functor J (Slice C Y))
+    → preserves-colimit (Base-change pb f) F
+```
+
+::: note
+This definition makes sense even if not all pullback functors exist; however,
+for the sake of simplicity, we assume that $\cC$ has all pullbacks.
+:::
+
+## Universality vs. pullback-stability
+
+If $\cC$ has all colimits of shape $\cJ$, we can show that the two
+notions are equivalent.
+
+::: source
+This is essentially a 1-categorical version of the proof of lemma 6.1.3.3
+in Higher Topos Theory [@HTT].
+:::
+
+We start by noticing that a cocone under $F$ with coapex $X$ in $\cC$ can
+equivalently be described as a functor $\cJ^\triangleright \to \cC$ that
+sends the [[adjoined terminal object]] of $\cJ^\triangleright$ to $X$ and
+otherwise restricts to $F$.
+
+<!--
+```agda
+  module _ {oj ℓj oc ℓc} {J : Precategory oj ℓj} {C : Precategory oc ℓc} where
+    module C = Cat.Reasoning C
+```
+-->
+
+```agda
+    cocone→cocone▹
+      : ∀ {X} {F : Functor J C} → F => X F∘ !F → Functor (J ▹) C
+    cocone▹→cocone
+      : (F : Functor (J ▹) C) → F F∘ ▹-in => Const (F .F₀ (inr _))
+
+    is-colimit▹ : Functor (J ▹) C → Type _
+    is-colimit▹ F = is-colimit (F F∘ ▹-in) (F .F₀ (inr _)) (cocone▹→cocone F)
+```
+
+Yet another way of describing a cocone with coapex $X$ is as a functor
+$\cJ \to \cC/X$ into the [[slice category]] over $X$:
+
+```agda
+    cocone/→cocone▹
+      : ∀ {X} → Functor J (Slice C X) → Functor (J ▹) C
+    cocone▹→cocone/
+      : (F : Functor (J ▹) C) → Functor J (Slice C (F .F₀ (inr _)))
+```
+
+<details>
+<summary>The proofs are by simple data repackaging.</summary>
+
+```agda
+    cocone→cocone▹ {X} {F} α .F₀ (inl j) = F .F₀ j
+    cocone→cocone▹ {X} {F} α .F₀ (inr tt) = X .F₀ _
+    cocone→cocone▹ {X} {F} α .F₁ {inl x} {inl y} (lift f) = F .F₁ f
+    cocone→cocone▹ {X} {F} α .F₁ {inl x} {inr tt} (lift f) = α .η x
+    cocone→cocone▹ {X} {F} α .F₁ {inr tt} {inr tt} (lift tt) = C.id
+    cocone→cocone▹ {X} {F} α .F-id {inl x} = F .F-id
+    cocone→cocone▹ {X} {F} α .F-id {inr x} = refl
+    cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inl y} {inl z} f g = F .F-∘ _ _
+    cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inl y} {inr z} f g =
+      sym (α .is-natural _ _ _ ∙ C.eliml (X .F-id))
+    cocone→cocone▹ {X} {F} α .F-∘ {inl x} {inr y} {inr z} f g = sym (C.idl _)
+    cocone→cocone▹ {X} {F} α .F-∘ {inr x} {inr y} {inr z} f g = sym (C.idl _)
+
+    cocone▹→cocone F .η j = F .F₁ _
+    cocone▹→cocone F .is-natural x y f = sym (F .F-∘ _ _) ∙ sym (C.idl _)
+
+    cocone/→cocone▹ F .F₀ (inl x) = F .F₀ x .domain
+    cocone/→cocone▹ {X} F .F₀ (inr _) = X
+    cocone/→cocone▹ F .F₁ {inl x} {inl y} (lift f) = F .F₁ f .map
+    cocone/→cocone▹ F .F₁ {inl x} {inr _} f = F .F₀ x .map
+    cocone/→cocone▹ F .F₁ {inr _} {inr _} f = C.id
+    cocone/→cocone▹ F .F-id {inl x} = ap map (F .F-id)
+    cocone/→cocone▹ F .F-id {inr _} = refl
+    cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inl z} f g = ap map (F .F-∘ _ _)
+    cocone/→cocone▹ F .F-∘ {inl x} {inl y} {inr z} f (lift g) = sym (F .F₁ g .commutes)
+    cocone/→cocone▹ F .F-∘ {inl x} {inr y} {inr z} f g = sym (C.idl _)
+    cocone/→cocone▹ F .F-∘ {inr x} {inr y} {inr z} f g = sym (C.idl _)
+
+    cocone▹→cocone/ F .F₀ j = cut {domain = F .F₀ (inl j)} (F .F₁ _)
+    cocone▹→cocone/ F .F₁ f .map = F .F₁ (lift f)
+    cocone▹→cocone/ F .F₁ f .commutes = sym (F .F-∘ _ _)
+    cocone▹→cocone/ F .F-id = ext (F .F-id)
+    cocone▹→cocone/ F .F-∘ f g = ext (F .F-∘ _ _)
+```
+</details>
+
+Using this language, we can define what it means for $\cC$
+to have universal colimits in the sense of the first diagram above:
+for every equifibred natural transformation $\alpha : F \To G$ between
+diagrams $\cJ^\triangleright \to \cC$, if $G$ is colimiting then $F$ is
+colimiting.
+
+```agda
+  has-universal-colimits =
+    ∀ (F G : Functor (J ▹) C) (α : F => G) → is-equifibred α
+    → is-colimit▹ G → is-colimit▹ F
+```
+
+We will establish the equivalence between pullback-stable and universal
+colimits in several steps. First, we show that pullback-stability is
+equivalent to the following condition: for every diagram as below, that
+is, for every [[equifibred]] natural transformation $\alpha : F \To G$
+between diagrams $F, G : \cJ^{\triangleright\triangleright} \to \cC$,
+if the bottom diagram $G$ (seen as a diagram $\cJ^\triangleright \to
+\cC/Y$) is colimiting, then the top diagram $F$ (seen as a diagram
+$\cJ^\triangleright \to \cC/X$) is colimiting.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  U & W & V \\
+  & X \\
+  & Y \\
+  A & C & B
+  \arrow[from=1-1, to=1-2]
+  \arrow[from=1-1, to=2-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-1, to=3-2]
+  \arrow[from=1-1, to=4-1]
+  \arrow[from=1-2, to=2-2]
+  \arrow[from=1-3, to=1-2]
+  \arrow[from=1-3, to=2-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125, rotate=-90}, draw=none, from=1-3, to=3-2]
+  \arrow[from=1-3, to=4-3]
+  \arrow["f", from=2-2, to=3-2]
+  \arrow[from=4-1, to=3-2]
+  \arrow[from=4-1, to=4-2]
+  \arrow[from=4-2, to=3-2]
+  \arrow[from=4-3, to=3-2]
+  \arrow[from=4-3, to=4-2]
+\end{tikzcd}\]
+~~~
+
+```agda
+  step2 =
+    ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
+    → is-colimit▹ (cocone▹→cocone/ G) → is-colimit▹ (cocone▹→cocone/ F)
+```
+
+In the forwards direction, we use the uniqueness of pullbacks to
+construct a natural isomorphism $f^* \circ G \cong F : \cJ^\triangleright
+\to \cC/X$; since the pullback functor $f^*$ is assumed to preserve
+colimits, we get that $F$ is colimiting.
+
+```agda
+  step1→2 : has-stable-colimits → step2
+  step1→2 u F G α eq G-colim = F-colim where
+    f = α .η (inr _)
+
+    f*G≅F : Base-change pb f F∘ cocone▹→cocone/ G F∘ ▹-in
+          ≅ⁿ cocone▹→cocone/ F F∘ ▹-in
+    f*G≅F = iso→isoⁿ
+      (λ j → C/.invertible→iso
+        (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
+                ; commutes = eq _ .p₁∘universal })
+        (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
+          (pb _ _ .Pullback.has-is-pb))))
+      λ f → ext (unique₂ (eq _)
+        {p = sym (pb _ _ .Pullback.square) ∙ pushl (G .F-∘ _ _)}
+        (pulll (sym (F .F-∘ _ _)) ∙ eq _ .p₁∘universal)
+        (pulll (α .is-natural _ _ _) ∙ pullr (eq _ .p₂∘universal))
+        (pulll (eq _ .p₁∘universal) ∙ pb _ _ .Pullback.p₂∘universal)
+        (pulll (eq _ .p₂∘universal) ∙ pb _ _ .Pullback.p₁∘universal))
+
+    f*G-colim : preserves-lan (Base-change pb f) G-colim
+    f*G-colim = u f _ G-colim
+
+    F-colim : is-colimit▹ (cocone▹→cocone/ F)
+    F-colim = natural-isos→is-lan idni
+      f*G≅F
+      (iso→⊤-natural-iso (C/.invertible→iso
+        (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
+                ; commutes = eq _ .p₁∘universal })
+        (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
+          (pb _ _ .Pullback.has-is-pb)))))
+      (ext λ j → (idl _ ⟩∘⟨refl) ∙ unique₂ (eq _)
+        {p = eq _ .square ∙ pushl (G .F-∘ _ _)}
+        (pulll (eq _ .p₁∘universal) ·· pulll (pb _ _ .Pullback.p₂∘universal) ·· pb _ _ .Pullback.p₂∘universal)
+        (pulll (eq _ .p₂∘universal) ·· pulll (pb _ _ .Pullback.p₁∘universal) ·· pullr (pb _ _ .Pullback.p₁∘universal))
+        (sym (F .F-∘ _ _))
+        (α .is-natural _ _ _))
+      f*G-colim
+```
+
+For the converse direction, we build a natural transformation from the
+pullback of $G$ to $G$ and show that it is equifibred using the
+[[pasting law for pullbacks]]. The rest of the proof consists in
+repackaging data between "obviously isomorphic" functors.
+
+```agda
+  step2→1 : step2 → has-stable-colimits
+  step2→1 u f F {K} {eta} =
+      natural-isos→is-lan idni
+        (iso→isoⁿ (λ _ → C/.id-iso) (λ _ → ext id-comm))
+        (iso→⊤-natural-iso C/.id-iso)
+        (ext λ j → eliml (eliml (ap map ((Base-change pb f F∘ K) .F-id))) ∙ idr _)
+    ⊙ u _ _ α eq
+    ⊙ natural-isos→is-lan idni
+        (iso→isoⁿ (λ j → C/.id-iso) λ f → ext id-comm)
+        (iso→⊤-natural-iso C/.id-iso)
+        (ext λ j → eliml (idl _) ∙ idr _)
+    where
+      α : cocone/→cocone▹ (Base-change pb f F∘ cocone→cocone▹ eta)
+       => cocone/→cocone▹ (cocone→cocone▹ eta)
+      α .η (inl j) = pb _ _ .Pullback.p₁
+      α .η (inr _) = f
+      α .is-natural (inl x) (inl y) g = pb _ _ .Pullback.p₁∘universal
+      α .is-natural (inl x) (inr _) g = sym (pb _ _ .Pullback.square)
+      α .is-natural (inr _) (inr _) g = id-comm
+
+      eq : is-equifibred α
+      eq {inl x} {inl y} (lift g) = pasting-outer→left-is-pullback
+        (rotate-pullback (pb _ _ .Pullback.has-is-pb))
+        (subst₂ (λ x y → is-pullback C x f (pb _ _ .Pullback.p₁) y)
+          (sym ((Base-change pb f F∘ cocone→cocone▹ eta) .F₁ g .commutes))
+          (sym (cocone→cocone▹ eta .F₁ g .commutes))
+          (rotate-pullback (pb _ _ .Pullback.has-is-pb)))
+        (α .is-natural (inl x) (inl y) (lift g))
+      eq {inl x} {inr _} g = rotate-pullback (pb _ _ .Pullback.has-is-pb)
+      eq {inr _} {inr _} g = id-is-pullback
+```
+
+Next, we prove that this is equivalent to requiring that the top
+diagram $\cJ^\triangleright \to \cC$ be colimiting if the bottom
+diagram $\cJ^\triangleright \to \cC$ is colimiting, disregarding
+the $X \to Y$ part entirely.
+
+```agda
+  step3 =
+    ∀ (F G : Functor (J ▹ ▹) C) (α : F => G) → is-equifibred α
+    → is-colimit▹ (G F∘ ▹-in) → is-colimit▹ (F F∘ ▹-in)
+```
+
+This follows from the characterisation of [[colimits in slice categories]]:
+assuming that all $\cJ$-colimits exist in $\cC$, the forgetful functor
+$\cC/X \to \cC$ both preserves and reflects colimits.
+
+```agda
+  module _ (J-colims : ∀ (F : Functor J C) → Colimit F) where
+    colim/≃colim
+      : (F : Functor (J ▹ ▹) C)
+      → is-colimit▹ (cocone▹→cocone/ F) ≃ is-colimit▹ (F F∘ ▹-in)
+    colim/≃colim F =
+      prop-ext!
+        (Forget/-preserves-colimits _ (J-colims _))
+        (Forget/-reflects-colimits _)
+      ∙e natural-isos→lan-equiv idni
+        (iso→isoⁿ (λ _ → id-iso) (λ _ → id-comm))
+        (iso→⊤-natural-iso id-iso)
+        (ext λ j → eliml (idl _) ∙ idr _)
+
+    step2≃3 : step2 ≃ step3
+    step2≃3 = Π-cod≃ λ F → Π-cod≃ λ G → Π-cod≃ λ α → Π-cod≃ λ eq →
+      function≃ (colim/≃colim G) (colim/≃colim F)
+```
+
+Finally, we show that this is equivalent to $\cC$ having universal colimits.
+This follows easily by noticing that $\cJ^{\triangleright\triangleright}$
+retracts onto $\cJ^\triangleright$.
+
+```agda
+  step3→4 : step3 → has-universal-colimits
+  step3→4 u F G α eq = Equiv.to (function≃ (▹-retract G) (▹-retract F))
+    (u _ _ (α ◂ ▹-join) (◂-equifibred ▹-join α eq))
+    where
+      ▹-retract
+        : (F : Functor (J ▹) C)
+        → is-colimit▹ ((F F∘ ▹-join) F∘ ▹-in) ≃ is-colimit▹ F
+      ▹-retract F = natural-isos→lan-equiv idni
+        (iso→isoⁿ (λ _ → id-iso) (λ _ → id-comm))
+        (iso→⊤-natural-iso id-iso)
+        (ext λ j → eliml (idl _) ∙ idr _)
+
+  step4→3 : has-universal-colimits → step3
+  step4→3 u F G α eq = u _ _ (α ◂ ▹-in) (◂-equifibred ▹-in α eq)
+```
+
+This concludes our equivalence.
+
+```agda
+  stable≃universal
+    : (∀ (F : Functor J C) → Colimit F)
+    → has-stable-colimits ≃ has-universal-colimits
+  stable≃universal J-colims =
+       prop-ext! step1→2 step2→1
+    ∙e step2≃3 J-colims
+    ∙e prop-ext! step3→4 step4→3
+```
+
+## Examples
+
+As a general class of examples, any [[locally cartesian closed category]]
+has pullback-stable colimits, because the pullback functor has a [[right
+adjoint]] and therefore preserves colimits.
+
+<!--
+```agda
+module _ {o ℓ} {C : Precategory o ℓ} (lcc : Locally-cartesian-closed C) where
+  open Locally-cartesian-closed lcc
+  open Finitely-complete has-is-lex
+```
+-->
+
+```agda
+  lcc→stable-colimits
+    : ∀ {oj ℓj} {J : Precategory oj ℓj}
+    → has-stable-colimits J C pullbacks
+  lcc→stable-colimits f F = left-adjoint-is-cocontinuous
+    (lcc→pullback⊣dependent-product C lcc f)
+```

--- a/src/Cat/Diagram/Duals.lagda.md
+++ b/src/Cat/Diagram/Duals.lagda.md
@@ -57,7 +57,7 @@ $C\op$. We prove these correspondences here:
       ; unique     = isp.unique
       }
     where module isp = is-product isp
-  
+
   is-coproduct→is-co-product
     : ∀ {A B P} {i1 : C.Hom A P} {i2 : C.Hom B P}
     → is-coproduct C i1 i2 → is-product (C ^op) i1 i2
@@ -85,7 +85,7 @@ $C\op$. We prove these correspondences here:
       ; unique     = eq.unique
       }
     where module eq = is-equaliser eq
-  
+
   is-coequaliser→is-co-equaliser
     : ∀ {A B E} {f g : C.Hom A B} {coeq : C.Hom B E}
     → is-coequaliser C f g coeq → is-equaliser (C ^op) f g coeq
@@ -104,19 +104,19 @@ $C\op$. We prove these correspondences here:
 ```agda
   open Terminal
   open Initial
-  
+
   is-coterminal→is-initial
     : ∀ {A} → is-terminal (C ^op) A → is-initial C A
   is-coterminal→is-initial x = x
-  
+
   is-initial→is-coterminal
     : ∀ {A} → is-initial C A → is-terminal (C ^op) A
   is-initial→is-coterminal x = x
-  
+
   Coterminal→Initial : Terminal (C ^op) → Initial C
   Coterminal→Initial term .bot = term .top
   Coterminal→Initial term .has⊥ = is-coterminal→is-initial (term .has⊤)
-  
+
   Initial→Coterminal : Initial C → Terminal (C ^op)
   Initial→Coterminal init .top = init .bot
   Initial→Coterminal init .has⊤ = is-initial→is-coterminal (init .has⊥)
@@ -137,7 +137,7 @@ $C\op$. We prove these correspondences here:
       ; unique = pb.unique
       }
     where module pb = is-pullback pb
-  
+
   is-pushout→is-co-pullback
     : ∀ {P X Y Z} {p1 : C.Hom X P} {f : C.Hom Z X} {p2 : C.Hom Y P} {g : C.Hom Z Y}
     → is-pushout C f p1 g p2 → is-pullback (C ^op) p1 f p2 g
@@ -157,39 +157,39 @@ $C\op$. We prove these correspondences here:
 ```agda
   module _ {o ℓ} {J : Precategory o ℓ} {F : Functor J C} where
     open Functor F renaming (op to F^op)
-  
+
     open Cocone-hom
     open Cone-hom
     open Cocone
     open Cone
-  
+
     Co-cone→Cocone : Cone F^op → Cocone F
     Co-cone→Cocone cone .coapex = cone .apex
     Co-cone→Cocone cone .ψ = cone .ψ
     Co-cone→Cocone cone .commutes = cone .commutes
-  
+
     Cocone→Co-cone : Cocone F → Cone F^op
     Cocone→Co-cone cone .apex     = cone .coapex
     Cocone→Co-cone cone .ψ        = cone .ψ
     Cocone→Co-cone cone .commutes = cone .commutes
-  
+
     Cocone→Co-cone→Cocone : ∀ K → Co-cone→Cocone (Cocone→Co-cone K) ≡ K
     Cocone→Co-cone→Cocone K i .coapex = K .coapex
     Cocone→Co-cone→Cocone K i .ψ = K .ψ
     Cocone→Co-cone→Cocone K i .commutes = K .commutes
-  
+
     Co-cone→Cocone→Co-cone : ∀ K → Cocone→Co-cone (Co-cone→Cocone K) ≡ K
     Co-cone→Cocone→Co-cone K i .apex = K .apex
     Co-cone→Cocone→Co-cone K i .ψ = K .ψ
     Co-cone→Cocone→Co-cone K i .commutes = K .commutes
-  
+
     Co-cone-hom→Cocone-hom
       : ∀ {x y}
       → Cone-hom F^op y x
       → Cocone-hom F (Co-cone→Cocone x) (Co-cone→Cocone y)
     Co-cone-hom→Cocone-hom ch .hom = ch .hom
     Co-cone-hom→Cocone-hom ch .commutes o = ch .commutes o
-  
+
     Cocone-hom→Co-cone-hom
       : ∀ {x y}
       → Cocone-hom F x y
@@ -214,20 +214,20 @@ We could work around this, but it's easier to just do the proofs by hand.
     Colimit→Co-limit colim = to-limit (to-is-limit ml) where
       module colim = Colimit colim
       open make-is-limit
-  
+
       ml : make-is-limit F^op colim.coapex
       ml .ψ = colim.ψ
       ml .commutes = colim.commutes
-      ml .universal eta p = colim.universal eta p
-      ml .factors eta p = colim.factors eta p
-      ml .unique eta p other q = colim.unique eta p other q
-  
+      ml .universal eps p = colim.universal eps p
+      ml .factors eps p = colim.factors eps p
+      ml .unique eps p other q = colim.unique eps p other q
+
     Co-limit→Colimit
       : Limit F^op → Colimit F
     Co-limit→Colimit lim = to-colimit (to-is-colimit mc) where
       module lim = Limit lim
       open make-is-colimit
-  
+
       mc : make-is-colimit F lim.apex
       mc .ψ = lim.ψ
       mc .commutes = lim.commutes

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -663,7 +663,7 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 ```
 
 
-# Preservation of limits
+# Preservation of limits {defines="preserved-limit"}
 
 <!--
 ```agda
@@ -697,7 +697,7 @@ object! Any limit is as good as any other.
     → preserves-ran F lim
 ```
 
-## Reflection of limits
+## Reflection of limits {defines="reflected-limit"}
 
 Using the terminology from before, we say a functor **reflects limits**
 if it *only* takes *limiting* cones "upstairs" to limiting cones "downstairs":

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -99,7 +99,7 @@ Luckily, we can! If we take a step back, we can notice that we are
 trying to construct a map into a functor. What are maps into functors?
 Natural transformations! Concretely, let $D : \cJ \to \cC$ be some
 diagram.  We can encode the same data as a cone in a natural
-transformation $\eta : {!x} \circ \mathord{!} \to D$, where $!x : \top
+transformation $\eps : {!x} \circ \mathord{!} \to D$, where $!x : \top
 \to \cC$ denotes the constant functor that maps object to $x$ and every
 morphism to $id$, and $! : \cJ \to \top$ denotes the unique functor into
 the [[terminal category]]. The components of such a natural
@@ -115,13 +115,13 @@ diagram. We can describe this situation diagrammatically like so:
   \arrow[from=3-1, to=1-3]
   \arrow["{!X}"', from=1-3, to=3-5]
   \arrow[""{name=0, anchor=center, inner sep=0}, from=3-1, to=3-5]
-  \arrow["\eta"{description}, shorten <=4pt, shorten >=4pt, Rightarrow, from=1-3, to=0]
+  \arrow["\eps"{description}, shorten <=4pt, shorten >=4pt, Rightarrow, from=1-3, to=0]
 \end{tikzcd}
 ~~~
 
 All that remains is the universal property. If we translate this into
 our existing machinery, that means that $!x$ must be the universal
-functor equipped with a natural transformation $\eta$; that is, for any
+functor equipped with a natural transformation $\eps$; that is, for any
 other $K : \{*\} \to \cC$ equipped with $\tau : K \circ \mathord{!} \to
 D$, we have a unique natural transformation $\sigma : K \to {!x}$ that
 factors $\tau$. This is a bit of a mouthful, so let's look at a diagram
@@ -136,7 +136,7 @@ instead.
   \arrow[""{name=0, anchor=center, inner sep=0}, "{!x}"', from=1-3, to=3-5]
   \arrow[""{name=1, anchor=center, inner sep=0}, from=3-1, to=3-5]
   \arrow[""{name=2, anchor=center, inner sep=0}, "K", curve={height=-18pt}, from=1-3, to=3-5]
-  \arrow["\eta"{description}, shorten <=4pt, shorten >=4pt, Rightarrow, from=1-3, to=1]
+  \arrow["\eps"{description}, shorten <=4pt, shorten >=4pt, Rightarrow, from=1-3, to=1]
   \arrow["\sigma", shorten <=3pt, shorten >=3pt, Rightarrow, from=2, to=0]
 \end{tikzcd}
 ~~~
@@ -166,9 +166,9 @@ module _ {J : Precategory o₁ h₁} {C : Precategory o₂ h₂} (Diagram : Func
   unquoteDef cone→counit = define-coherence cone→counit
 
   counit→cone : ∀ {K : Functor ⊤Cat C} → K F∘ !F => Diagram → (Const (K .F₀ tt) => Diagram)
-  counit→cone {K = K} eta .η = eta .η
-  counit→cone {K = K} eta .is-natural x y f =
-    ap (_ C.∘_) (sym (K .F-id)) ∙ eta .is-natural x y f
+  counit→cone {K = K} eps .η = eps .η
+  counit→cone {K = K} eps .is-natural x y f =
+    ap (_ C.∘_) (sym (K .F-id)) ∙ eps .is-natural x y f
 
   is-limit : (x : C.Ob) → Const x => Diagram → Type _
   is-limit x cone = is-ran !F Diagram (const! x) (cone→counit cone)
@@ -237,42 +237,42 @@ triangles
 ```
 
 The rest of the data says that $\psi$ is the universal family of maps
-with this property: If $\eta_j : x \to Fj$ is another family of maps
-with the same commutativity property, then each $\eta_j$ factors through
+with this property: If $\eps_j : x \to Fj$ is another family of maps
+with the same commutativity property, then each $\eps_j$ factors through
 the apex by a single, _unique_ universal morphism:
 
 ```agda
       universal
         : ∀ {x : C.Ob}
-        → (eta : ∀ j → C.Hom x (F₀ j))
-        → (∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eta x ≡ eta y)
+        → (eps : ∀ j → C.Hom x (F₀ j))
+        → (∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eps x ≡ eps y)
         → C.Hom x apex
 
       factors
         : ∀ {j : J.Ob} {x : C.Ob}
-        → (eta : ∀ j → C.Hom x (F₀ j))
-        → (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eta x ≡ eta y)
-        → ψ j C.∘ universal eta p ≡ eta j
+        → (eps : ∀ j → C.Hom x (F₀ j))
+        → (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eps x ≡ eps y)
+        → ψ j C.∘ universal eps p ≡ eps j
 
       unique
         : ∀ {x : C.Ob}
-        → (eta : ∀ j → C.Hom x (F₀ j))
-        → (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eta x ≡ eta y)
+        → (eps : ∀ j → C.Hom x (F₀ j))
+        → (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eps x ≡ eps y)
         → (other : C.Hom x apex)
-        → (∀ j → ψ j C.∘ other ≡ eta j)
-        → other ≡ universal eta p
+        → (∀ j → ψ j C.∘ other ≡ eps j)
+        → other ≡ universal eps p
 ```
 
 <!--
 ```agda
     unique₂
       : ∀ {x : C.Ob}
-      → (eta : ∀ j → C.Hom x (F₀ j))
-      → (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eta x ≡ eta y)
-      → {o1 : C.Hom x apex} → (∀ j → ψ j C.∘ o1 ≡ eta j)
-      → {o2 : C.Hom x apex} → (∀ j → ψ j C.∘ o2 ≡ eta j)
+      → (eps : ∀ j → C.Hom x (F₀ j))
+      → (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eps x ≡ eps y)
+      → {o1 : C.Hom x apex} → (∀ j → ψ j C.∘ o1 ≡ eps j)
+      → {o2 : C.Hom x apex} → (∀ j → ψ j C.∘ o2 ≡ eps j)
       → o1 ≡ o2
-    unique₂ {x = x} eta p q r = unique eta p _ q ∙ sym (unique eta p _ r)
+    unique₂ {x = x} eps p q r = unique eps p _ q ∙ sym (unique eps p _ r)
 ```
 -->
 
@@ -364,24 +364,24 @@ limit:
     open make-is-limit
     open _=>_
 
-    module _ {x} (eta : ∀ j → C.Hom x (F₀ j))
-                 (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eta x ≡ eta y)
+    module _ {x} (eps : ∀ j → C.Hom x (F₀ j))
+                 (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eps x ≡ eps y)
       where
 
-      eta-nt : const! x F∘ !F => D
-      eta-nt .η = eta
-      eta-nt .is-natural _ _ f = C.idr _ ∙ sym (p f)
+      eps-nt : const! x F∘ !F => D
+      eps-nt .η = eps
+      eps-nt .is-natural _ _ f = C.idr _ ∙ sym (p f)
 
       hom : C.Hom x a
-      hom = σ {M = const! x} eta-nt .η tt
+      hom = σ {M = const! x} eps-nt .η tt
 
     ml : make-is-limit D a
     ml .ψ j        = eps.η j
     ml .commutes f = sym (eps.is-natural _ _ f) ∙ C.elimr (F .Functor.F-id)
 
     ml .universal   = hom
-    ml .factors e p = σ-comm {β = eta-nt e p} ηₚ _
-    ml .unique {x = x} eta p other q =
+    ml .factors e p = σ-comm {β = eps-nt e p} ηₚ _
+    ml .unique {x = x} eps p other q =
       sym $ σ-uniq {σ' = other-nt} (ext λ j → sym (q j)) ηₚ tt
       where
         other-nt : const! x => F
@@ -573,23 +573,23 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 
   family→cone
     : ∀ {x}
-    → (eta : ∀ j → C.Hom x (D.₀ j))
-    → (∀ {x y} (f : J.Hom x y) → D.₁ f C.∘ eta x ≡ eta y)
+    → (eps : ∀ j → C.Hom x (D.₀ j))
+    → (∀ {x y} (f : J.Hom x y) → D.₁ f C.∘ eps x ≡ eps y)
     → Const x => D
-  family→cone eta p .η = eta
-  family→cone eta p .is-natural _ _ _ = C.idr _ ∙ sym (p _)
+  family→cone eps p .η = eps
+  family→cone eps p .is-natural _ _ _ = C.idr _ ∙ sym (p _)
 ```
 -->
 
 ```agda
   is-invertible→is-limitp
     : ∀ {K' : Functor ⊤Cat C} {eps : K' F∘ !F => D}
-    → (eta : ∀ j → C.Hom (K' .F₀ tt) (D.₀ j))
-    → (p : ∀ {x y} (f : J.Hom x y) → D.₁ f C.∘ eta x ≡ eta y)
-    → (∀ {j} → eta j ≡ eps .η j)
-    → C.is-invertible (Ly.universal eta p)
+    → (eps' : ∀ j → C.Hom (K' .F₀ tt) (D.₀ j))
+    → (p : ∀ {x y} (f : J.Hom x y) → D.₁ f C.∘ eps' x ≡ eps' y)
+    → (∀ {j} → eps' j ≡ eps .η j)
+    → C.is-invertible (Ly.universal eps' p)
     → is-ran !F D K' eps
-  is-invertible→is-limitp {K' = K'} eta p q invert =
+  is-invertible→is-limitp {K' = K'} eps' p q invert =
     generalize-limitp
       (is-invertible→is-ran Ly $ invertible→invertibleⁿ _ (λ _ → invert))
       q
@@ -720,8 +720,8 @@ module preserves-limit
   {J : Precategory o₁ h₁} {C : Precategory o₂ h₂} {D : Precategory o₃ h₃}
   {F : Functor C D} {Dia : Functor J C}
   (preserves : preserves-limit F Dia)
-  {K : Functor ⊤Cat C} {eta : K F∘ !F => Dia}
-  (lim : is-ran !F Dia K eta)
+  {K : Functor ⊤Cat C} {eps : K F∘ !F => Dia}
+  (lim : is-ran !F Dia K eps)
   where
   private
     module D = Precategory D

--- a/src/Cat/Diagram/Limit/Equaliser.lagda.md
+++ b/src/Cat/Diagram/Limit/Equaliser.lagda.md
@@ -49,21 +49,21 @@ is-equaliser→is-limit {e} F {equ} is-eq =
     ml .commutes {false} {true} true = sym is-eq.equal
     ml .commutes {false} {true} false = refl
     ml .commutes {false} {false} tt = eliml (F .F-id)
-    ml .universal eta p =
+    ml .universal eps p =
       is-eq.universal (p {false} {true} false ∙ sym (p {false} {true} true))
-    ml .factors {true} eta p =
+    ml .factors {true} eps p =
       pullr is-eq.factors ∙ p {false} {true} false
-    ml .factors {false} eta p =
+    ml .factors {false} eps p =
       is-eq.factors
-    ml .unique eta p other q =
+    ml .unique eps p other q =
       is-eq.unique (q false)
 
 is-limit→is-equaliser
   : ∀ (F : Functor ·⇉· C) {K : Functor ⊤Cat C}
-  → {eta : K F∘ !F => F}
-  → is-ran !F F K eta
-  → is-equaliser C (forkl F) (forkr F) (eta .η false)
-is-limit→is-equaliser F {K} {eta} lim = eq where
+  → {eps : K F∘ !F => F}
+  → is-ran !F F K eps
+  → is-equaliser C (forkl F) (forkr F) (eps .η false)
+is-limit→is-equaliser F {K} {eps} lim = eq where
   module lim = is-limit lim
 
   parallel
@@ -82,16 +82,16 @@ is-limit→is-equaliser F {K} {eta} lim = eq where
   parallel-commutes p false true false = refl
   parallel-commutes p false false tt = eliml (F .F-id)
 
-  eq : is-equaliser C (forkl F) (forkr F) (eta .η false)
+  eq : is-equaliser C (forkl F) (forkr F) (eps .η false)
   eq .equal =
-    sym (eta .is-natural false true false) ∙ eta .is-natural false true true
+    sym (eps .is-natural false true false) ∙ eps .is-natural false true true
   eq .universal {e' = e'} p =
     lim.universal (parallel e') (λ {i} {j} h → parallel-commutes p i j h)
   eq .factors = lim.factors {j = false} _ _
   eq .unique {p = p} {other = other} q =
     lim.unique _ _ _ λ where
       true →
-        ap (_∘ other) (intror (K .F-id) ∙ eta .is-natural false true true)
+        ap (_∘ other) (intror (K .F-id) ∙ eps .is-natural false true true)
         ·· pullr q
         ·· sym p
       false → q

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -89,17 +89,17 @@ is-product→is-limit {x = x} {a} {b} {p1} {p2} is-prod =
     ml .commutes {true}  {false} f = absurd (true≠false f)
     ml .commutes {false} {true}  f = absurd (true≠false $ sym f)
     ml .commutes {false} {false} f = idl p2
-    ml .universal       eta _ = is-prod.⟨ eta true , eta false ⟩
-    ml .factors {true}  eta _ = is-prod.π₁∘factor
-    ml .factors {false} eta _ = is-prod.π₂∘factor
-    ml .unique eta p other q = is-prod.unique other (q true) (q false)
+    ml .universal       eps _ = is-prod.⟨ eps true , eps false ⟩
+    ml .factors {true}  eps _ = is-prod.π₁∘factor
+    ml .factors {false} eps _ = is-prod.π₂∘factor
+    ml .unique eps p other q = is-prod.unique other (q true) (q false)
 
 is-limit→is-product
   : ∀ {a b} {K : Functor ⊤Cat C}
-  → {eta : K F∘ !F => 2-object-diagram a b}
-  → is-ran !F (2-object-diagram a b) K eta
-  → is-product C (eta .η true) (eta .η false)
-is-limit→is-product {a} {b} {K} {eta} lim = prod where
+  → {eps : K F∘ !F => 2-object-diagram a b}
+  → is-ran !F (2-object-diagram a b) K eps
+  → is-product C (eps .η true) (eps .η false)
+is-limit→is-product {a} {b} {K} {eps} lim = prod where
   module lim = is-limit lim
 
   pair
@@ -117,7 +117,7 @@ is-limit→is-product {a} {b} {K} {eta} lim = prod where
       J (λ _ p → 2-object-diagram a b .F₁ p ∘ pair p1 p2 _ ≡ pair p1 p2 _)
         (eliml (2-object-diagram a b .F-id))
 
-  prod : is-product C (eta .η true) (eta .η false)
+  prod : is-product C (eps .η true) (eps .η false)
   prod .⟨_,_⟩ f g = lim.universal (pair f g) pair-commutes
   prod .π₁∘factor {_} {p1'} {p2'} = lim.factors (pair p1' p2') pair-commutes
   prod .π₂∘factor {_} {p1'} {p2'} = lim.factors (pair p1' p2') pair-commutes
@@ -199,20 +199,20 @@ module _ {ℓ} {I : Type ℓ} (i-is-grpd : is-groupoid I) (F : I → Ob) where
         J (λ j p → subst (Hom (F i) ⊙ F) p id ∘ π i ≡ π j)
           (eliml (transport-refl _))
           p
-      ml .universal eta p = ip.tuple eta
-      ml .factors eta p = ip.commute
-      ml .unique eta p other q = ip.unique eta q
+      ml .universal eps p = ip.tuple eps
+      ml .factors eps p = ip.commute
+      ml .unique eps p other q = ip.unique eps q
 
   is-limit→is-indexed-product
     : ∀ {K : Functor ⊤Cat C}
-    → {eta : K F∘ !F => Disc-adjunct {iss = i-is-grpd} F}
-    → is-ran !F (Disc-adjunct F) K eta
-    → is-indexed-product C F (eta .η)
-  is-limit→is-indexed-product {K = K} {eta} lim = ip where
+    → {eps : K F∘ !F => Disc-adjunct {iss = i-is-grpd} F}
+    → is-ran !F (Disc-adjunct F) K eps
+    → is-indexed-product C F (eps .η)
+  is-limit→is-indexed-product {K = K} {eps} lim = ip where
     module lim = is-limit lim
-    open is-indexed-product hiding (eta)
+    open is-indexed-product
 
-    ip : is-indexed-product C F (eta .η)
+    ip : is-indexed-product C F (eps .η)
     ip .tuple k =
       lim.universal k
         (J (λ j p → subst (Hom (F _) ⊙ F) p id ∘ k _ ≡ k j)

--- a/src/Cat/Diagram/Limit/Terminal.lagda.md
+++ b/src/Cat/Diagram/Limit/Terminal.lagda.md
@@ -34,8 +34,8 @@ A [[terminal object]] is equivalently defined as a limit of the empty diagram.
 
 ```agda
 is-limit→is-terminal
-  : ∀ {T : Ob} {eta : Const T => ¡F}
-  → is-limit {C = C} ¡F T eta
+  : ∀ {T : Ob} {eps : Const T => ¡F}
+  → is-limit {C = C} ¡F T eps
   → is-terminal C T
 is-limit→is-terminal lim Y = contr (lim.universal (λ ()) (λ ()))
                                    (λ _ → sym (lim.unique _ _ _ λ ()))

--- a/src/Cat/Diagram/Monad/Limits.lagda.md
+++ b/src/Cat/Diagram/Monad/Limits.lagda.md
@@ -110,17 +110,17 @@ $\cC$ later.
     em-lim .ψ j .morphism = lim.ψ j
     em-lim .ψ j .commutes = comm j
     em-lim .commutes f    = ext (lim.commutes f)
-    em-lim .universal eta p .morphism =
-      lim.universal (λ j → eta j .morphism) (λ f i → p f i .morphism)
-    em-lim .factors eta p =
+    em-lim .universal eps p .morphism =
+      lim.universal (λ j → eps j .morphism) (λ f i → p f i .morphism)
+    em-lim .factors eps p =
       ext (lim.factors _ _)
-    em-lim .unique eta p other q =
+    em-lim .unique eps p other q =
       ext (lim.unique _ _ _ λ j i → q j i .morphism)
-    em-lim .universal eta p .commutes = lim.unique₂ _
+    em-lim .universal eps p .commutes = lim.unique₂ _
       (λ f → C.pulll (F.F₁ f .commutes)
            ∙ C.pullr (sym (M.M-∘ _ _) ∙ ap M.M₁ (ap morphism (p f))))
       (λ j → C.pulll (lim.factors _ _)
-           ∙ eta j .commutes)
+           ∙ eps j .commutes)
       (λ j → C.pulll (comm j)
            ∙ C.pullr (sym (M.M-∘ _ _) ∙ ap M.M₁ (lim.factors _ _)))
 ```

--- a/src/Cat/Diagram/Pullback.lagda.md
+++ b/src/Cat/Diagram/Pullback.lagda.md
@@ -31,7 +31,7 @@ $x$; Hence the pullback is also called the **fibred product**.
 ```agda
   record is-pullback {P} (p₁ : Hom P X) (f : Hom X Z) (p₂ : Hom P Y) (g : Hom Y Z)
     : Type (o ⊔ ℓ) where
-  
+
     no-eta-equality
     field
       square   : f ∘ p₁ ≡ g ∘ p₂
@@ -62,12 +62,12 @@ overall square has to commute.
                → f ∘ p₁' ≡ g ∘ p₂' → Hom P' P
       p₁∘universal : {p : f ∘ p₁' ≡ g ∘ p₂'} → p₁ ∘ universal p ≡ p₁'
       p₂∘universal : {p : f ∘ p₁' ≡ g ∘ p₂'} → p₂ ∘ universal p ≡ p₂'
-  
+
       unique : {p : f ∘ p₁' ≡ g ∘ p₂'} {lim' : Hom P' P}
              → p₁ ∘ lim' ≡ p₁'
              → p₂ ∘ lim' ≡ p₂'
              → lim' ≡ universal p
-  
+
     unique₂
       : {p : f ∘ p₁' ≡ g ∘ p₂'} {lim' lim'' : Hom P' P}
       → p₁ ∘ lim' ≡ p₁' → p₂ ∘ lim' ≡ p₂'
@@ -122,9 +122,35 @@ maps:
       p₁ : Hom apex X
       p₂ : Hom apex Y
       has-is-pb : is-pullback p₁ f p₂ g
-  
+
     open is-pullback has-is-pb public
 ```
+
+<!--
+```agda
+module _ {o ℓ} {C : Precategory o ℓ} where
+  open Cat.Reasoning C
+  private variable
+    P' X Y Z : Ob
+    h p₁' p₂' : Hom X Y
+
+  is-pullback-is-prop : ∀ {P} {p₁ : Hom P X} {f : Hom X Z} {p₂ : Hom P Y} {g : Hom Y Z} → is-prop (is-pullback C p₁ f p₂ g)
+  is-pullback-is-prop {X = X} {Y = Y} {p₁ = p₁} {f} {p₂} {g} x y = q where
+    open is-pullback
+    p : Path (∀ {P'} {p₁' : Hom P' X} {p₂' : Hom P' Y} → f ∘ p₁' ≡ g ∘ p₂' → _) (x .universal) (y .universal)
+    p i sq = y .unique {p = sq} (x .p₁∘universal {p = sq}) (x .p₂∘universal) i
+    q : x ≡ y
+    q i .square = Hom-set _ _ _ _ (x .square) (y .square) i
+    q i .universal = p i
+    q i .p₁∘universal {p₁' = p₁'} {p = sq} = is-prop→pathp (λ i → Hom-set _ _ (p₁ ∘ p i sq) p₁') (x .p₁∘universal) (y .p₁∘universal) i
+    q i .p₂∘universal {p = sq} = is-prop→pathp (λ i → Hom-set _ _ (p₂ ∘ p i sq) _) (x .p₂∘universal) (y .p₂∘universal) i
+    q i .unique {p = sq} {lim' = lim'} c₁ c₂ = is-prop→pathp (λ i → Hom-set _ _ lim' (p i sq)) (x .unique c₁ c₂) (y .unique c₁ c₂) i
+
+  instance
+    H-Level-is-pullback : ∀ {P} {p₁ : Hom P X} {f : Hom X Z} {p₂ : Hom P Y} {g : Hom Y Z} {n} → H-Level (is-pullback C p₁ f p₂ g) (suc n)
+    H-Level-is-pullback = prop-instance is-pullback-is-prop
+```
+-->
 
 # Categories with all pullbacks
 
@@ -152,7 +178,8 @@ module Pullbacks
 ## Stability {defines="pullback-stability pullback-stable"}
 
 Pullbacks, in addition to their nature as limits, serve as the way of
-"changing the base" of a family of objects: if we think of an arrow
+"[[changing the base|pullback functor]]" of a family of objects: if we
+think of an arrow
 $f : A \to B$ as encoding the data of a family over $B$ (think of the
 special case where $A = \Sigma_{x : A} F(x)$, and $f = \pi_1$), then we
 can think of pulling back $f$ along $g : X \to B$ as "the universal
@@ -162,7 +189,7 @@ category with pullbacks.
 
 In that framing, there is a canonical choice for "the" pullback of an
 arrow along another: We put the arrow $f$ we want to pullback on the
-right side of the diagram, and the pullback is the right arrow. Using
+right side of the diagram, and the pullback is the left arrow. Using
 the type `is-pullback`{.Agda} defined above, the arrow which results
 from pulling back is adjacent _to the adjustment_: `is-pullback f⁺ g _ f`.
 To help keep this straight, we define what it means for a class of

--- a/src/Cat/Diagram/Pullback/Properties.lagda.md
+++ b/src/Cat/Diagram/Pullback/Properties.lagda.md
@@ -16,7 +16,7 @@ module Cat.Diagram.Pullback.Properties where
 module _ {o ℓ} {C : Precategory o ℓ} where
   open Cat.Reasoning C
   open is-pullback
-  
+
   private variable
     A B P : Ob
     f g h : Hom A B
@@ -27,7 +27,31 @@ module _ {o ℓ} {C : Precategory o ℓ} where
 
 This module chronicles some general properties of [[pullbacks]].
 
-## Pasting law
+## Identity
+
+Degenerate squares where two opposite sides are identities are pullbacks.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  a & a \\
+  b & b
+  \arrow[Rightarrow, no head, from=1-1, to=1-2]
+  \arrow["f"', from=1-1, to=2-1]
+  \arrow["f", from=1-2, to=2-2]
+  \arrow[Rightarrow, no head, from=2-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+```agda
+  id-is-pullback : ∀ {a b : Ob} {f : Hom a b} → is-pullback C id f f id
+  id-is-pullback .square = id-comm
+  id-is-pullback .universal {p₁' = p₁'} _ = p₁'
+  id-is-pullback .p₁∘universal = idl _
+  id-is-pullback .p₂∘universal {p = p} = p ∙ idl _
+  id-is-pullback .unique q r = sym (idl _) ∙ q
+```
+
+## Pasting law {defines="pasting-law-for-pullbacks"}
 
 The pasting law for pullbacks says that, if in the _commutative_ diagram
 below the the right square is a pullback, then the left square is
@@ -58,7 +82,7 @@ through.
            {c→f : Hom c f}
            (right-pullback : is-pullback C b→c c→f b→e e→f)
     where
-  
+
     private module right = is-pullback right-pullback
 ```
 
@@ -109,7 +133,7 @@ assumption $p$ in the code). Check out the calculation below:
           e→f ∘ b→e ∘ P→b   ≡⟨ ap (e→f ∘_) p ⟩
           e→f ∘ d→e ∘ P→d   ≡⟨ cat! C ⟩
           (e→f ∘ d→e) ∘ P→d ∎
-  
+
       pb : is-pullback C _ _ _ _
       pb .is-pullback.square =
         b→e ∘ a→b ≡⟨ square ⟩
@@ -122,15 +146,15 @@ makes everything in sight commute, and does so uniquely.
 ```agda
       pb .universal {p₁' = P→b} {p₂' = P→d} p =
         outer.universal {p₁' = b→c ∘ P→b} {p₂' = P→d} (path p)
-  
+
       pb .p₁∘universal {p₁' = P→b} {p₂' = P→d} {p = p} =
         right.unique₂ {p = pulll right.square ∙ pullr p}
           (assoc _ _ _ ∙ outer.p₁∘universal)
           (pulll square ∙ pullr outer.p₂∘universal)
           refl p
-  
+
       pb .p₂∘universal {p₁' = P→b} {p₂' = P→d} {p = p} = outer.p₂∘universal
-  
+
       pb .unique {p = p} q r =
         outer.unique (sym (ap (_ ∘_) (sym q) ∙ assoc _ _ _)) r
 ```
@@ -148,7 +172,7 @@ then have a map $x \to a$, as we wanted.
       → is-pullback C (b→c ∘ a→b) c→f a→d (e→f ∘ d→e)
     pasting-left→outer-is-pullback left square = pb where
       module left = is-pullback left
-  
+
       pb : is-pullback C (b→c ∘ a→b) c→f a→d (e→f ∘ d→e)
       pb .is-pullback.square =
         c→f ∘ b→c ∘ a→b   ≡⟨ square ⟩
@@ -193,7 +217,7 @@ is a monomorphism iff. the square below is a pullback.
     is-monic→is-pullback mono .p₁∘universal = idl _
     is-monic→is-pullback mono .p₂∘universal {p = p} = idl _ ∙ mono _ _ p
     is-monic→is-pullback mono .unique p q = introl refl ∙ p
-  
+
     is-pullback→is-monic : is-pullback C id f id f → is-monic f
     is-pullback→is-monic pb f g p = sym (pb .p₁∘universal {p = p}) ∙ pb .p₂∘universal
 ```
@@ -215,10 +239,10 @@ Pullbacks additionally preserve monomorphisms, as shown below:
         g ∘ p2 ∘ h ≡⟨ ap (g ∘_) p ⟩
         g ∘ p2 ∘ j ≡˘⟨ extendl pb.square ⟩
         f ∘ p1 ∘ j ∎
-  
+
       r : p1 ∘ h ≡ p1 ∘ j
       r = mono _ _ q
-  
+
       eq : h ≡ j
       eq = pb.unique₂ {p = extendl pb.square} r p refl refl
 ```
@@ -234,42 +258,47 @@ Pullbacks additionally preserve monomorphisms, as shown below:
   rotate-pullback pb .p₁∘universal = pb .p₂∘universal
   rotate-pullback pb .p₂∘universal = pb .p₁∘universal
   rotate-pullback pb .unique p q = pb .unique q p
-  
+
+  pullback-unique
+    : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
+        {p1' : Hom p' x} {p2' : Hom p' y}
+    → (pb : is-pullback C p1 f p2 g)
+    → (sq : f ∘ p1' ≡ g ∘ p2')
+    → is-invertible (pb .universal sq)
+    ≃ is-pullback C p1' f p2' g
+  pullback-unique {f = f} {g} {p1} {p2} {p1'} {p2'} pb sq
+    = prop-ext! inv→pb pb→inv
+    where
+    module _ (inv : is-invertible (pb .universal sq)) where
+      module i = is-invertible inv
+      open is-pullback
+      inv→pb : is-pullback C p1' f p2' g
+      inv→pb .square = sq
+      inv→pb .universal p = i.inv ∘ pb .universal p
+      inv→pb .p₁∘universal = pulll (rswizzle (sym (pb .p₁∘universal)) i.invl) ∙ pb .p₁∘universal
+      inv→pb .p₂∘universal = pulll (rswizzle (sym (pb .p₂∘universal)) i.invl) ∙ pb .p₂∘universal
+      inv→pb .unique p q =
+        sym (lswizzle (sym (pb .unique (pulll (pb .p₁∘universal) ∙ p) (pulll (pb .p₂∘universal) ∙ q))) i.invr)
+    pb→inv : is-pullback C p1' f p2' g → is-invertible (pb .universal sq)
+    pb→inv pb' = make-invertible (pb' .universal (pb .square))
+      (unique₂ pb {p = pb .square}
+        (pulll (pb .p₁∘universal) ∙ pb' .p₁∘universal)
+        (pulll (pb .p₂∘universal) ∙ pb' .p₂∘universal)
+        (idr _) (idr _))
+      (unique₂ pb' {p = pb' .square}
+        (pulll (pb' .p₁∘universal) ∙ pb .p₁∘universal)
+        (pulll (pb' .p₂∘universal) ∙ pb .p₂∘universal)
+        (idr _) (idr _))
+
   is-pullback-iso
     : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
     → (i : p ≅ p')
     → is-pullback C p1 f p2 g
     → is-pullback C (p1 ∘ _≅_.from i) f (p2 ∘ _≅_.from i) g
-  is-pullback-iso {f = f} {g} {p1} {p2} i pb = pb' where
-    module i = _≅_ i
-    pb' : is-pullback C _ _ _ _
-    pb' .square = extendl (pb .square)
-    pb' .universal p = i.to ∘ pb .universal p
-    pb' .p₁∘universal = cancel-inner i.invr ∙ pb .p₁∘universal
-    pb' .p₂∘universal = cancel-inner i.invr ∙ pb .p₂∘universal
-    pb' .unique p q = invertible→monic (iso→invertible (i Iso⁻¹)) _ _ $ sym $
-      cancell i.invr ∙ sym (pb .unique (assoc _ _ _ ∙ p) (assoc _ _ _ ∙ q))
-  
-  pullback-unique
-    : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
-        {p1' : Hom p' x} {p2' : Hom p' y}
-    → is-pullback C p1 f p2 g
-    → is-pullback C p1' f p2' g
-    → p ≅ p'
-  pullback-unique {f = f} {g} {p1} {p2} {p1'} {p2'} pb pb'
-    = make-iso pb→pb' pb'→pb il ir
-    where
-      pb→pb' = pb' .universal (pb .square)
-      pb'→pb = pb .universal (pb' .square)
-      il = unique₂ pb' {p = pb' .square}
-        (pulll (pb' .p₁∘universal) ∙ pb .p₁∘universal)
-        (pulll (pb' .p₂∘universal) ∙ pb .p₂∘universal)
-        (idr _) (idr _)
-      ir = unique₂ pb {p = pb .square}
-        (pulll (pb .p₁∘universal) ∙ pb' .p₁∘universal)
-        (pulll (pb .p₂∘universal) ∙ pb' .p₂∘universal)
-        (idr _) (idr _)
-  
+  is-pullback-iso i pb = Equiv.to
+    (pullback-unique pb (extendl (pb .square)))
+    (subst is-invertible (pb .unique refl refl) (iso→invertible (i Iso⁻¹)))
+
   Pullback-unique
     : ∀ {x y z} {f : Hom x z} {g : Hom y z}
     → is-category C
@@ -278,22 +307,22 @@ Pullbacks additionally preserve monomorphisms, as shown below:
     open Pullback
     module x = Pullback x
     module y = Pullback y
-    apices = c-cat .to-path (pullback-unique (x .has-is-pb) (y .has-is-pb))
-  
+    apices = c-cat .to-path (invertible→iso _ (Equiv.from (pullback-unique (y .has-is-pb) (x .square)) (x .has-is-pb)))
+
     abstract
       p1s : PathP (λ i → Hom (apices i) X) x.p₁ y.p₁
       p1s = Univalent.Hom-pathp-refll-iso c-cat (x.p₁∘universal)
-  
+
       p2s : PathP (λ i → Hom (apices i) Y) x.p₂ y.p₂
       p2s = Univalent.Hom-pathp-refll-iso c-cat (x.p₂∘universal)
-  
+
       lims
         : ∀ {P'} {p1' : Hom P' X} {p2' : Hom P' Y} (p : f ∘ p1' ≡ g ∘ p2')
         → PathP (λ i → Hom P' (apices i)) (x.universal p) (y.universal p)
       lims p = Univalent.Hom-pathp-reflr-iso c-cat $
         y.unique (pulll y.p₁∘universal ∙ x.p₁∘universal)
                 (pulll y.p₂∘universal ∙ x.p₂∘universal)
-  
+
     p : x ≡ y
     p i .apex = apices i
     p i .p₁ = p1s i
@@ -317,7 +346,7 @@ Pullbacks additionally preserve monomorphisms, as shown below:
         (λ lim → x.unique {lim' = lim})
         (λ lim → y.unique {lim' = lim})
         i lim'
-  
+
   canonically-stable
     : ∀ {ℓ'} (P : ∀ {a b} → Hom a b → Type ℓ')
     → is-category C

--- a/src/Cat/Displayed/Cartesian.lagda.md
+++ b/src/Cat/Displayed/Cartesian.lagda.md
@@ -493,9 +493,7 @@ cartesian-vertical-retraction-stable {f' = f'} {f''} {ϕ} f-cart ϕ-sect factor 
 ```
 
 We also have the following extremely useful pasting lemma, which
-generalizes the [pasting law for pullbacks].
-
-[pasting law for pullbacks]: Cat.Diagram.Pullback.Properties.html#pasting-law
+generalizes the [[pasting law for pullbacks]].
 
 ```agda
 cartesian-pasting

--- a/src/Cat/Functor/Conservative.lagda.md
+++ b/src/Cat/Functor/Conservative.lagda.md
@@ -1,6 +1,8 @@
 <!--
 ```agda
+open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Limit.Base
+open import Cat.Morphism.Duality
 open import Cat.Morphism
 open import Cat.Prelude hiding (J)
 
@@ -23,7 +25,7 @@ open Functor
 ```
 -->
 
-# Conservative functors
+# Conservative functors {defines="conservative conservative-functor"}
 
 We say a functor is _conservative_ if it reflects isomorphisms. More concretely,
 if $f : A \to B$ is some morphism $\cC$, and if $F(f)$ is an iso in $\cD$,
@@ -36,16 +38,34 @@ is-conservative {C = C} {D = D} F =
   → is-invertible D (F .F₁ f) → is-invertible C f
 ```
 
-As a general fact, conservative functors reflect limits that they preserve
-(given those limits exist in the first place!).
+As a general fact, conservative functors reflect limits and colimits that
+they preserve (given those (co)limits exist in the first place!).
 
-The rough proof sketch is as follows: Let $K$ be some cone in $C$ such that
-$F(K)$ is a limit in $D$, and $L$ a limit in $C$ of the same diagram.
+The rough proof sketch is as follows: let $K$ be some cone in $\cC$ such
+that $F(K)$ is a limit in $\cD$, and $L$ a limit in $\cC$ of the same
+diagram that is preserved by $F$.
 By the universal property of $L$, there exists a map $\eta$ from the apex of $K$
-to the apex of $L$ in $C$. Furthermore, as $F(K)$ is a limit in $D$, $F(\eta)$
-becomes an isomorphism in $D$. However, $F$ is conservative, which implies that
-$\eta$ was an isomorphism in $C$ all along! This means that $K$ must be a limit
-in $C$ as well (see `is-invertible→is-limitp`{.Agda}).
+to the apex of $L$ in $\cC$. Furthermore, as $F(K)$ is a limit in $\cD$, $F(\eta)$
+becomes an isomorphism in $\cD$.
+The situation is summarised by the following diagram, which shows how $F$
+maps cones in $\cC$ to cones in $\cD$ (the coloured cones are assumes to
+be limiting).
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  K & \textcolor{rgb,255:red,214;green,92;blue,214}{L} \\
+  \textcolor{rgb,255:red,214;green,92;blue,214}{F(K)} & \textcolor{rgb,255:red,214;green,92;blue,214}{F(L)}
+  \arrow[maps to, from=1-2, to=2-2]
+  \arrow[maps to, from=1-1, to=2-1]
+  \arrow[""{name=0, anchor=center, inner sep=0}, "\eta", from=1-1, to=1-2]
+  \arrow[""{name=1, anchor=center, inner sep=0}, "\sim"', from=2-1, to=2-2]
+  \arrow[shorten <=4pt, shorten >=4pt, maps to, from=0, to=1]
+\end{tikzcd}\]
+~~~
+
+However, $F$ is conservative, which implies that
+$\eta$ was an isomorphism in $\cC$ all along! This means that $K$ must be a limit
+in $\cC$ as well (see `is-invertible→is-limitp`{.Agda}).
 
 ```agda
 module _ {F : Functor C D} (conservative : is-conservative F) where
@@ -55,11 +75,12 @@ module _ {F : Functor C D} (conservative : is-conservative F) where
     module D = Cat D
     module F = Func F
 
-  conservative-reflects-limits : ∀ {Dia : Functor J C}
-                               → (L : Limit Dia)
-                               → preserves-limit F Dia
-                               → reflects-limit F Dia
-  conservative-reflects-limits L-lim preservesa {K} {eps} lim =
+  conservative-reflects-limits
+    : ∀ {Dia : Functor J C}
+    → Limit Dia
+    → preserves-limit F Dia
+    → reflects-limit F Dia
+  conservative-reflects-limits L-lim preservesa {K} {eps} FK-lim =
     is-invertible→is-limitp
       {K = Limit.Ext L-lim} {epsy = Limit.cone L-lim} (Limit.has-limit L-lim)
       (eps .η) (λ f → sym (eps .is-natural _ _ f) ∙ C.elimr (K .F-id)) refl
@@ -69,21 +90,81 @@ module _ {F : Functor C D} (conservative : is-conservative F) where
     where
       module L-lim = Limit L-lim
       module FL-lim = is-limit (preservesa L-lim.has-limit)
-      module lim = is-limit lim
+      module FK-lim = is-limit FK-lim
 
       uinv : D.Hom (F .F₀ L-lim.apex) (F .F₀ (K .F₀ tt))
       uinv =
-          (lim.universal
-            (λ j → F .F₁ (L-lim.ψ j))
-            (λ f → sym (F .F-∘ _ _) ∙ ap (F .F₁) (L-lim.commutes f)))
+        FK-lim.universal
+          (λ j → F .F₁ (L-lim.ψ j))
+          (λ f → sym (F .F-∘ _ _) ∙ ap (F .F₁) (L-lim.commutes f))
 
       invert : D.is-invertible (F .F₁ (L-lim.universal (eps .η) _))
       invert =
         D.make-invertible uinv
           (FL-lim.unique₂ _ (λ j → FL-lim.commutes j)
-            (λ j → F.pulll (L-lim.factors _ _) ∙ lim.factors _ _)
+            (λ j → F.pulll (L-lim.factors _ _) ∙ FK-lim.factors _ _)
             (λ j → D.idr _))
-          (lim.unique₂ _ (λ j → lim.commutes j)
-            (λ j → D.pulll (lim.factors _ _) ∙ F.collapse (L-lim.factors _ _))
+          (FK-lim.unique₂ _ (λ j → FK-lim.commutes j)
+            (λ j → D.pulll (FK-lim.factors _ _) ∙ F.collapse (L-lim.factors _ _))
             (λ j → D.idr _))
 ```
+
+<!--
+```agda
+  conservative→equiv :
+    ∀ {A B} {f : C .Hom A B}
+    → C.is-invertible f ≃ D.is-invertible (F .F₁ f)
+  conservative→equiv = prop-ext! F.F-map-invertible conservative
+
+  conservative^op : is-conservative F.op
+  conservative^op inv
+    = invertible→co-invertible C
+    $ conservative
+    $ co-invertible→invertible D inv
+```
+-->
+
+<details>
+<summary>
+Clearly, if $F$ is conservative then so is $F\op$, so the statement
+about colimits follows by duality.
+
+```agda
+  conservative-reflects-colimits
+    : ∀ {Dia : Functor J C}
+    → Colimit Dia
+    → preserves-colimit F Dia
+    → reflects-colimit F Dia
+```
+</summary>
+
+```agda
+  conservative-reflects-colimits C-colim preservesa {K} {eps} FK-colim =
+    is-invertible→is-colimitp
+      {K = Colimit.Ext C-colim} {etay = Colimit.cocone C-colim} (Colimit.has-colimit C-colim)
+      (eps .η) (λ f → eps .is-natural _ _ f ∙ C.eliml (K .F-id)) refl
+      $ conservative
+      $ invert
+
+    where
+      module C-colim = Colimit C-colim
+      module FC-colim = is-colimit (preservesa C-colim.has-colimit)
+      module FK-colim = is-colimit FK-colim
+
+      uinv : D.Hom (F .F₀ (K .F₀ tt)) (F .F₀ C-colim.coapex)
+      uinv =
+        FK-colim.universal
+          (λ j → F .F₁ (C-colim.ψ j))
+          (λ f → sym (F .F-∘ _ _) ∙ ap (F .F₁) (C-colim.commutes f))
+
+      invert : D.is-invertible (F .F₁ (C-colim.universal (eps .η) _))
+      invert =
+        D.make-invertible uinv
+          (FK-colim.unique₂ _ (λ j → FK-colim.commutes j)
+            (λ j → D.pullr (FK-colim.factors _ _) ∙ F.collapse (C-colim.factors _ _))
+            (λ j → D.idl _))
+          (FC-colim.unique₂ _ (λ j → FC-colim.commutes j)
+            (λ j → F.pullr (C-colim.factors _ _) ∙ FK-colim.factors _ _)
+            (λ j → D.idl _))
+```
+</details>

--- a/src/Cat/Functor/Conservative.lagda.md
+++ b/src/Cat/Functor/Conservative.lagda.md
@@ -139,10 +139,10 @@ about colimits follows by duality.
 </summary>
 
 ```agda
-  conservative-reflects-colimits C-colim preservesa {K} {eps} FK-colim =
+  conservative-reflects-colimits C-colim preservesa {K} {eta} FK-colim =
     is-invertible→is-colimitp
       {K = Colimit.Ext C-colim} {etay = Colimit.cocone C-colim} (Colimit.has-colimit C-colim)
-      (eps .η) (λ f → eps .is-natural _ _ f ∙ C.eliml (K .F-id)) refl
+      (eta .η) (λ f → eta .is-natural _ _ f ∙ C.eliml (K .F-id)) refl
       $ conservative
       $ invert
 
@@ -157,7 +157,7 @@ about colimits follows by duality.
           (λ j → F .F₁ (C-colim.ψ j))
           (λ f → sym (F .F-∘ _ _) ∙ ap (F .F₁) (C-colim.commutes f))
 
-      invert : D.is-invertible (F .F₁ (C-colim.universal (eps .η) _))
+      invert : D.is-invertible (F .F₁ (C-colim.universal (eta .η) _))
       invert =
         D.make-invertible uinv
           (FK-colim.unique₂ _ (λ j → FK-colim.commutes j)

--- a/src/Cat/Functor/Final.lagda.md
+++ b/src/Cat/Functor/Final.lagda.md
@@ -247,14 +247,14 @@ it in this `<details>`{.html} tag for the curious reader only.
         mc : make-is-colimit D coapex
         mc .ψ x = extend-cocone K .η x
         mc .commutes f = extend-cocone K .is-natural _ _ _ ∙ ℰ.idl _
-        mc .universal eps p =
-          colim.universal (λ j → eps (F.₀ j)) λ f → p (F.₁ f)
-        mc .factors {j} eps p =
+        mc .universal eta p =
+          colim.universal (λ j → eta (F.₀ j)) λ f → p (F.₁ f)
+        mc .factors {j} eta p =
           extend-cocone-elim K j
-            (λ ex → mc .universal eps p ℰ.∘ ex ≡ eps j)
+            (λ ex → mc .universal eta p ℰ.∘ ex ≡ eta j)
             (λ _ → hlevel 1)
             λ f → ℰ.pulll (colim.factors _ _) ∙ p (f .map)
-        mc .unique eps p other q =
+        mc .unique eta p other q =
           colim.unique _ _ _ λ j →
             sym (ℰ.refl⟩∘⟨ extend-cocone-is-iso .linv K ηₚ j)
             ∙ q (F.₀ j)

--- a/src/Cat/Functor/Hom/Coyoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Coyoneda.lagda.md
@@ -96,12 +96,12 @@ construct to the identity morphism. Naturality follows from the fact
 that $K$ is a cocone, and the components of $K$ are natural.
 
 ```agda
-    colim .universal eps _ .η x px =  eps (elem x px) .η x id
-    colim .universal {Q} eps comm .is-natural x y f = funext λ px →
-      eps (elem y (P.F₁ f px)) .η y id        ≡˘⟨ (λ i → comm (induce C P f px) i .η y id) ⟩
-      eps (elem x px) .η y (f ∘ id)           ≡⟨ ap (eps (elem x px) .η y) id-comm ⟩
-      eps (elem x px) .η y (id ∘ f)           ≡⟨ happly (eps (elem x px) .is-natural x y f) id ⟩
-      Q .F₁ f (eps (elem x px) .η x id)       ∎
+    colim .universal eta _ .η x px =  eta (elem x px) .η x id
+    colim .universal {Q} eta comm .is-natural x y f = funext λ px →
+      eta (elem y (P.F₁ f px)) .η y id        ≡˘⟨ (λ i → comm (induce C P f px) i .η y id) ⟩
+      eta (elem x px) .η y (f ∘ id)           ≡⟨ ap (eta (elem x px) .η y) id-comm ⟩
+      eta (elem x px) .η y (id ∘ f)           ≡⟨ happly (eta (elem x px) .is-natural x y f) id ⟩
+      Q .F₁ f (eta (elem x px) .η x id)       ∎
 ```
 
 Next, we need to show that this morphism factors each of the components
@@ -109,20 +109,20 @@ of $K$. The tricky bit of the proof here is that we need to use
 `induce`{.Agda} to regard `f` as a morphism in the category of elements.
 
 ```agda
-    colim .factors {o} eps comm = ext λ x f →
-      eps (elem x (P.F₁ f (o .section))) .η x id ≡˘⟨ (λ i → comm (induce C P f (o .section)) i .η x id) ⟩
-      eps o .η x (f ∘ id)                        ≡⟨ ap (eps o .η x) (idr f) ⟩
-      eps o .η x f                               ∎
+    colim .factors {o} eta comm = ext λ x f →
+      eta (elem x (P.F₁ f (o .section))) .η x id ≡˘⟨ (λ i → comm (induce C P f (o .section)) i .η x id) ⟩
+      eta o .η x (f ∘ id)                        ≡⟨ ap (eta o .η x) (idr f) ⟩
+      eta o .η x f                               ∎
 ```
 
 Finally, uniqueness: This just follows by the commuting conditions on
 `α`.
 
 ```agda
-    colim .unique eps comm α p = ext λ x px →
+    colim .unique eta comm α p = ext λ x px →
       α .η x px               ≡˘⟨ ap (α .η x) (happly P.F-id px) ⟩
       α .η x (P.F₁ id px)     ≡⟨ happly (p _ ηₚ x) id ⟩
-      eps (elem x px) .η x id ∎
+      eta (elem x px) .η x id ∎
 ```
 
 And that's it! The important takeaway here is not the shuffling around

--- a/src/Cat/Functor/Hom/Representable.lagda.md
+++ b/src/Cat/Functor/Hom/Representable.lagda.md
@@ -412,8 +412,8 @@ Hom-from-preserves-limits c {Diagram = Dia} {K} {eps} lim =
   ml .commutes f = funext λ g →
     C.pulll (sym (eps .is-natural _ _ _))
     ∙ (C.elimr (K .F-id) C.⟩∘⟨refl)
-  ml .universal eta p x =
-    lim.universal (λ j → eta j x) (λ f → p f $ₚ x)
+  ml .universal eps p x =
+    lim.universal (λ j → eps j x) (λ f → p f $ₚ x)
   ml .factors _ _ = funext λ _ →
     lim.factors _ _
   ml .unique eps p other q = funext λ x →
@@ -462,11 +462,11 @@ a pair of maps $a \to x$ and $b \to x$.
   mc .commutes f = funext λ g →
     C.pullr (eta .is-natural _ _ _)
     ∙ (C.refl⟩∘⟨ C.eliml (K .F-id))
-  mc .universal eps p x =
-    colim.universal (λ j → eps j x) (λ f → p f $ₚ x)
-  mc .factors eps p = funext λ _ →
+  mc .universal eta p x =
+    colim.universal (λ j → eta j x) (λ f → p f $ₚ x)
+  mc .factors eta p = funext λ _ →
     colim.factors _ _
-  mc .unique eps p other q = funext λ x →
+  mc .unique eta p other q = funext λ x →
     colim.unique _ _ _ λ j → q j $ₚ x
 
 representable-reverses-colimits

--- a/src/Cat/Functor/Kan/Base.lagda.md
+++ b/src/Cat/Functor/Kan/Base.lagda.md
@@ -214,51 +214,57 @@ record Ran (p : Functor C C') (F : Functor C D) : Type (kan-lvl p F) where
 
 <!--
 ```agda
-is-lan-is-prop
-  : {p : Functor C C'} {F : Functor C D} {G : Functor C' D} {eta : F => G F∘ p}
-  → is-prop (is-lan p F G eta)
-is-lan-is-prop {p = p} {F} {G} {eta} a b = path where
-  private
-    module a = is-lan a
-    module b = is-lan b
+module _ {p : Functor C C'} {F : Functor C D} {G : Functor C' D} {eta : F => G F∘ p} where
+  is-lan-is-prop : is-prop (is-lan p F G eta)
+  is-lan-is-prop a b = path where
+    private
+      module a = is-lan a
+      module b = is-lan b
 
-  σ≡ : {M : Functor _ _} (α : F => M F∘ p) → a.σ α ≡ b.σ α
-  σ≡ α = ext (a.σ-uniq (sym b.σ-comm) ηₚ_)
+    σ≡ : {M : Functor _ _} (α : F => M F∘ p) → a.σ α ≡ b.σ α
+    σ≡ α = ext (a.σ-uniq (sym b.σ-comm) ηₚ_)
 
-  open is-lan
-  path : a ≡ b
-  path i .σ α = σ≡ α i
-  path i .σ-comm {α = α} =
-    is-prop→pathp (λ i → Nat-is-set ((σ≡ α i ◂ p) ∘nt eta) α)
-      (a.σ-comm {α = α}) (b.σ-comm {α = α})
-      i
-  path i .σ-uniq {α = α} β =
-    is-prop→pathp (λ i → Nat-is-set (σ≡ α i) _)
-      (a.σ-uniq β) (b.σ-uniq β)
-      i
+    open is-lan
+    path : a ≡ b
+    path i .σ α = σ≡ α i
+    path i .σ-comm {α = α} =
+      is-prop→pathp (λ i → Nat-is-set ((σ≡ α i ◂ p) ∘nt eta) α)
+        (a.σ-comm {α = α}) (b.σ-comm {α = α})
+        i
+    path i .σ-uniq {α = α} β =
+      is-prop→pathp (λ i → Nat-is-set (σ≡ α i) _)
+        (a.σ-uniq β) (b.σ-uniq β)
+        i
 
-is-ran-is-prop
-  : {p : Functor C C'} {F : Functor C D} {G : Functor C' D} {eps : G F∘ p => F}
-  → is-prop (is-ran p F G eps)
-is-ran-is-prop {p = p} {F} {G} {eps} a b = path where
-  private
-    module a = is-ran a
-    module b = is-ran b
+  instance
+    H-Level-is-lan : ∀ {k} → H-Level (is-lan p F G eta) (suc k)
+    H-Level-is-lan = prop-instance is-lan-is-prop
 
-  σ≡ : {M : Functor _ _} (α : M F∘ p => F) → a.σ α ≡ b.σ α
-  σ≡ α = ext (a.σ-uniq (sym b.σ-comm) ηₚ_)
+module _ {p : Functor C C'} {F : Functor C D} {G : Functor C' D} {eps : G F∘ p => F} where
+  is-ran-is-prop : is-prop (is-ran p F G eps)
+  is-ran-is-prop a b = path where
+    private
+      module a = is-ran a
+      module b = is-ran b
 
-  open is-ran
-  path : a ≡ b
-  path i .σ α = σ≡ α i
-  path i .σ-comm {β = α} =
-    is-prop→pathp (λ i → Nat-is-set (eps ∘nt (σ≡ α i ◂ p)) α)
-      (a.σ-comm {β = α}) (b.σ-comm {β = α})
-      i
-  path i .σ-uniq {β = α} γ =
-    is-prop→pathp (λ i → Nat-is-set (σ≡ α i) _)
-      (a.σ-uniq γ) (b.σ-uniq γ)
-      i
+    σ≡ : {M : Functor _ _} (α : M F∘ p => F) → a.σ α ≡ b.σ α
+    σ≡ α = ext (a.σ-uniq (sym b.σ-comm) ηₚ_)
+
+    open is-ran
+    path : a ≡ b
+    path i .σ α = σ≡ α i
+    path i .σ-comm {β = α} =
+      is-prop→pathp (λ i → Nat-is-set (eps ∘nt (σ≡ α i ◂ p)) α)
+        (a.σ-comm {β = α}) (b.σ-comm {β = α})
+        i
+    path i .σ-uniq {β = α} γ =
+      is-prop→pathp (λ i → Nat-is-set (σ≡ α i) _)
+        (a.σ-uniq γ) (b.σ-uniq γ)
+        i
+
+  instance
+    H-Level-is-ran : ∀ {k} → H-Level (is-ran p F G eps) (suc k)
+    H-Level-is-ran = prop-instance is-ran-is-prop
 ```
 -->
 

--- a/src/Cat/Functor/Kan/Reflection.agda
+++ b/src/Cat/Functor/Kan/Reflection.agda
@@ -1,0 +1,66 @@
+open import 1Lab.Reflection.Subst
+open import 1Lab.Reflection
+
+open import Cat.Functor.Naturality.Reflection
+open import Cat.Functor.Kan.Unique
+open import Cat.Functor.Naturality
+open import Cat.Functor.Kan.Base
+open import Cat.Functor.Compose
+open import Cat.Functor.Base
+open import Cat.Reasoning
+open import Cat.Prelude
+
+module Cat.Functor.Kan.Reflection where
+
+module _
+    {o ℓ o' ℓ' od ℓd}
+    {C : Precategory o ℓ} {C' : Precategory o' ℓ'} {D : Precategory od ℓd}
+    {p p' : Functor C C'} {F F' : Functor C D}
+    {G G' : Functor C' D} {eta : F => G F∘ p} {eta' : F' => G' F∘ p'}
+    where
+
+  cohere-eta! : Term → TC ⊤
+  cohere-eta! hole = do
+    `D ← quoteTC D
+    `G' ← quoteTC G'
+    unify hole $ def₀ (quote Nat-path)
+      ##ₙ vlam "c" (def₀ (quote _··_··_)
+        ##ₙ (def₀ (quote eliml)
+          ##ₙ raise 1 `D
+          ##ₙ (def₀ (quote eliml)
+            ##ₙ raise 1 `D
+            ##ₙ (def₀ (quote Functor.F-id) ##ₙ raise 1 `G')))
+        ##ₙ def₀ (quote trivial!)
+        ##ₙ (def₀ (quote idr) ##ₙ raise 1 `D ##ₙ unknown))
+
+  trivial-is-lan!
+    : {@(tactic trivial-isoⁿ p p') p-iso : p ≅ⁿ p'}
+    → {@(tactic trivial-isoⁿ F F') F-iso : F ≅ⁿ F'}
+    → {@(tactic trivial-isoⁿ G G') G-iso : G ≅ⁿ G'}
+    → {@(tactic cohere-eta!) q : (Isoⁿ.to G-iso ◆ Isoⁿ.to p-iso) ∘nt eta ∘nt Isoⁿ.from F-iso ≡ eta'}
+    → is-lan p F G eta
+    → is-lan p' F' G' eta'
+  trivial-is-lan! {p-iso = p-iso} {F-iso} {G-iso} {q} =
+    natural-isos→is-lan p-iso F-iso G-iso q
+
+  trivial-lan-equiv!
+    : {@(tactic trivial-isoⁿ p p') p-iso : p ≅ⁿ p'}
+    → {@(tactic trivial-isoⁿ F F') F-iso : F ≅ⁿ F'}
+    → {@(tactic trivial-isoⁿ G G') G-iso : G ≅ⁿ G'}
+    → {@(tactic cohere-eta!) q : (Isoⁿ.to G-iso ◆ Isoⁿ.to p-iso) ∘nt eta ∘nt Isoⁿ.from F-iso ≡ eta'}
+    → is-lan p F G eta
+    ≃ is-lan p' F' G' eta'
+  trivial-lan-equiv! {p-iso = p-iso} {F-iso} {G-iso} {q} =
+    natural-isos→lan-equiv p-iso F-iso G-iso q
+
+-- Tests
+
+module _
+    {o ℓ o' ℓ' od ℓd}
+    {C : Precategory o ℓ} {C' : Precategory o' ℓ'} {D : Precategory od ℓd}
+    {p : Functor C C'} {F : Functor C D}
+    {G : Functor C' D} {eta}
+    where
+
+  _ : is-lan p F G eta → is-lan p F G eta
+  _ = trivial-is-lan!

--- a/src/Cat/Functor/Kan/Reflection.agda
+++ b/src/Cat/Functor/Kan/Reflection.agda
@@ -2,6 +2,7 @@ open import 1Lab.Reflection.Subst
 open import 1Lab.Reflection
 
 open import Cat.Functor.Naturality.Reflection
+open import Cat.Instances.Shape.Terminal
 open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Naturality
 open import Cat.Functor.Kan.Base
@@ -52,6 +53,31 @@ module _
     ≃ is-lan p' F' G' eta'
   trivial-lan-equiv! {p-iso = p-iso} {F-iso} {G-iso} {q} =
     natural-isos→lan-equiv p-iso F-iso G-iso q
+
+module _
+    {o ℓ od ℓd}
+    {C : Precategory o ℓ} {D : Precategory od ℓd}
+    {F F' : Functor C D}
+    {G G' : Functor ⊤Cat D} {eta : F => G F∘ !F} {eta' : F' => G' F∘ !F}
+    where
+
+  trivial-is-colimit!
+    : {@(tactic trivial-isoⁿ F F') F-iso : F ≅ⁿ F'}
+    → {@(tactic trivial-isoⁿ G G') G-iso : G ≅ⁿ G'}
+    → {@(tactic cohere-eta! {eta = eta} {eta' = eta'}) q : (Isoⁿ.to G-iso ◆ Isoⁿ.to idni) ∘nt eta ∘nt Isoⁿ.from F-iso ≡ eta'}
+    → is-lan !F F G eta
+    → is-lan !F F' G' eta'
+  trivial-is-colimit! {F-iso = F-iso} {G-iso} {q} =
+    natural-isos→is-lan idni F-iso G-iso q
+
+  trivial-colimit-equiv!
+    : {@(tactic trivial-isoⁿ F F') F-iso : F ≅ⁿ F'}
+    → {@(tactic trivial-isoⁿ G G') G-iso : G ≅ⁿ G'}
+    → {@(tactic cohere-eta! {eta = eta} {eta' = eta'}) q : (Isoⁿ.to G-iso ◆ Isoⁿ.to idni) ∘nt eta ∘nt Isoⁿ.from F-iso ≡ eta'}
+    → is-lan !F F G eta
+    ≃ is-lan !F F' G' eta'
+  trivial-colimit-equiv! {F-iso = F-iso} {G-iso} {q} =
+    natural-isos→lan-equiv idni F-iso G-iso q
 
 -- Tests
 

--- a/src/Cat/Functor/Kan/Unique.lagda.md
+++ b/src/Cat/Functor/Kan/Unique.lagda.md
@@ -2,6 +2,7 @@
 ```agda
 open import Cat.Functor.Naturality
 open import Cat.Functor.Univalence
+open import Cat.Instances.Functor
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Compose
 open import Cat.Functor.Base
@@ -46,7 +47,7 @@ of $F$ along $p$".
 ```agda
 private variable
   o ℓ : Level
-  C C' D : Precategory o ℓ
+  C C' D E : Precategory o ℓ
 
 module
   Lan-unique
@@ -262,6 +263,7 @@ module _
     {G G' : Functor C' D} {eps eps'}
     where
   private
+    module C' = Cat.Reasoning C'
     module D = Cat.Reasoning D
     open Cat.Functor.Reasoning
     open _=>_
@@ -278,7 +280,7 @@ which is propositionally equal to the whiskering:
     : (p-iso : p ≅ⁿ p')
     → (F-iso : F ≅ⁿ F')
     → (G-iso : G ≅ⁿ G')
-    → ((Isoⁿ.to G-iso ◆ Isoⁿ.to p-iso) ∘nt eps ∘nt Isoⁿ.from F-iso) ≡ eps'
+    → (Isoⁿ.to G-iso ◆ Isoⁿ.to p-iso) ∘nt eps ∘nt Isoⁿ.from F-iso ≡ eps'
     → is-lan p F G eps
     → is-lan p' F' G' eps'
 ```
@@ -292,8 +294,53 @@ which is propositionally equal to the whiskering:
         G-iso)
       (ext λ x → D.extendl (D.pulll (G-iso .to .is-natural _ _ _)) ∙ q ηₚ _)
     where open Isoⁿ
+
+module _
+    {p p' : Functor C C'} {F F' : Functor C D}
+    {G G' : Functor C' D} {eps eps'}
+    where
+  open Cat.Reasoning Cat[ C , D ]
+  private module ◆ = Cat.Functor.Reasoning (F∘-functor {B = C'} {C = D} {A = C})
+
+  natural-isos→lan-equiv
+    : (p-iso : p ≅ⁿ p')
+    → (F-iso : F ≅ⁿ F')
+    → (G-iso : G ≅ⁿ G')
+    → (Isoⁿ.to G-iso ◆ Isoⁿ.to p-iso) ∘nt eps ∘nt Isoⁿ.from F-iso ≡ eps'
+    → is-lan p F G eps
+    ≃ is-lan p' F' G' eps'
+  natural-isos→lan-equiv p-iso F-iso G-iso q = prop-ext!
+    (natural-isos→is-lan p-iso F-iso G-iso q)
+    (natural-isos→is-lan (p-iso ni⁻¹) (F-iso ni⁻¹) (G-iso ni⁻¹)
+      (lswizzle (rswizzle (sym q ∙ assoc _ _ _) (F-iso .Isoⁿ.invr)) (◆.annihilate (G-iso .Isoⁿ.invr ,ₚ p-iso .Isoⁿ.invr))))
 ```
 -->
+
+As a consequence of uniqueness, if a functor preserves a given Kan
+extension, then it preserves *all* extensions for the same diagram.
+
+```agda
+preserves-lan→preserves-all
+  : ∀ (H : Functor D E) {p : Functor C C'} {F : Functor C D}
+  → ∀ {G} {eta : F => G F∘ p} (lan : is-lan p F G eta)
+  → preserves-lan H lan
+  → ∀ {G'} {eta' : F => G' F∘ p} (lan' : is-lan p F G' eta')
+  → preserves-lan H lan'
+preserves-lan→preserves-all {E = E} {C' = C'} H lan pres {G'} lan' =
+  natural-isos→is-lan idni idni
+    (F∘-iso-r One.unique)
+    (ext λ c →
+      (H.₁ (G'.₁ C'.id) E.∘ H.₁ _) E.∘ H.₁ _ E.∘ E.id ≡⟨ E.pullr (H.pulll (One.unit ηₚ c)) ⟩
+      H.₁ (G'.₁ C'.id) E.∘ H.₁ _ E.∘ E.id             ≡⟨ H.eliml G'.F-id ∙ E.idr _ ⟩
+      H.₁ _                                           ∎)
+    pres
+  where
+    module C' = Cat.Reasoning C'
+    module E = Cat.Reasoning E
+    module H = Cat.Functor.Reasoning H
+    module G' = Cat.Functor.Reasoning G'
+    module One = Lan-unique lan lan'
+```
 
 ## Into univalent categories
 
@@ -511,7 +558,7 @@ module _
     : (p-iso : p ≅ⁿ p')
     → (F-iso : F ≅ⁿ F')
     → (G-iso : G ≅ⁿ G')
-    → (Isoⁿ.to F-iso ∘nt eps ∘nt (Isoⁿ.from G-iso ◆ Isoⁿ.from p-iso)) ≡ eps'
+    → Isoⁿ.to F-iso ∘nt eps ∘nt (Isoⁿ.from G-iso ◆ Isoⁿ.from p-iso) ≡ eps'
     → is-ran p F G eps
     → is-ran p' F' G' eps'
   natural-isos→is-ran p-iso F-iso G-iso p ran =
@@ -521,6 +568,46 @@ module _
         F-iso)
       G-iso)
     (ext λ c → sym (D.assoc _ _ _) ·· ap₂ D._∘_ refl (sym $ D.assoc _ _ _) ·· p ηₚ _)
+
+module _
+    {p p' : Functor C C'} {F F' : Functor C D}
+    {G G' : Functor C' D} {eps eps'}
+    where
+  open Cat.Reasoning Cat[ C , D ]
+  private module ◆ = Cat.Functor.Reasoning (F∘-functor {B = C'} {C = D} {A = C})
+
+  natural-isos→ran-equiv
+    : (p-iso : p ≅ⁿ p')
+    → (F-iso : F ≅ⁿ F')
+    → (G-iso : G ≅ⁿ G')
+    → Isoⁿ.to F-iso ∘nt eps ∘nt (Isoⁿ.from G-iso ◆ Isoⁿ.from p-iso) ≡ eps'
+    → is-ran p F G eps
+    ≃ is-ran p' F' G' eps'
+  natural-isos→ran-equiv p-iso F-iso G-iso q = prop-ext!
+    (natural-isos→is-ran p-iso F-iso G-iso q)
+    (natural-isos→is-ran (p-iso ni⁻¹) (F-iso ni⁻¹) (G-iso ni⁻¹)
+      (lswizzle (rswizzle (sym q ∙ assoc _ _ _) (◆.annihilate (G-iso .Isoⁿ.invr ,ₚ p-iso .Isoⁿ.invr))) (F-iso .Isoⁿ.invr)))
+
+preserves-ran→preserves-all
+  : ∀ (H : Functor D E) {p : Functor C C'} {F : Functor C D}
+  → ∀ {G} {eps : G F∘ p => F} (ran : is-ran p F G eps)
+  → preserves-ran H ran
+  → ∀ {G'} {eps' : G' F∘ p => F} (ran' : is-ran p F G' eps')
+  → preserves-ran H ran'
+preserves-ran→preserves-all {E = E} {C' = C'} H {G = G} ran pres ran' =
+  natural-isos→is-ran idni idni
+    (F∘-iso-r One.unique)
+    (ext λ c →
+      E.id E.∘ H.₁ _ E.∘ H.₁ (G.₁ C'.id) E.∘ H.₁ _ ≡⟨ E.idl _ ∙ (E.refl⟩∘⟨ H.eliml G.F-id) ⟩
+      H.₁ _ E.∘ H.₁ _                              ≡⟨ H.collapse (One.counit ηₚ c) ⟩
+      H.₁ _                                        ∎)
+    pres
+  where
+    module C' = Cat.Reasoning C'
+    module E = Cat.Reasoning E
+    module H = Cat.Functor.Reasoning H
+    module G = Cat.Functor.Reasoning G
+    module One = Ran-unique ran ran'
 
 Ran-is-prop
   : ∀ {p : Functor C C'} {F : Functor C D} → is-category D → is-prop (Ran p F)

--- a/src/Cat/Functor/Naturality/Reflection.agda
+++ b/src/Cat/Functor/Naturality/Reflection.agda
@@ -1,0 +1,51 @@
+open import 1Lab.Reflection.Subst
+open import 1Lab.Reflection
+
+open import Cat.Instances.Shape.Terminal
+open import Cat.Functor.Naturality
+open import Cat.Reasoning
+open import Cat.Prelude
+
+module Cat.Functor.Naturality.Reflection where
+
+module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} where
+
+  -- Tactic worker for filling in trivial natural isomorphisms F ≅ⁿ G.
+  --
+  -- The assumptions are:
+  -- 1. ∀ x, F .F₀ x is definitionally equal to G .F₀ x
+  -- 2. ∀ f, F .F₁ f is extensionally equal (by `trivial!`) to G .F₁ f
+  --    OR C = ⊤Cat
+  --
+  -- The functor arguments are only used for type inference.
+  trivial-isoⁿ : (F G : Functor C D) → Term → TC ⊤
+  trivial-isoⁿ _ _ hole = do
+    `C ← quoteTC C
+    `D ← quoteTC D
+    wait-just-a-bit `C >>= unify hole ⊙ λ where
+      (def₀ (quote ⊤Cat)) → def₀ (quote iso→⊤-natural-iso)
+        ##ₙ (def₀ (quote id-iso) ##ₙ `D)
+      _ → def₀ (quote iso→isoⁿ)
+        ##ₙ vlam "" (def₀ (quote id-iso) ##ₙ raise 1 `D)
+        ##ₙ vlam ""
+          (def₀ (quote _··_··_)
+            ##ₙ (def₀ (quote idr) ##ₙ raise 1 `D ##ₙ unknown)
+            ##ₙ def₀ (quote trivial!)
+            ##ₙ (def₀ (quote sym)
+              ##ₙ (def₀ (quote idl) ##ₙ raise 1 `D ##ₙ unknown)))
+
+  trivial-isoⁿ!
+    : ∀ {F G : Functor C D}
+    → {@(tactic trivial-isoⁿ F G) is : F ≅ⁿ G}
+    → F ≅ⁿ G
+  trivial-isoⁿ! {is = is} = is
+
+-- Tests
+
+module _ {o ℓ} {C : Precategory o ℓ} where
+
+  _ : ∀ {F : Functor C C} → F ≅ⁿ F
+  _ = trivial-isoⁿ!
+
+  _ : ∀ {K : Functor ⊤Cat C} → const! (K .Functor.F₀ _) ≅ⁿ K
+  _ = trivial-isoⁿ!

--- a/src/Cat/Functor/Properties.lagda.md
+++ b/src/Cat/Functor/Properties.lagda.md
@@ -36,7 +36,7 @@ is-full {C = C} {D = D} F = ∀ {x y} → is-surjective (F .F₁ {x = x} {y})
 ```
 :::
 
-:::{.definition #faithful-functor}
+:::{.definition #faithful-functor alias="faithful"}
 A functor is **faithful** when its action on hom-sets is injective:
 
 ```agda

--- a/src/Cat/Functor/Pullback.lagda.md
+++ b/src/Cat/Functor/Pullback.lagda.md
@@ -5,6 +5,7 @@ open import Cat.Functor.Properties
 open import Cat.Diagram.Pullback
 open import Cat.Diagram.Initial
 open import Cat.Functor.Adjoint
+open import Cat.Functor.Compose
 open import Cat.Instances.Comma
 open import Cat.Instances.Slice
 open import Cat.Prelude
@@ -26,6 +27,7 @@ open is-pullback
 open Pullback
 open Initial
 open Functor
+open _=>_
 open /-Obj
 open /-Hom
 ```
@@ -34,7 +36,7 @@ open /-Hom
 # Base change {defines="pullback-functor"}
 
 Let $\cC$ be a category with all [[pullbacks]], and $f : Y \to X$ a
-morphism in $\cC$. Then we have a functor $f* : \cC/X \to \cC/Y$, called
+morphism in $\cC$. Then we have a functor $f^* : \cC/X \to \cC/Y$, called
 the **base change**, where the action on objects is given by pulling
 back along $f$.
 
@@ -131,7 +133,6 @@ module _ {X Y : Ob} (f : Hom Y X) where
   Σf .F-∘ f g = trivial!
 
   open _⊣_
-  open _=>_
 ```
 
 <!--
@@ -212,4 +213,41 @@ module _ (pullbacks : ∀ {X Y Z} f g → Pullback C {X} {Y} {Z} f g) {X Y : Ob}
       (pulll pb.p₂∘universal ∙ pb'.p₂∘universal))) where
     module pb = Pullback (pullbacks (B .map) f)
     module pb' = Pullback (pullbacks (f ∘ pb.p₂) f)
+```
+
+## Equifibred natural transformations {defines="equifibred cartesian-natural-transformation"}
+
+A [[natural transformation]] $F \To G$ is called **equifibred**, or
+**cartesian**, if each of its naturality squares is a [[pullback]]:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  Fa & Fb \\
+  Ga & Gb
+  \arrow["Ff", from=1-1, to=1-2]
+  \arrow["{\alpha_a}"', from=1-1, to=2-1]
+  \arrow["Gf"', from=2-1, to=2-2]
+  \arrow["{\alpha_b}", from=1-2, to=2-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+```agda
+is-equifibred
+  : ∀ {oj ℓj} {J : Precategory oj ℓj} {F G : Functor J C}
+  → F => G → Type _
+is-equifibred {J = J} {F} {G} α =
+  ∀ {x y} (f : J .Precategory.Hom x y)
+  → is-pullback C (F .F₁ f) (α .η y) (α .η x) (G .F₁ f)
+```
+
+An easy property of equifibered transformations is that they are
+closed under pre-whiskering:
+
+```agda
+◂-equifibred
+  : ∀ {oj ℓj ok ℓk} {J : Precategory oj ℓj} {K : Precategory ok ℓk}
+  → {F G : Functor J C} (H : Functor K J) (α : F => G)
+  → is-equifibred α → is-equifibred (α ◂ H)
+◂-equifibred H α eq f = eq (H .F₁ f)
 ```

--- a/src/Cat/Instances/Functor/Limits.lagda.md
+++ b/src/Cat/Instances/Functor/Limits.lagda.md
@@ -99,20 +99,20 @@ homomorphism $K \to \lim F(-, x)$ will be called `!-for`{.Agda}.
       D-lim.factors _ _ _ ∙ ap₂ C._∘_ (C.eliml (F.F-id ηₚ _)) refl
     ml .commutes f = ext λ j →
       C.pushr (C.introl (F.₀ _ .F-id)) ∙ D-lim.commutes j f
-    ml .universal eta p .η x = D-lim.universal x
-      (λ j → eta j .η x)
+    ml .universal eps p .η x = D-lim.universal x
+      (λ j → eps j .η x)
       (λ f → ap₂ C._∘_ (C.elimr (F.₀ _ .F-id)) refl ∙ p f ηₚ x)
-    ml .universal eta p .is-natural x y f = D-lim.unique₂ y _
+    ml .universal eps p .is-natural x y f = D-lim.unique₂ y _
       (λ g → C.pulll (ap₂ C._∘_ (C.elimr (F.₀ _ .F-id)) refl ∙ p g ηₚ y))
       (λ j → C.pulll (D-lim.factors _ _ _))
       (λ j →
           C.pulll (D-lim.factors _ _ _)
         ∙ C.pullr (D-lim.factors _ _ _)
         ∙ ap₂ C._∘_ (C.eliml (F.F-id ηₚ _)) refl
-        ∙ sym (eta j .is-natural x y f))
-    ml .factors eta p = ext λ j →
+        ∙ sym (eps j .is-natural x y f))
+    ml .factors eps p = ext λ j →
       D-lim.factors j _ _
-    ml .unique eta p other q = ext λ x →
+    ml .unique eps p other q = ext λ x →
       D-lim.unique _ _ _ _ λ j → q j ηₚ x
 ```
 

--- a/src/Cat/Instances/Sets/Cocomplete.lagda.md
+++ b/src/Cat/Instances/Sets/Cocomplete.lagda.md
@@ -115,23 +115,23 @@ definition.
 
 ```agda
   univ : ∀ {A : Set (ι ⊔ κ ⊔ o)}
-       → (eps : ∀ j → F ʻ j → ∣ A ∣)
-       → (∀ {x y} (f : D.Hom x y) → ∀ Fx → eps y (F.F₁ f Fx) ≡ eps x Fx)
+       → (eta : ∀ j → F ʻ j → ∣ A ∣)
+       → (∀ {x y} (f : D.Hom x y) → ∀ Fx → eta y (F.F₁ f Fx) ≡ eta x Fx)
        → sum / rel
        → ∣ A ∣
-  univ {A} eps p =
+  univ {A} eta p =
     Coeq-rec
-      (λ { (x , p) → eps x p })
-      (λ { ((X , x) , (Y , y) , f , q) → sym (p f x) ∙ ap (eps _) q})
+      (λ { (x , p) → eta x p })
+      (λ { ((X , x) , (Y , y) , f , q) → sym (p f x) ∙ ap (eta _) q})
 
   colim : make-is-colimit F (el! (sum / rel))
   colim .ψ x p = inc (x , p)
   colim .commutes f = funext λ _ → sym (quot (f , refl))
-  colim .universal {A} eps p x = univ {A} eps (λ f → happly (p f)) x
-  colim .factors eps p = refl
-  colim .unique {A} eps p other q = funext λ x →
+  colim .universal {A} eta p x = univ {A} eta (λ f → happly (p f)) x
+  colim .factors eta p = refl
+  colim .unique {A} eta p other q = funext λ x →
     Coeq-elim-prop
-      (λ x →  A .is-tr (other x) (univ {A} eps (λ f → happly (p f)) x))
+      (λ x →  A .is-tr (other x) (univ {A} eta (λ f → happly (p f)) x))
       (λ x → happly (q (x .fst)) (x .snd))
       x
 ```

--- a/src/Cat/Instances/Shape/Join.lagda.md
+++ b/src/Cat/Instances/Shape/Join.lagda.md
@@ -1,8 +1,12 @@
 <!--
 ```agda
+open import Cat.Instances.Shape.Terminal
 open import Cat.Prelude
 
 open import Data.Sum
+
+open Precategory
+open Functor
 ```
 -->
 
@@ -21,7 +25,6 @@ module _ {o ℓ o' ℓ'} (C : Precategory o ℓ) (D : Precategory o' ℓ') where
   private
     module C = Precategory C
     module D = Precategory D
-    open Precategory
 
   ⋆Ob : Type (o ⊔ o')
   ⋆Ob = C.Ob ⊎ D.Ob
@@ -60,4 +63,83 @@ module _ {o ℓ o' ℓ'} (C : Precategory o ℓ) (D : Precategory o' ℓ') where
   _⋆_ .assoc {inl w} {inl x} {inr y} {inr z} (lift f) (lift g) (lift h) = refl
   _⋆_ .assoc {inl w} {inr x} {inr y} {inr z} (lift f) (lift g) (lift h) = refl
   _⋆_ .assoc {inr w} {inr x} {inr y} {inr z} (lift f) (lift g) (lift h) = ap lift (D.assoc f g h)
+
+module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} where
+  ⋆-inl : Functor C (C ⋆ D)
+  ⋆-inl .F₀ = inl
+  ⋆-inl .F₁ = lift
+  ⋆-inl .F-id = refl
+  ⋆-inl .F-∘ f g = refl
+
+  ⋆-inr : Functor D (C ⋆ D)
+  ⋆-inr .F₀ = inr
+  ⋆-inr .F₁ = lift
+  ⋆-inr .F-id = refl
+  ⋆-inr .F-∘ f g = refl
+
+module _ {oc ℓc od ℓd oe ℓe}
+  {C : Precategory oc ℓc} {D : Precategory od ℓd} {E : Precategory oe ℓe}
+  where
+
+  ⋆-mapl : Functor C D → Functor (C ⋆ E) (D ⋆ E)
+  ⋆-mapl F .F₀ = ⊎-mapl (F .F₀)
+  ⋆-mapl F .F₁ {inl x} {inl y} (lift f) = lift (F .F₁ f)
+  ⋆-mapl F .F₁ {inl x} {inr y} _ = _
+  ⋆-mapl F .F₁ {inr x} {inr y} (lift f) = lift f
+  ⋆-mapl F .F-id {inl x} = ap lift (F .F-id)
+  ⋆-mapl F .F-id {inr x} = refl
+  ⋆-mapl F .F-∘ {inl x} {inl y} {inl z} f g = ap lift (F .F-∘ _ _)
+  ⋆-mapl F .F-∘ {inl x} {inl y} {inr z} f g = refl
+  ⋆-mapl F .F-∘ {inl x} {inr y} {inr z} f g = refl
+  ⋆-mapl F .F-∘ {inr x} {inr y} {inr z} f g = refl
+
+  ⋆-mapr : Functor D E → Functor (C ⋆ D) (C ⋆ E)
+  ⋆-mapr F .F₀ = ⊎-mapr (F .F₀)
+  ⋆-mapr F .F₁ {inl x} {inl y} (lift f) = lift f
+  ⋆-mapr F .F₁ {inl x} {inr y} _ = _
+  ⋆-mapr F .F₁ {inr x} {inr y} (lift f) = lift (F .F₁ f)
+  ⋆-mapr F .F-id {inl x} = refl
+  ⋆-mapr F .F-id {inr x} = ap lift (F .F-id)
+  ⋆-mapr F .F-∘ {inl x} {inl y} {inl z} f g = refl
+  ⋆-mapr F .F-∘ {inl x} {inl y} {inr z} f g = refl
+  ⋆-mapr F .F-∘ {inl x} {inr y} {inr z} f g = refl
+  ⋆-mapr F .F-∘ {inr x} {inr y} {inr z} f g = ap lift (F .F-∘ _ _)
+```
+
+## Adjoining a terminal object {defines="adjoined-terminal-object"}
+
+Given a category $\cJ$, we can freely adjoin a [[terminal object]] to $\cJ$ by taking
+the join $\cJ^\triangleright = \cJ \star \top$ with the [[terminal category]].
+
+```agda
+_▹ : ∀ {o ℓ} → Precategory o ℓ → Precategory o ℓ
+J ▹ = J ⋆ ⊤Cat
+
+module _ {o ℓ} {J : Precategory o ℓ} where
+  ▹-in : Functor J (J ▹)
+  ▹-in = ⋆-inl
+
+  ▹-join : Functor (J ▹ ▹) (J ▹)
+  ▹-join .F₀ (inl (inl j)) = inl j
+  ▹-join .F₀ (inl (inr _)) = inr _
+  ▹-join .F₀ (inr _) = inr _
+  ▹-join .F₁ {inl (inl x)} {inl (inl y)} (lift f) = f
+  ▹-join .F₁ {inl (inl x)} {inl (inr y)} f = _
+  ▹-join .F₁ {inl (inl x)} {inr y} f = _
+  ▹-join .F₁ {inl (inr x)} {inl (inr y)} f = _
+  ▹-join .F₁ {inl (inr x)} {inr y} f = _
+  ▹-join .F₁ {inr x} {inr y} f = _
+  ▹-join .F-id {inl (inl x)} = refl
+  ▹-join .F-id {inl (inr x)} = refl
+  ▹-join .F-id {inr x} = refl
+  ▹-join .F-∘ {inl (inl x)} {inl (inl y)} {inl (inl z)} f g = refl
+  ▹-join .F-∘ {inl (inl x)} {inl (inl y)} {inl (inr z)} f g = refl
+  ▹-join .F-∘ {inl (inl x)} {inl (inl y)} {inr z} f g = refl
+  ▹-join .F-∘ {inl (inl x)} {inl (inr y)} {inl (inr z)} f g = refl
+  ▹-join .F-∘ {inl (inl x)} {inl (inr y)} {inr z} f g = refl
+  ▹-join .F-∘ {inl (inl x)} {inr y} {inr z} f g = refl
+  ▹-join .F-∘ {inl (inr x)} {inl (inr y)} {inl (inr z)} f g = refl
+  ▹-join .F-∘ {inl (inr x)} {inl (inr y)} {inr z} f g = refl
+  ▹-join .F-∘ {inl (inr x)} {inr y} {inr z} f g = refl
+  ▹-join .F-∘ {inr x} {inr y} {inr z} f g = refl
 ```

--- a/src/Cat/Instances/Slice/Colimit.lagda.md
+++ b/src/Cat/Instances/Slice/Colimit.lagda.md
@@ -115,13 +115,13 @@ with the relevant maps into $c$; this follows from the uniqueness of
 the universal map.
 
 ```agda
-      mk .universal eta' comm .map = UF-colim.universal
-        (λ j → eta' j .map)
+      mk .universal eta comm .map = UF-colim.universal
+        (λ j → eta j .map)
         (λ f → unext (comm f))
-      mk .universal eta' comm .commutes = ext (UF-colim.unique _ _ _ λ j →
-        C.pullr (UF-colim.factors _ _) ∙ eta' j .commutes)
-      mk .factors eta' comm = ext (UF-colim.factors _ _)
-      mk .unique eta' comm u fac = ext (UF-colim.unique _ _ _ λ j →
+      mk .universal eta comm .commutes = ext (UF-colim.unique _ _ _ λ j →
+        C.pullr (UF-colim.factors _ _) ∙ eta j .commutes)
+      mk .factors eta comm = ext (UF-colim.factors _ _)
+      mk .unique eta comm u fac = ext (UF-colim.unique _ _ _ λ j →
         unext (fac j))
 
       K-colim : is-colimit F K (to-cocone mk)

--- a/src/Cat/Instances/Slice/Colimit.lagda.md
+++ b/src/Cat/Instances/Slice/Colimit.lagda.md
@@ -1,0 +1,168 @@
+<!--
+```agda
+open import Cat.Diagram.Colimit.Base
+open import Cat.Functor.Conservative
+open import Cat.Functor.Kan.Unique
+open import Cat.Functor.Kan.Base
+open import Cat.Instances.Slice
+open import Cat.Prelude
+
+import Cat.Reasoning
+
+open Functor
+open /-Obj
+open /-Hom
+open _=>_
+```
+-->
+
+```agda
+module Cat.Instances.Slice.Colimit
+  {o ℓ} {C : Precategory o ℓ} {c : ⌞ C ⌟}
+  where
+```
+
+# Colimits in slices {defines="colimits-in-slice-categories"}
+
+Unlike [[limits in slice categories]], [[colimits]] in a [[slice category]]
+are computed just like colimits in the base category. That is, if we are
+given a diagram $F : \cJ \to \cC/c$ such that $U \circ F$ has a
+colimit in $\cC$ (where $U$ is the `forgetful`{.Agda ident=Forget/} functor $\cC/c
+\to \cC$), we can conclude:
+
+- that $F$ has a colimit in $\cC/c$;
+- that this colimit is [[preserved|preserved colimit]] by $U$;
+- and that $U$ [[reflects|reflected colimit]] colimits of $F$.
+
+In summary, we say that $U$ *creates* the colimits that exist in $\cC$.
+To understand why the assumption that the colimit exists in $\cC$ is
+necessary, consider the case where $\cC$ is a [[poset]], and we're
+interested in computing [[bottom elements]] ([[initial objects]], i.e.
+colimits of the empty diagram).
+Note that the existence of a bottom element in $\cC/c$ only means that
+there is a least element *that is less than $c$*, but does not imply
+the existence of a global bottom element. For example, the poset
+pictured below has an initial object $a$ in the slice over $c$, but
+no global initial object.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  c & d \\
+  a & b
+  \arrow[from=2-1, to=1-1]
+  \arrow[from=2-2, to=1-2]
+\end{tikzcd}\]
+~~~
+
+<!--
+```agda
+private
+  module C   = Cat.Reasoning C
+  module C/c = Cat.Reasoning (Slice C c)
+
+  U : Functor (Slice C c) C
+  U = Forget/
+
+module
+  _ {o' ℓ'} {J : Precategory o' ℓ'} (F : Functor J (Slice C c))
+  where
+  open make-is-colimit
+
+  private
+    module J = Cat.Reasoning J
+    module F = Functor F
+```
+-->
+
+Back to categories, let's consider the case of coproducts, as in the
+diagram below. We are given a binary diagram $a \to c \ot b$ in $\cC/c$
+and a colimiting cocone $a \to a + b \ot b$ in $\cC$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  a & {a+b} & b \\
+  & c
+  \arrow[from=1-1, to=1-2]
+  \arrow[from=1-1, to=2-2]
+  \arrow[dashed, from=1-2, to=2-2]
+  \arrow[from=1-3, to=1-2]
+  \arrow[from=1-3, to=2-2]
+\end{tikzcd}\]
+~~~
+
+The first observation is that there is a unique map $a + b \to c$ that
+turns this into a cocone in $\cC/c$:
+
+```agda
+  Forget/-lifts-colimits : Colimit (U F∘ F) → Colimit F
+  Forget/-lifts-colimits UF-colim = to-colimit K-colim
+    module Forget/-lifts where
+      module UF-colim = Colimit UF-colim
+      K : C/c.Ob
+      K .domain = UF-colim.coapex
+      K .map = UF-colim.universal (λ j → F.₀ j .map) (λ f → F.₁ f .commutes)
+
+      mk : make-is-colimit F K
+      mk .ψ j .map = UF-colim.cocone .η j
+      mk .ψ j .commutes = UF-colim.factors _ _
+      mk .commutes f = ext (UF-colim.cocone .is-natural _ _ f ∙ C.idl _)
+```
+
+All that remains is to show that this cocone is colimiting in $\cC/c$.
+Given another cocone with apex $z$ we get a map $a + b \to z$ by the
+universal property of $a + b$, but we need to check that it commutes
+with the relevant maps into $c$; this follows from the uniqueness of
+the universal map.
+
+```agda
+      mk .universal eta' comm .map = UF-colim.universal
+        (λ j → eta' j .map)
+        (λ f → unext (comm f))
+      mk .universal eta' comm .commutes = ext (UF-colim.unique _ _ _ λ j →
+        C.pullr (UF-colim.factors _ _) ∙ eta' j .commutes)
+      mk .factors eta' comm = ext (UF-colim.factors _ _)
+      mk .unique eta' comm u fac = ext (UF-colim.unique _ _ _ λ j →
+        unext (fac j))
+
+      K-colim : is-colimit F K (to-cocone mk)
+      K-colim = to-is-colimit mk
+
+      preserved : preserves-lan U K-colim
+      preserved = generalize-colimitp UF-colim.has-colimit refl
+```
+
+The colimit thus constructed is preserved by $U$ *by construction*, as
+we haven't touched the "top" part of the diagram. We can generalise this
+to all colimits of $F$.
+
+```agda
+  Forget/-preserves-colimits : Colimit (U F∘ F) → preserves-colimit U F
+  Forget/-preserves-colimits UF-colim =
+    preserves-lan→preserves-all U K-colim preserved
+    where open Forget/-lifts UF-colim
+```
+
+Finally, $U$ is [[conservative]], hence it reflects the colimits that it
+preserves, provided they exist in $\cC/c$. We can use the fact that
+$U$ lifts limits to satisfy the hypotheses.
+
+```agda
+  Forget/-reflects-colimits : reflects-colimit U F
+  Forget/-reflects-colimits UK-colim = conservative-reflects-colimits
+    Forget/-is-conservative
+    (Forget/-lifts-colimits UF-colim)
+    (Forget/-preserves-colimits UF-colim)
+    UK-colim
+    where UF-colim = to-colimit UK-colim
+```
+
+In particular, if a category $\cC$ is cocomplete, then so are its slices:
+
+```agda
+is-cocomplete→slice-is-cocomplete
+  : ∀ {o' ℓ'}
+  → is-cocomplete o' ℓ' C
+  → is-cocomplete o' ℓ' (Slice C c)
+is-cocomplete→slice-is-cocomplete colims F =
+  Forget/-lifts-colimits F (colims (U F∘ F))
+```

--- a/src/Cat/Instances/Slice/Limit.lagda.md
+++ b/src/Cat/Instances/Slice/Limit.lagda.md
@@ -19,7 +19,7 @@ open Functor
 module Cat.Instances.Slice.Limit where
 ```
 
-# Arbitrary limits in slices
+# Arbitrary limits in slices {defines="limits-in-slice-categories"}
 
 Suppose we have some really weird diagram $F : \cJ \to \cC/c$ in a
 [[slice category]], like the
@@ -40,7 +40,7 @@ limit in the slice.
 The observation that will let us compute a limit for this diagram is
 inspecting the computation of [[products in a slice]]. To
 compute the product of $(a, f)$ and $(b, g)$, we had to pass to a
-_pullback_ of $a \xto{f} c \xot{b}$ in $\cC$ --- which we had assumed
+_pullback_ of $a \xto{f} c \xot{g} b$ in $\cC$ --- which we had assumed
 exists. But! Take a look at what that diagram _looks like_:
 
 ~~~{.quiver}

--- a/src/Cat/Instances/Slice/Limit.lagda.md
+++ b/src/Cat/Instances/Slice/Limit.lagda.md
@@ -113,12 +113,12 @@ in $\cC$, then pass back to the slice category.
 
     module Cone
       {x : C/o.Ob}
-      (eta : (j : J.Ob) → C/o.Hom x (F .F₀ j))
-      (p : ∀ {i j : J.Ob} → (f : J.Hom i j) → F .F₁ f C/o.∘ eta i ≡ eta j)
+      (eps : (j : J.Ob) → C/o.Hom x (F .F₀ j))
+      (p : ∀ {i j : J.Ob} → (f : J.Hom i j) → F .F₁ f C/o.∘ eps i ≡ eps j)
       where
 
         ϕ : (j : J.Ob ⊎ ⊤) → C.Hom (x .domain) (F' .F₀ j)
-        ϕ (inl j) = eta j .map
+        ϕ (inl j) = eps j .map
         ϕ (inr _) = x .map
 
         ϕ-commutes
@@ -126,12 +126,12 @@ in $\cC$, then pass back to the slice category.
           → (f : ⋆Hom J ⊤Cat i j)
           → F' .F₁ f C.∘ ϕ i ≡ ϕ j
         ϕ-commutes {inl i} {inl j} (lift f) = ap map (p f)
-        ϕ-commutes {inl i} {inr j} (lift f) = eta i .commutes
+        ϕ-commutes {inl i} {inr j} (lift f) = eps i .commutes
         ϕ-commutes {inr i} {inr x} (lift f) = C.idl _
 
         ϕ-factor
           : ∀ (other : /-Hom x apex)
-          → (∀ j → nadir j C/o.∘ other ≡ eta j)
+          → (∀ j → nadir j C/o.∘ other ≡ eps j)
           → (j : J.Ob ⊎ ⊤)
           → lims.ψ j C.∘ other .map ≡ ϕ j
         ϕ-factor other q (inl j) = ap map (q j)
@@ -140,13 +140,13 @@ in $\cC$, then pass back to the slice category.
     lim : make-is-limit F apex
     lim .ψ = nadir
     lim .commutes f = ext (lims.commutes (lift f))
-    lim .universal {x} eta p .map =
-      lims.universal (Cone.ϕ eta p) (Cone.ϕ-commutes eta p)
-    lim .universal eta p .commutes =
+    lim .universal {x} eps p .map =
+      lims.universal (Cone.ϕ eps p) (Cone.ϕ-commutes eps p)
+    lim .universal eps p .commutes =
       lims.factors _ _
-    lim .factors eta p = ext (lims.factors _ _)
-    lim .unique eta p other q = ext $
-      lims.unique _ _ (other .map) (Cone.ϕ-factor eta p other q)
+    lim .factors eps p = ext (lims.factors _ _)
+    lim .unique eps p other q = ext $
+      lims.unique _ _ (other .map) (Cone.ϕ-factor eps p other q)
 ```
 
 In particular, if a category $\cC$ is complete, then so are its slices:

--- a/src/Cat/Site/Instances/Canonical.lagda.md
+++ b/src/Cat/Site/Instances/Canonical.lagda.md
@@ -74,7 +74,7 @@ an arbitrary category, colimits may not be preserved by [[pullback]]; in
 terms of sieves, even if $S$ is a colim sieve over $U$, we may not have
 that $f^*(S)$ is a colim sieve over $V$ for $f : V \to U$. We can,
 however, turn this into a site, by restricting the notion of colim sieve
-so that it's stable under pullbacks: we say that $S$ is a **universal
+so that it's stable under pullbacks: we say that $S$ is a **[[universal|universal colimit]]
 colim sieve** if $f^*(S)$ is a colim sieve, for any appropriate $f$.
 
 ```agda

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -246,3 +246,12 @@
   howpublished = {\url{https://stacks.math.columbia.edu}},
   year         = {2018},
 }
+
+@misc{HTT,
+      title={Higher Topos Theory},
+      author={Jacob Lurie},
+      year={2008},
+      eprint={math/0608040},
+      archivePrefix={arXiv},
+      primaryClass={id='math.CT' full_name='Category Theory' is_active=True alt_name=None in_archive='math' is_general=False description='Enriched categories, topoi, abelian categories, monoidal categories, homological algebra'}
+}


### PR DESCRIPTION
Define universal colimits (à la Borceux §2.14) and pullback-stable colimits (preserved by the base change functor) and prove that they are equivalent if the colimits are assumed to exist.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
