### PR TITLE
Refactor `Const`

### DIFF
--- a/src/Cat/Abelian/Images.lagda.md
+++ b/src/Cat/Abelian/Images.lagda.md
@@ -51,7 +51,7 @@ epi] followed by a [regular mono].
 ```agda
 images : ∀ {A B} (f : Hom A B) → Image C f
 images f = im where
-  the-img : ↓Obj (const! (cut f)) Forget-full-subcat
+  the-img : ↓Obj (!Const (cut f)) Forget-full-subcat
   the-img .x = tt
   the-img .y .fst = cut (Ker.kernel (Coker.coeq f))
   the-img .y .snd {c} = kernels-are-subobjects C ∅ _ (Ker.has-is-kernel _)
@@ -112,7 +112,7 @@ commutes.
   im : Image C f
   im .Initial.bot = the-img
   im .Initial.has⊥ other = contr factor unique where
-    factor : ↓Hom (const! (cut f)) Forget-full-subcat the-img other
+    factor : ↓Hom (!Const (cut f)) Forget-full-subcat the-img other
     factor .α = tt
     factor .β ./-Hom.map =
         Coker.universal (Ker.kernel f) {e' = other .map .map} path

--- a/src/Cat/Base.lagda.md
+++ b/src/Cat/Base.lagda.md
@@ -482,23 +482,6 @@ is-natural-transformation {C = C} {D = D} F G η =
   where module D = Precategory D
         open Functor
 
-module _ where
-  open Precategory
-  open Functor
-
-  Const : ∀ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
-        → Ob D → Functor C D
-  Const {D = D} x .F₀ _ = x
-  Const {D = D} x .F₁ _ = id D
-  Const {D = D} x .F-id = refl
-  Const {D = D} x .F-∘ _ _ = sym (idr D _)
-
-  const-nt : ∀ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'}
-           → {x y : Ob D} → Hom D x y
-           → Const {C = C} {D = D} x => Const {C = C} {D = D} y
-  const-nt f ._=>_.η _ = f
-  const-nt {D = D} f ._=>_.is-natural _ _ _ = idr D _ ∙ sym (idl D _)
-
 infixr 30 _F∘_
 infix 20 _=>_
 

--- a/src/Cat/Diagram/Coend/Formula.lagda.md
+++ b/src/Cat/Diagram/Coend/Formula.lagda.md
@@ -4,6 +4,7 @@ open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Product
 open import Cat.Instances.Twisted
 open import Cat.Diagram.Initial
+open import Cat.Functor.Constant
 open import Cat.Diagram.Coend
 open import Cat.Prelude
 

--- a/src/Cat/Diagram/Coend/Formula.lagda.md
+++ b/src/Cat/Diagram/Coend/Formula.lagda.md
@@ -3,8 +3,8 @@
 open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Product
 open import Cat.Instances.Twisted
-open import Cat.Diagram.Initial
 open import Cat.Functor.Constant
+open import Cat.Diagram.Initial
 open import Cat.Diagram.Coend
 open import Cat.Prelude
 

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -7,6 +7,7 @@ open import Cat.Diagram.Coequaliser
 open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Coherence
 open import Cat.Instances.Functor
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Prelude
 
@@ -61,12 +62,9 @@ module _ {J : Precategory o₁ h₁} {C : Precategory o₂ h₂} (Diagram : Func
   private
     module C = Precategory C
 
-  cocone→unit : ∀ {x : C.Ob} → (Diagram => Const x) → Diagram => const! x F∘ !F
-  unquoteDef cocone→unit = define-coherence cocone→unit
-
   is-colimit : (x : C.Ob) → Diagram => Const x → Type _
   is-colimit x cocone =
-    is-lan !F Diagram (const! x) (cocone→unit cocone)
+    is-lan !F Diagram (!Const x) cocone
 
   Colimit : Type _
   Colimit = Lan !F Diagram
@@ -199,8 +197,8 @@ the rest of the data.
   -- colimit, but this has better definitional behaviour.
   generalize-colimitp
     : ∀ {D : Functor J C} {K : Functor ⊤Cat C}
-    → {eta : D => (const! (Functor.F₀ K tt)) F∘ !F} {eta' : D => K F∘ !F}
-    → is-lan !F D (const! (Functor.F₀ K tt)) eta
+    → {eta : D => (Const (Functor.F₀ K tt))} {eta' : D => K F∘ !F}
+    → is-lan !F D (!Const (Functor.F₀ K tt)) eta
     → (∀ {j} → eta .η j ≡ eta' .η j)
     → is-lan !F D K eta'
   generalize-colimitp {D} {K} {eta} {eta'} lan q = lan' where
@@ -209,12 +207,12 @@ the rest of the data.
     open Functor
 
     lan' : is-lan !F D K eta'
-    lan' .σ α = hom→⊤-natural-trans (lan.σ α .η tt)
+    lan' .σ α = !constⁿ (lan.σ α .η tt)
     lan' .σ-comm {M} {α} = ext λ j →
         ap (_ C.∘_) (sym q)
       ∙ lan.σ-comm {α = α} ηₚ _
     lan' .σ-uniq {M} {α} {σ'} r = ext λ j →
-      lan.σ-uniq {σ' = hom→⊤-natural-trans (σ' .η tt)}
+      lan.σ-uniq {σ' = !constⁿ (σ' .η tt)}
         (ext λ j → r ηₚ j ∙ ap (_ C.∘_) (sym q)) ηₚ j
 
   to-is-colimitp
@@ -248,12 +246,12 @@ function which **un**makes a colimit.
                  (p : ∀ {x y} (f : J.Hom x y) →  eta y C.∘ F₁ f ≡ eta x)
       where
 
-      eta-nt : D => const! x F∘ !F
+      eta-nt : D => Const x
       eta-nt .η = eta
       eta-nt .is-natural _ _ f = p f ∙ sym (C.idl _)
 
       hom : C.Hom coapex x
-      hom = σ {M = const! x} eta-nt .η tt
+      hom = σ {M = !Const x} eta-nt .η tt
 
     mc : make-is-colimit D coapex
     mc .ψ = eta.η
@@ -263,7 +261,7 @@ function which **un**makes a colimit.
     mc .unique {x = x} eta p other q =
       sym $ σ-uniq {σ' = other-nt} (ext λ j → sym (q j)) ηₚ tt
       where
-        other-nt : F => const! x
+        other-nt : F => !Const x
         other-nt .η _ = other
         other-nt .is-natural _ _ _ = C.elimr (F .Functor.F-id) ∙ sym (C.idl _)
 ```
@@ -404,14 +402,14 @@ module _ {o₁ h₁ o₂ h₂ : _} {J : Precategory o₁ h₁} {C : Precategory 
 <!--
 ```agda
   colimits→inversesp {f = f} {g = g} f-factor g-factor =
-    inversesⁿ→inverses {α = hom→⊤-natural-trans f} {β = hom→⊤-natural-trans g}
+    inversesⁿ→inverses {α = !constⁿ f} {β = !constⁿ g}
       (Lan-unique.σ-inversesp Cx Cy
         (ext λ j → f-factor {j})
         (ext λ j → g-factor {j}))
       tt
 
   colimits→invertiblep {f = f} f-factor =
-    is-invertibleⁿ→is-invertible {α = hom→⊤-natural-trans f}
+    is-invertibleⁿ→is-invertible {α = !constⁿ f}
       (Lan-unique.σ-is-invertiblep
         Cx Cy (ext λ j → f-factor {j}))
       tt

--- a/src/Cat/Diagram/Colimit/Cocone.lagda.md
+++ b/src/Cat/Diagram/Colimit/Cocone.lagda.md
@@ -1,6 +1,7 @@
 <!--
 ```agda
 open import Cat.Diagram.Colimit.Base
+open import Cat.Functor.Constant
 open import Cat.Diagram.Initial
 open import Cat.Prelude
 

--- a/src/Cat/Diagram/Colimit/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Colimit/Coproduct.lagda.md
@@ -11,8 +11,8 @@ open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Shape.Two
 open import Cat.Instances.Discrete
-open import Cat.Functor.Constant
 open import Cat.Diagram.Coproduct
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Prelude
 

--- a/src/Cat/Diagram/Colimit/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Colimit/Coproduct.lagda.md
@@ -11,6 +11,7 @@ open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Shape.Two
 open import Cat.Instances.Discrete
+open import Cat.Functor.Constant
 open import Cat.Diagram.Coproduct
 open import Cat.Functor.Kan.Base
 open import Cat.Prelude

--- a/src/Cat/Diagram/Colimit/Initial.lagda.md
+++ b/src/Cat/Diagram/Colimit/Initial.lagda.md
@@ -8,8 +8,8 @@ description: |
 ```agda
 open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Colimit.Base
-open import Cat.Diagram.Initial
 open import Cat.Functor.Constant
+open import Cat.Diagram.Initial
 open import Cat.Prelude
 ```
 -->

--- a/src/Cat/Diagram/Colimit/Initial.lagda.md
+++ b/src/Cat/Diagram/Colimit/Initial.lagda.md
@@ -9,6 +9,7 @@ description: |
 open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Initial
+open import Cat.Functor.Constant
 open import Cat.Prelude
 ```
 -->

--- a/src/Cat/Diagram/Colimit/Representable.lagda.md
+++ b/src/Cat/Diagram/Colimit/Representable.lagda.md
@@ -4,6 +4,7 @@ open import Cat.Functor.Hom.Representable
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Functor
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Compose
 open import Cat.Functor.Hom
@@ -48,14 +49,14 @@ conditions.
 ```agda
   Lim[C[F-,=]] : Functor C (Sets ℓ)
   Lim[C[F-,=]] .F₀ c = el (Dia => Const c) Nat-is-set
-  Lim[C[F-,=]] .F₁ f α = const-nt f ∘nt α
+  Lim[C[F-,=]] .F₁ f α = constⁿ f ∘nt α
   Lim[C[F-,=]] .F-id = ext λ _ _ → C.idl _
   Lim[C[F-,=]] .F-∘ _ _ = ext λ _ _ → sym $ C.assoc _ _ _
 
   Hom-into-inj
     : ∀ {c : C.Ob} (eta : Dia => Const c)
     → Hom-from C c => Lim[C[F-,=]]
-  Hom-into-inj eta .η x f = const-nt f ∘nt eta
+  Hom-into-inj eta .η x f = constⁿ f ∘nt eta
   Hom-into-inj eta .is-natural x y f = ext λ g _ →
     sym $ C.assoc _ _ _
 
@@ -68,12 +69,11 @@ conditions.
 
     colim : is-colimit Dia c eta
     colim .σ {M} α =
-      hom→⊤-natural-trans $ nat-inv.inv .η _ (idnat-constr ∘nt α)
-    colim .σ-comm {M} {α} = ext λ j →
-      unext nat-inv.invl _ _ j ∙ C.idl _
+      !constⁿ (nat-inv.inv .η _ (to-coconeⁿ α))
+    colim .σ-comm {M} {α} = ext λ j → unext nat-inv.invl _ _ j
     colim .σ-uniq {M} {α} {σ'} q = ext λ j →
-      nat-inv.inv .η _ (idnat-constr ∘nt ⌜ α ⌝)                               ≡⟨ ap! q ⟩
-      nat-inv.inv .η _ ⌜ idnat-constr ∘nt (σ' ◂ !F) ∘nt cocone→unit Dia eta ⌝ ≡⟨ ap! (ext λ _ → C.idl _) ⟩
-      nat-inv.inv .η (M .F₀ tt) (const-nt (σ' .η j) ∘nt eta)                  ≡⟨ unext nat-inv.invr _ _ ⟩
-      σ' .η tt ∎
+      nat-inv.inv .η _ (to-coconeⁿ ⌜ α ⌝)                  ≡⟨ ap! q ⟩
+      nat-inv.inv .η _ ⌜ to-coconeⁿ ((σ' ◂ !F) ∘nt eta) ⌝  ≡⟨ ap! trivial! ⟩
+      nat-inv.inv .η _ ((!constⁿ (σ' .η tt) ◂ !F) ∘nt eta) ≡⟨ unext nat-inv.invr _ _ ⟩
+      σ' .η tt                                             ∎
 ```

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -12,6 +12,7 @@ open import Cat.Diagram.Limit.Finite
 open import Cat.Instances.Shape.Join
 open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Naturality
+open import Cat.Functor.Constant
 open import Cat.Diagram.Pullback
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Pullback
@@ -307,7 +308,7 @@ colimits, we get that $F$ is colimiting.
       F-colim : is-colimit▹ (cocone▹→cocone/ F)
       F-colim = natural-isos→is-lan idni
         f*G≅F
-        (iso→⊤-natural-iso (C/.invertible→iso
+        (!const-isoⁿ (C/.invertible→iso
           (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
                   ; commutes = eq _ .p₁∘universal })
           (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -12,8 +12,8 @@ open import Cat.Diagram.Limit.Finite
 open import Cat.Instances.Shape.Join
 open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Naturality
-open import Cat.Functor.Constant
 open import Cat.Diagram.Pullback
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Pullback
 open import Cat.Functor.Compose

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -7,6 +7,7 @@ open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Naturality
 open import Cat.Diagram.Equaliser
 open import Cat.Functor.Coherence
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Base
 open import Cat.Prelude
@@ -162,16 +163,8 @@ module _ {J : Precategory o₁ h₁} {C : Precategory o₂ h₂} (Diagram : Func
     open _=>_
     open Functor
 
-  cone→counit : ∀ {x : C.Ob} → (Const x => Diagram) → const! x F∘ !F => Diagram
-  unquoteDef cone→counit = define-coherence cone→counit
-
-  counit→cone : ∀ {K : Functor ⊤Cat C} → K F∘ !F => Diagram → (Const (K .F₀ tt) => Diagram)
-  counit→cone {K = K} eps .η = eps .η
-  counit→cone {K = K} eps .is-natural x y f =
-    ap (_ C.∘_) (sym (K .F-id)) ∙ eps .is-natural x y f
-
   is-limit : (x : C.Ob) → Const x => Diagram → Type _
-  is-limit x cone = is-ran !F Diagram (const! x) (cone→counit cone)
+  is-limit x cone = is-ran !F Diagram (!Const x) cone
 ```
 
 In a "bundled" form, we may define the _type of limits_ for a diagram
@@ -317,8 +310,8 @@ other data we have been given:
 ```agda
   generalize-limitp
     : ∀ {D : Functor J C} {K : Functor ⊤Cat C}
-    → {eps : (const! (Functor.F₀ K tt)) F∘ !F => D} {eps' : K F∘ !F => D}
-    → is-ran !F D (const! (Functor.F₀ K tt)) eps
+    → {eps : (Const (Functor.F₀ K tt)) => D} {eps' : K F∘ !F => D}
+    → is-ran !F D (!Const (Functor.F₀ K tt)) eps
     → (∀ {j} → eps .η j ≡ eps' .η j)
     → is-ran !F D K eps'
   generalize-limitp {D} {K} {eps} {eps'} ran q = ran' where
@@ -327,11 +320,11 @@ other data we have been given:
     open Functor
 
     ran' : is-ran !F D K eps'
-    ran' .σ α = hom→⊤-natural-trans (ran.σ α .η tt)
+    ran' .σ α = !constⁿ (ran.σ α .η tt)
     ran' .σ-comm {M} {β} = ext λ j →
       ap (C._∘ _) (sym q) ∙ ran.σ-comm {β = β} ηₚ _
     ran' .σ-uniq {M} {β} {σ'} r = ext λ j →
-      ran.σ-uniq {σ' = hom→⊤-natural-trans (σ' .η tt)}
+      ran.σ-uniq {σ' = !constⁿ (σ' .η tt)}
         (ext λ j → r ηₚ j ∙ ap (C._∘ _) (sym q)) ηₚ j
 
   to-is-limitp
@@ -368,12 +361,12 @@ limit:
                  (p : ∀ {x y} (f : J.Hom x y) → F₁ f C.∘ eps x ≡ eps y)
       where
 
-      eps-nt : const! x F∘ !F => D
+      eps-nt : Const x => D
       eps-nt .η = eps
       eps-nt .is-natural _ _ f = C.idr _ ∙ sym (p f)
 
       hom : C.Hom x a
-      hom = σ {M = const! x} eps-nt .η tt
+      hom = σ {M = !Const x} eps-nt .η tt
 
     ml : make-is-limit D a
     ml .ψ j        = eps.η j
@@ -384,7 +377,7 @@ limit:
     ml .unique {x = x} eps p other q =
       sym $ σ-uniq {σ' = other-nt} (ext λ j → sym (q j)) ηₚ tt
       where
-        other-nt : const! x => F
+        other-nt : !Const x => F
         other-nt .η _ = other
         other-nt .is-natural _ _ _ = C.idr _ ∙ C.introl (F .Functor.F-id)
 
@@ -508,7 +501,7 @@ with the 2 limits, then $f$ and $g$ are inverses.
     → (∀ {j : J.Ob} → Lx.ψ j C.∘ g ≡ Ly.ψ j)
     → C.Inverses f g
   limits→inversesp {f = f} {g = g} f-factor g-factor =
-    inversesⁿ→inverses {α = hom→⊤-natural-trans f} {β = hom→⊤-natural-trans g}
+    inversesⁿ→inverses {α = !constⁿ f} {β = !constⁿ g}
       (Ran-unique.σ-inversesp Ly Lx
         (ext λ j → f-factor {j})
         (ext λ j → g-factor {j}))
@@ -524,7 +517,7 @@ must be invertible.
     → (∀ {j : J.Ob} → Ly.ψ j C.∘ f ≡ Lx.ψ j)
     → C.is-invertible f
   limits→invertiblep {f = f} f-factor = is-invertibleⁿ→is-invertible
-    {α = hom→⊤-natural-trans f}
+    {α = !constⁿ f}
     (Ran-unique.σ-is-invertiblep Ly Lx
       (ext λ j → f-factor {j}))
     tt

--- a/src/Cat/Diagram/Limit/Cone.lagda.md
+++ b/src/Cat/Diagram/Limit/Cone.lagda.md
@@ -4,6 +4,7 @@ open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Limit.Base
 open import Cat.Instances.Functor
 open import Cat.Diagram.Terminal
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Prelude
 
@@ -193,14 +194,14 @@ differently.
     open is-ran
     open Cone
 
-    isl : is-ran _ F _ (cone→counit F (Cone→cone K))
+    isl : is-ran _ F _ (Cone→cone K)
     isl .σ {M = M} α = nt where
       α' : Cone
       α' .apex = M .Functor.F₀ tt
       α' .ψ x = α .η x
       α' .commutes f = sym (α .is-natural _ _ f) ∙ C.elimr (M .Functor.F-id)
 
-      nt : M => const! (K .apex)
+      nt : M => !Const (K .apex)
       nt .η x = term α' .centre .hom
       nt .is-natural tt tt tt = C.elimr (M .Functor.F-id) ∙ C.introl refl
     isl .σ-comm = ext λ x → term _ .centre .commutes _

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -11,6 +11,7 @@ open import Cat.Diagram.Product.Indexed
 open import Cat.Instances.Shape.Two
 open import Cat.Diagram.Limit.Base
 open import Cat.Instances.Discrete
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Diagram.Product
 open import Cat.Prelude

--- a/src/Cat/Diagram/Limit/Terminal.lagda.md
+++ b/src/Cat/Diagram/Limit/Terminal.lagda.md
@@ -6,9 +6,11 @@ description: |
 
 <!--
 ```agda
+open import Cat.Instances.Shape.Terminal
 open import Cat.Instances.Shape.Initial
 open import Cat.Diagram.Limit.Base
 open import Cat.Diagram.Terminal
+open import Cat.Functor.Constant
 open import Cat.Prelude
 ```
 -->

--- a/src/Cat/Diagram/Terminal.lagda.md
+++ b/src/Cat/Diagram/Terminal.lagda.md
@@ -97,7 +97,7 @@ to the unique functor $\cC \to \top$ if and only if $x$ is terminal.
 
 ```agda
   module _ (x : Ob) (term : is-terminal x) where
-    is-terminal→inclusion-is-right-adjoint : !F ⊣ const! {A = C} x
+    is-terminal→inclusion-is-right-adjoint : !F ⊣ !Const {C = C} x
     is-terminal→inclusion-is-right-adjoint =
       hom-iso→adjoints (e _ .fst) (e _ .snd)
         λ _ _ _ → term _ .paths _
@@ -105,7 +105,7 @@ to the unique functor $\cC \to \top$ if and only if $x$ is terminal.
         e : ∀ y → ⊤ ≃ Hom y x
         e y = is-contr→≃ (hlevel 0) (term y)
 
-  module _ (x : Ob) (adj : !F ⊣ const! {A = C} x) where
+  module _ (x : Ob) (adj : !F ⊣ !Const {C = C} x) where
     inclusion-is-right-adjoint→is-terminal : is-terminal x
     inclusion-is-right-adjoint→is-terminal y = Equiv→is-hlevel 0
       (Σ-contract (λ _ → hlevel 0) e⁻¹)

--- a/src/Cat/Displayed/Instances/Diagrams.lagda.md
+++ b/src/Cat/Displayed/Instances/Diagrams.lagda.md
@@ -4,6 +4,7 @@ open import Cat.Displayed.Instances.Pullback
 open import Cat.Displayed.Instances.Lifting
 open import Cat.Displayed.Cartesian
 open import Cat.Functor.Equivalence
+open import Cat.Functor.Constant
 open import Cat.Displayed.Functor
 open import Cat.Instances.Functor
 open import Cat.Displayed.Fibre
@@ -93,15 +94,15 @@ transformations between them.
   ConstL : ∀ {x} → Ob[ x ] → Lifting {J = J} E (Const x)
   ConstL x' .F₀' _ = x'
   ConstL x' .F₁' _ = id'
-  ConstL x' .F-id' = refl
-  ConstL x' .F-∘' _ _ = symP (idr' _)
+  ConstL x' .F-id' = cast[] (λ _ → id')
+  ConstL x' .F-∘' _ _ = cast[] (symP (idr' _))
 
   const-ntl
     : ∀ {x y x' y'} {f : Hom x y} → Hom[ f ] x' y'
-    → (ConstL x') =[ const-nt f ]=>l (ConstL y')
+    → (ConstL x') =[ constⁿ f ]=>l (ConstL y')
   const-ntl f' .η' _ = f'
   const-ntl f' .is-natural' _ _ _ =
-    idr' _ ∙[] symP (idl' _)
+    cast[] (idr' _ ∙[] (symP (idl' _)))
 ```
 
 We also have a vertical functor from $\cE$ to the fibration of diagrams
@@ -131,13 +132,13 @@ diagrams in fibre categories.
 ```agda
   ConstL→Diagram F' .F₀ = F' .F₀'
   ConstL→Diagram F' .F₁ = F' .F₁'
-  ConstL→Diagram F' .F-id = F' .F-id'
+  ConstL→Diagram F' .F-id = cast[] (F' .F-id')
   ConstL→Diagram F' .F-∘ f g =
     from-pathp⁻ $ cast[] {q = sym (idl _)} (F' .F-∘' f g)
 
   Diagram→ConstL F .F₀' = F .F₀
   Diagram→ConstL F .F₁' = F .F₁
-  Diagram→ConstL F .F-id' = F .F-id
+  Diagram→ConstL F .F-id' = cast[] (F .F-id)
   Diagram→ConstL F .F-∘' f g =
     cast[] {p = sym (idl _)} $ to-pathp⁻ (F .F-∘ f g)
 ```
@@ -150,13 +151,13 @@ functor.
 ```agda
   ConstL-natl→Diagram-nat
     : ∀ {x} {F G : Functor J (Fibre E x)}
-    → Diagram→ConstL F =[ const-nt id ]=>l Diagram→ConstL G
+    → Diagram→ConstL F =[ constⁿ id ]=>l Diagram→ConstL G
     → F => G
 
   Diagram-nat→ConstL-natl
     : ∀ {x} {F G : Functor J (Fibre E x)}
     → F => G
-    → Diagram→ConstL F =[ const-nt id ]=>l Diagram→ConstL G
+    → Diagram→ConstL F =[ constⁿ id ]=>l Diagram→ConstL G
 ```
 
 <!--

--- a/src/Cat/Displayed/Instances/Diagrams.lagda.md
+++ b/src/Cat/Displayed/Instances/Diagrams.lagda.md
@@ -4,9 +4,9 @@ open import Cat.Displayed.Instances.Pullback
 open import Cat.Displayed.Instances.Lifting
 open import Cat.Displayed.Cartesian
 open import Cat.Functor.Equivalence
-open import Cat.Functor.Constant
 open import Cat.Displayed.Functor
 open import Cat.Instances.Functor
+open import Cat.Functor.Constant
 open import Cat.Displayed.Fibre
 open import Cat.Displayed.Base
 open import Cat.Prelude

--- a/src/Cat/Functor/Constant.lagda.md
+++ b/src/Cat/Functor/Constant.lagda.md
@@ -10,8 +10,8 @@ open import Cat.Functor.Compose
 open import Cat.Functor.Base
 open import Cat.Prelude
 
-import Cat.Reasoning
 import Cat.Functor.Reasoning
+import Cat.Reasoning
 ```
 -->
 

--- a/src/Cat/Functor/Constant.lagda.md
+++ b/src/Cat/Functor/Constant.lagda.md
@@ -1,0 +1,146 @@
+---
+description: |
+  Constant functors.
+---
+<!--
+```agda
+open import Cat.Instances.Shape.Terminal
+open import Cat.Functor.Naturality
+open import Cat.Functor.Compose
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Reasoning
+import Cat.Functor.Reasoning
+```
+-->
+
+```agda
+module Cat.Functor.Constant where
+```
+
+# Constant functors {defines="constant-functor"}
+
+A **constant functor** is a [[functor]] $F : \cC \to \cD$ that sends
+every object of $\cC$ to a single object $d : \cD$, and every morphism
+of $\cC$ to the identity morphism.
+
+<!--
+```agda
+module _
+  {o ℓ o' ℓ'}
+  {C : Precategory o ℓ} {D : Precategory o' ℓ'}
+  where
+  private
+    module C = Cat.Reasoning C
+    module D = Cat.Reasoning D
+  open Functor
+  open _=>_
+```
+-->
+
+Equivalently, constant functors $\cC \to \cD$ are
+factorizations through the [[terminal category]]. We opt to take this
+notion as primitive for ergonomic reasons: it is useful to only be able
+to write constant functors in a single way.
+
+```agda
+  Const : D.Ob → Functor C D
+  Const X = !Const X F∘ !F
+```
+
+Natural transformations between constant functors are given by a single
+morphism, and natural isomorphisms by a single iso.
+
+```agda
+  constⁿ
+    : {X Y : D.Ob}
+    → D.Hom X Y
+    → Const X => Const Y
+  constⁿ f = !constⁿ f ◂ !F
+
+  const-isoⁿ
+    : {X Y : D.Ob}
+    → X D.≅ Y
+    → Const X ≅ⁿ Const Y
+  const-isoⁿ f =
+    iso→isoⁿ (λ _ → f) (λ f → D.id-comm-sym)
+```
+
+<!--
+```agda
+  -- Coherence lemmas for cones and cocones as natural transformations.
+  to-coconeⁿ
+    : ∀ {F : Functor C D} {K : Functor ⊤Cat D}
+    → F => K F∘ !F
+    → F => Const (K .F₀ tt)
+  to-coconeⁿ {K = K} ψ .η = ψ .η
+  to-coconeⁿ {K = K} ψ .is-natural x y f =
+    ψ .is-natural x y f ∙ ap₂ D._∘_ (K .F-id) refl
+
+  to-coneⁿ
+    : ∀ {F : Functor C D} {K : Functor ⊤Cat D}
+    → K F∘ !F => F
+    → Const (K .F₀ tt) => F
+  to-coneⁿ {K = K} ψ .η = ψ .η
+  to-coneⁿ {K = K} ψ .is-natural x y f =
+    ap₂ D._∘_ refl (sym (K .F-id)) ∙ ψ .is-natural x y f
+```
+-->
+
+
+## Essentially constant functors {defines="essentially-constant-functor"}
+
+A functor is **essentially constant** if it is (merely) isomorphic
+to a constant functor.
+
+```agda
+  is-essentially-constant : Functor C D → Type _
+  is-essentially-constant F = ∃[ X ∈ D.Ob ] (F ≅ⁿ Const X)
+```
+
+<!--
+```agda
+module _
+  {ob ℓb oc ℓc od ℓd}
+  {B : Precategory ob ℓb}
+  {C : Precategory oc ℓc}
+  {D : Precategory od ℓd}
+  (F : Functor C D) (G : Functor B C)
+  where
+  private
+    module D = Cat.Reasoning D
+    module F = Cat.Functor.Reasoning F
+    module G = Cat.Functor.Reasoning G
+
+  open Isoⁿ
+  open _=>_
+```
+-->
+
+Essentially constant functors are closed under pre and postcomposition
+by arbitrary functors.
+
+```agda
+  essentially-constant-∘l
+    : is-essentially-constant F
+    → is-essentially-constant (F F∘ G)
+  essentially-constant-∘l =
+    rec! λ d f →
+      pure $ d ,
+        iso→isoⁿ
+          (λ b → isoⁿ→iso f (G.₀ b))
+          (λ g → sym (f .to .is-natural _ _ (G.₁ g)))
+
+  essentially-constant-∘r
+    : is-essentially-constant G
+    → is-essentially-constant (F F∘ G)
+  essentially-constant-∘r =
+    rec! λ c f →
+      pure $ F.₀ c ,
+        iso→isoⁿ
+          (λ b → F-map-iso F (isoⁿ→iso f b))
+          (λ g →
+            ap₂ D._∘_ (sym (F.F-id)) refl
+            ∙ F.weave (sym (f .to .is-natural _ _ g)))
+```

--- a/src/Cat/Functor/Dense.lagda.md
+++ b/src/Cat/Functor/Dense.lagda.md
@@ -3,8 +3,8 @@
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Colimit.Base
 open import Cat.Functor.Properties
-open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Nerve
+open import Cat.Functor.Constant
 open import Cat.Instances.Comma
 open import Cat.Prelude
 

--- a/src/Cat/Functor/Dense.lagda.md
+++ b/src/Cat/Functor/Dense.lagda.md
@@ -3,6 +3,7 @@
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Colimit.Base
 open import Cat.Functor.Properties
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Nerve
 open import Cat.Instances.Comma
 open import Cat.Prelude
@@ -51,7 +52,7 @@ module
 -->
 
 ```agda
-  dense-cocone : ∀ d → F F∘ Dom F (const! d) => Const d
+  dense-cocone : ∀ d → F F∘ Dom F (!Const d) => Const d
   dense-cocone d .η x = x .map
   dense-cocone d .is-natural _ _ f = f .sq
 

--- a/src/Cat/Functor/Final.lagda.md
+++ b/src/Cat/Functor/Final.lagda.md
@@ -7,8 +7,8 @@ open import Cat.Functor.Adjoint.Hom
 open import Cat.Functor.Properties
 open import Cat.Instances.Discrete
 open import Cat.Diagram.Terminal
-open import Cat.Functor.Adjoint
 open import Cat.Functor.Constant
+open import Cat.Functor.Adjoint
 open import Cat.Instances.Comma
 open import Cat.Connected
 open import Cat.Groupoid

--- a/src/Cat/Functor/Final.lagda.md
+++ b/src/Cat/Functor/Final.lagda.md
@@ -8,6 +8,7 @@ open import Cat.Functor.Properties
 open import Cat.Instances.Discrete
 open import Cat.Diagram.Terminal
 open import Cat.Functor.Adjoint
+open import Cat.Functor.Constant
 open import Cat.Instances.Comma
 open import Cat.Connected
 open import Cat.Groupoid
@@ -353,7 +354,7 @@ the terminal object.
 terminal→inclusion-is-final
   : ∀ {o ℓ} {𝒞 : Precategory o ℓ}
   → (top : 𝒞 .Ob) (term : is-terminal 𝒞 top)
-  → is-final (const! {A = 𝒞} top)
+  → is-final (!Const {C = 𝒞} top)
 terminal→inclusion-is-final top term = right-adjoint-is-final
   (is-terminal→inclusion-is-right-adjoint _ top term)
 ```

--- a/src/Cat/Functor/Hom/Representable.lagda.md
+++ b/src/Cat/Functor/Hom/Representable.lagda.md
@@ -7,6 +7,7 @@ open import Cat.Functor.Properties
 open import Cat.Instances.Elements
 open import Cat.Instances.Functor
 open import Cat.Diagram.Terminal
+open import Cat.Functor.Constant
 open import Cat.Morphism.Duality
 open import Cat.Diagram.Initial
 open import Cat.Functor.Hom

--- a/src/Cat/Functor/Kan/Nerve.lagda.md
+++ b/src/Cat/Functor/Kan/Nerve.lagda.md
@@ -210,7 +210,7 @@ module _
     module F = Func F
 
     module ↓colim c' =
-      comma-colimits→lan.↓colim (よ C) F (λ c'' → cocompl (F F∘ Dom (よ C) (Const c''))) c'
+      comma-colimits→lan.↓colim (よ C) F (λ c'' → cocompl (F F∘ Dom (よ C) (!Const c''))) c'
 ```
 -->
 
@@ -238,7 +238,7 @@ below we denote `elem`{.Agda}.
 
 ```agda
     elem : (P : Functor (C ^op) (Sets κ)) (i : C.Ob)
-         → (arg : P ʻ i) → ↓Obj (よ C) (const! P)
+         → (arg : P ʻ i) → ↓Obj (よ C) (!Const P)
     elem P i arg .x = i
     elem P i arg .y = tt
     elem P i arg .map .η j h = P .F₁ h arg
@@ -275,7 +275,7 @@ from that same naturality:
     adj .counit .η ob = ↓colim.universal _ (λ j → j .map .η _ C.id) comm
       where abstract
       comm
-        : ∀ {x y} (f : ↓Hom (よ C) (const! (Nerve F .F₀ ob)) x y)
+        : ∀ {x y} (f : ↓Hom (よ C) (!Const (Nerve F .F₀ ob)) x y)
         → y .map .η _ C.id D.∘ F.₁ (f .α) ≡ x .map .η _ C.id
       comm {x} {y} f =
         y .map .η _ C.id D.∘ F.₁ (f .α) ≡˘⟨ y .map .is-natural _ _ _ $ₚ _ ⟩

--- a/src/Cat/Functor/Kan/Pointwise.lagda.md
+++ b/src/Cat/Functor/Kan/Pointwise.lagda.md
@@ -10,6 +10,7 @@ open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Naturality
 open import Cat.Functor.Properties
 open import Cat.Functor.Coherence
+open import Cat.Functor.Constant
 open import Cat.Functor.Kan.Base
 open import Cat.Functor.Compose
 open import Cat.Instances.Comma
@@ -183,7 +184,7 @@ diagrams all have colimits in $\cD$.
 
 ```agda
     ↓Dia : (c' : C'.Ob) → Functor (F ↘ c') D
-    ↓Dia c' = G F∘ Dom F (Const c')
+    ↓Dia c' = G F∘ Dom F (!Const c')
 ```
 
 In fact, we can weaken the precondition from cocompleteness of $\cD$ to
@@ -349,12 +350,12 @@ end up being off by a bunch of natural isomorphisms.
       open make-natural-iso
       open Func
 
-      ↓colim : (c' : C'.Ob) → Colimit (G F∘ Dom F (Const c'))
-      ↓colim c' = colimits (G F∘ Dom F (Const c'))
+      ↓colim : (c' : C'.Ob) → Colimit (G F∘ Dom F (!Const c'))
+      ↓colim c' = colimits (G F∘ Dom F (!Const c'))
 
       module ↓colim c' = Colimit (↓colim c')
 
-      H-↓colim : (c' : C'.Ob) → Colimit ((H F∘ G) F∘ Dom F (Const c'))
+      H-↓colim : (c' : C'.Ob) → Colimit ((H F∘ G) F∘ Dom F (!Const c'))
       H-↓colim c' =
         natural-iso→colimit ni-assoc $
         preserves-colimit.colimit cocont (↓colim c')
@@ -371,7 +372,7 @@ up not being very interesting.
 
 ```agda
       F' : Functor C' D
-      F' = comma-colimits→lan.F' F G λ c' → colimits (G F∘ Dom F (Const c'))
+      F' = comma-colimits→lan.F' F G λ c' → colimits (G F∘ Dom F (!Const c'))
 
       HF' : Functor C' E
       HF' = comma-colimits→lan.F' F (H F∘ G) H-↓colim
@@ -454,7 +455,7 @@ module _
 We begin by constructing a cocone for every object $c' : \cC'$.
 
 ```agda
-  ↓cocone : ∀ (c' : C'.Ob) → F F∘ Dom p (const! c') => Const (L .F₀ c')
+  ↓cocone : ∀ (c' : C'.Ob) → F F∘ Dom p (!Const c') => Const (L .F₀ c')
   ↓cocone c' .η j = L .F₁ (j .map) D.∘ eta .η _
   ↓cocone c' .is-natural _ _ f =
     D.pullr (eta .is-natural _ _ _ )
@@ -470,7 +471,7 @@ we shall appeal to the fact that [colimits are representable].
 ```agda
   pointwise-lan→has-comma-colimits
     : ∀ (c' : C'.Ob)
-    → is-colimit (F F∘ Dom p (const! c')) (L .F₀ c') (↓cocone c')
+    → is-colimit (F F∘ Dom p (!Const c')) (L .F₀ c') (↓cocone c')
   pointwise-lan→has-comma-colimits c' =
     represents→is-colimit $
     [D,Sets].make-invertible inv invl invr
@@ -485,7 +486,7 @@ representability nonsense to get there.
 ```agda
       represent-↓cocone
         : ∀ (d : D.Ob)
-        → F F∘ Dom p (const! c') => Const d
+        → F F∘ Dom p (!Const c') => Const d
         → Functor.op (よ₀ D d) F∘ F => Functor.op (よ₀ C' c') F∘ p
       represent-↓cocone d α .η c f = α .η (↓obj f)
       represent-↓cocone d α .is-natural _ _ f = funext λ g →
@@ -494,7 +495,7 @@ representability nonsense to get there.
 
       pointwise-↓cocone
         : ∀ (d : D.Ob)
-        → (α : F F∘ Dom p (const! c') => Const d)
+        → (α : F F∘ Dom p (!Const c') => Const d)
         → Functor.op (Hom-into D d) F∘ L => Functor.op (Hom-into C' c')
       pointwise-↓cocone d α = pointwise.σ d (represent-↓cocone d α)
 ```
@@ -565,7 +566,7 @@ construct the requisite cocone.
            (λ j → D.idl _
                 ∙ ap₂ D._∘_ (ap (L .F₁) (sym (equiv→counit p-ff (j .map)))) refl))
          (pointwise.σ-comm _ ηₚ c $ₚ C'.id
-          ∙ elimr F (ap (equiv→inverse p-ff) (sym (p .F-id)) ∙ equiv→unit p-ff _))
+          ∙ elim F (ap (equiv→inverse p-ff) (sym (p .F-id)) ∙ equiv→unit p-ff _))
 ```
 
 <!--
@@ -574,7 +575,7 @@ construct the requisite cocone.
       module pointwise-colim c' = is-colimit (pointwise-lan→has-comma-colimits c')
 
       path
-        : {c : C.Ob} {x y : ↓Obj p (const! (p .F₀ c))} (f : ↓Hom p (const! (p .F₀ c)) x y)
+        : {c : C.Ob} {x y : ↓Obj p (!Const (p .F₀ c))} (f : ↓Hom p (!Const (p .F₀ c)) x y)
         → p .F₁ (equiv→inverse p-ff (y .map) C.∘ f .α) ≡ p .F₁ (equiv→inverse p-ff (x .map))
       path {c} {x} {y} f =
         p .F₁ (equiv→inverse p-ff (y .map) C.∘ f .α)          ≡⟨ p .F-∘ _ _ ⟩
@@ -613,7 +614,7 @@ module _
     → is-fully-faithful F
     → cocomplete→lan F G cocompl .Ext F∘ F ≅ⁿ G
   ff→cocomplete-lan-ext cocompl ff = (to-natural-iso ni) ni⁻¹ where
-    open comma-colimits→lan F G (λ c' → cocompl (G F∘ Dom F (Const c')))
+    open comma-colimits→lan F G (λ c' → cocompl (G F∘ Dom F (!Const c')))
     open make-natural-iso renaming (eta to to)
     module ff {x} {y} = Equiv (_ , ff {x} {y})
 

--- a/src/Cat/Functor/Naturality/Reflection.agda
+++ b/src/Cat/Functor/Naturality/Reflection.agda
@@ -23,7 +23,7 @@ module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {D : Precategory o' ℓ'} where
     `C ← quoteTC C
     `D ← quoteTC D
     wait-just-a-bit `C >>= unify hole ⊙ λ where
-      (def₀ (quote ⊤Cat)) → def₀ (quote iso→⊤-natural-iso)
+      (def₀ (quote ⊤Cat)) → def₀ (quote !const-isoⁿ)
         ##ₙ (def₀ (quote id-iso) ##ₙ `D)
       _ → def₀ (quote iso→isoⁿ)
         ##ₙ vlam "" (def₀ (quote id-iso) ##ₙ raise 1 `D)
@@ -47,5 +47,5 @@ module _ {o ℓ} {C : Precategory o ℓ} where
   _ : ∀ {F : Functor C C} → F ≅ⁿ F
   _ = trivial-isoⁿ!
 
-  _ : ∀ {K : Functor ⊤Cat C} → const! (K .Functor.F₀ _) ≅ⁿ K
+  _ : ∀ {K : Functor ⊤Cat C} → !Const (K .Functor.F₀ _) ≅ⁿ K
   _ = trivial-isoⁿ!

--- a/src/Cat/Functor/Properties/FullyFaithful.lagda.md
+++ b/src/Cat/Functor/Properties/FullyFaithful.lagda.md
@@ -136,13 +136,13 @@ we can lift it to a `Limit`{.Agda} of $G$ (and similarly for
     → ∀ {o} → apex Lim D.≅ F.₀ o
     → Limit G
   ff→reflects-Limit Lim {o} is = to-limit (ff→reflects-limit lim) where
-    eps' : F F∘ Const o F∘ !F => F F∘ G
+    eps' : F F∘ !Const o F∘ !F => F F∘ G
     eps' = nat-unassoc-from
-      (Lim .eps ∘nt (hom→⊤-natural-trans (is .D.from) ◂ !F))
+      (Lim .eps ∘nt (!constⁿ (is .D.from) ◂ !F))
 
-    lim : is-ran !F (F F∘ G) (F F∘ Const o) (nat-assoc-from (F ▸ unwhisker eps'))
+    lim : is-ran !F (F F∘ G) (F F∘ !Const o) (nat-assoc-from (F ▸ unwhisker eps'))
     lim = natural-isos→is-ran idni idni
-      (iso→⊤-natural-iso is)
+      (!const-isoⁿ is)
       (ext λ j → D.idl _ ·· (D.refl⟩∘⟨ D.eliml (Lim .Ext .F-id)) ·· sym (F.ε _))
       (Lim .has-ran)
 
@@ -151,13 +151,13 @@ we can lift it to a `Limit`{.Agda} of $G$ (and similarly for
     → ∀ {o} → coapex Colim D.≅ F.₀ o
     → Colimit G
   ff→reflects-Colimit Colim {o} is = to-colimit (ff→reflects-colimit colim) where
-    eta' : F F∘ G => F F∘ Const o F∘ !F
+    eta' : F F∘ G => F F∘ !Const o F∘ !F
     eta' = nat-unassoc-to
-      ((hom→⊤-natural-trans (is .D.to) ◂ !F) ∘nt Colim .eta)
+      ((!constⁿ (is .D.to) ◂ !F) ∘nt Colim .eta)
 
-    colim : is-lan !F (F F∘ G) (F F∘ Const o) (nat-assoc-to (F ▸ unwhisker eta'))
+    colim : is-lan !F (F F∘ G) (F F∘ !Const o) (nat-assoc-to (F ▸ unwhisker eta'))
     colim = natural-isos→is-lan idni idni
-      (iso→⊤-natural-iso is)
+      (!const-isoⁿ is)
       (ext λ j → (F.eliml refl D.⟩∘⟨ D.idr _) ∙ sym (F.ε _))
       (Colim .has-lan)
 ```

--- a/src/Cat/Instances/Comma.lagda.md
+++ b/src/Cat/Instances/Comma.lagda.md
@@ -241,10 +241,10 @@ module _ {A : Precategory ao ah} {B : Precategory bo bh} where
 
   infix 5 _↙_ _↘_
   _↙_ : A.Ob → Functor B A → Precategory _ _
-  X ↙ T = const! X ↓ T
+  X ↙ T = !Const X ↓ T
 
   _↘_ : Functor B A → A.Ob → Precategory _ _
-  S ↘ X = S ↓ const! X
+  S ↘ X = S ↓ !Const X
 
 module ↙-compose
     {oc ℓc od ℓd oe ℓe}
@@ -299,21 +299,21 @@ module _ where
     Extensional-↙Hom
       : ∀ {ℓr}
       → {X : A .Ob} {T : Functor B A}
-      → {f g : ↓Obj (const! X) T}
+      → {f g : ↓Obj (!Const X) T}
       → ⦃ sb : Extensional (B .Hom (f .y) (g .y)) ℓr ⦄
-      → Extensional (↓Hom (const! X) T f g) ℓr
+      → Extensional (↓Hom (!Const X) T f g) ℓr
     Extensional-↙Hom {B = B} {X = X} {T = T} {f = f} {g = g} ⦃ sb ⦄ =
-      injection→extensional! {f = λ sq → sq .β} (λ p → ↓Hom-path (const! X) T refl p) sb
+      injection→extensional! {f = λ sq → sq .β} (λ p → ↓Hom-path (!Const X) T refl p) sb
     {-# OVERLAPS Extensional-↙Hom #-}
 
     Extensional-↘Hom
       : ∀ {ℓr}
       → {T : Functor A B} {X : B .Ob}
-      → {f g : ↓Obj T (const! X)}
+      → {f g : ↓Obj T (!Const X)}
       → ⦃ sa : Extensional (A .Hom (f .x) (g .x)) ℓr ⦄
-      → Extensional (↓Hom T (const! X) f g) ℓr
+      → Extensional (↓Hom T (!Const X) f g) ℓr
     Extensional-↘Hom {A = A} {T = T} {X = X} {f = f} {g = g} ⦃ sa ⦄ =
-      injection→extensional! {f = λ sq → sq .α} (λ p → ↓Hom-path T (const! X) p refl) sa
+      injection→extensional! {f = λ sq → sq .α} (λ p → ↓Hom-path T (!Const X) p refl) sa
     {-# OVERLAPS Extensional-↘Hom #-}
 
 
@@ -323,30 +323,30 @@ module _ where
       : ∀ {ℓr}
       → {X : A .Ob} {T : Functor B A}
       → ⦃ sb : Extensional (Σ[ Y ∈ B .Ob ] (A .Hom X (T .F₀ Y))) ℓr ⦄
-      → Extensional (↓Obj (const! X) T) ℓr
+      → Extensional (↓Obj (!Const X) T) ℓr
     Extensional-↙Obj {A = A} {B = B} {X = X} {T = T} ⦃ sb ⦄ =
       iso→extensional isom sb
         where
           -- Easier to just do this by hand.
-          isom : Iso (↓Obj (const! X) T) (Σ[ Y ∈ B .Ob ] (A .Hom X (T .F₀ Y)))
+          isom : Iso (↓Obj (!Const X) T) (Σ[ Y ∈ B .Ob ] (A .Hom X (T .F₀ Y)))
           isom .fst α = ↓Obj.y α , ↓Obj.map α
           isom .snd .is-iso.inv (Y , f) = ↓obj f
           isom .snd .is-iso.rinv _ = refl
-          isom .snd .is-iso.linv _ = ↓Obj-path (const! X) T refl refl refl
+          isom .snd .is-iso.linv _ = ↓Obj-path (!Const X) T refl refl refl
 
     Extensional-↘Obj
       : ∀ {ℓr}
       → {T : Functor A B} {Y : B .Ob}
       → ⦃ sb : Extensional (Σ[ X ∈ A .Ob ] (B .Hom (T .F₀ X) Y)) ℓr ⦄
-      → Extensional (↓Obj T (const! Y)) ℓr
+      → Extensional (↓Obj T (!Const Y)) ℓr
     Extensional-↘Obj {A = A} {B = B} {T = T} {Y = Y} ⦃ sb ⦄ =
       iso→extensional isom sb
         where
           -- Easier to just do this by hand.
-          isom : Iso (↓Obj T (const! Y)) (Σ[ X ∈ A .Ob ] (B .Hom (T .F₀ X) Y))
+          isom : Iso (↓Obj T (!Const Y)) (Σ[ X ∈ A .Ob ] (B .Hom (T .F₀ X) Y))
           isom .fst α = ↓Obj.x α , ↓Obj.map α
           isom .snd .is-iso.inv (Y , f) = ↓obj f
           isom .snd .is-iso.rinv _ = refl
-          isom .snd .is-iso.linv _ = ↓Obj-path T (const! Y) refl refl refl
+          isom .snd .is-iso.linv _ = ↓Obj-path T (!Const Y) refl refl refl
 ```
 -->

--- a/src/Cat/Instances/Functor.lagda.md
+++ b/src/Cat/Instances/Functor.lagda.md
@@ -2,6 +2,7 @@
 ```agda
 open import Cat.Instances.Product
 open import Cat.Functor.Compose
+open import Cat.Functor.Constant
 open import Cat.Prelude
 
 import Cat.Functor.Reasoning
@@ -56,7 +57,7 @@ module _ {o ℓ o' ℓ'} {C : Precategory o ℓ} {J : Precategory o' ℓ'} where
 ```agda
   ConstD : Functor C Cat[ J , C ]
   ConstD .F₀ x = Const x
-  ConstD .F₁ f = const-nt f
+  ConstD .F₁ f = constⁿ f
   ConstD .F-id = ext λ _ → refl
   ConstD .F-∘ f g = ext λ _ → refl
 ```

--- a/src/Cat/Instances/Functor.lagda.md
+++ b/src/Cat/Instances/Functor.lagda.md
@@ -1,8 +1,8 @@
 <!--
 ```agda
 open import Cat.Instances.Product
-open import Cat.Functor.Compose
 open import Cat.Functor.Constant
+open import Cat.Functor.Compose
 open import Cat.Prelude
 
 import Cat.Functor.Reasoning

--- a/src/Cat/Instances/Shape/Parallel.lagda.md
+++ b/src/Cat/Instances/Shape/Parallel.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import Cat.Functor.Constant
 open import Cat.Prelude
 open import Cat.Finite
 

--- a/src/Cat/Instances/Shape/Terminal.lagda.md
+++ b/src/Cat/Instances/Shape/Terminal.lagda.md
@@ -3,6 +3,7 @@
 open import 1Lab.Prelude
 
 open import Cat.Functor.Naturality
+open import Cat.Functor.Compose
 open import Cat.Functor.Base
 open import Cat.Groupoid
 open import Cat.Morphism
@@ -37,64 +38,75 @@ trivial morphisms.
 ⊤Cat .idr _ _ = tt
 ⊤Cat .idl _ _ = tt
 ⊤Cat .assoc _ _ _ _ = tt
+```
 
+The ony morphism in the terminal category is the identity, so the
+terminal category is a [[pregroupoid]].
+
+```agda
 ⊤Cat-is-pregroupoid : is-pregroupoid ⊤Cat
 ⊤Cat-is-pregroupoid _ = id-invertible ⊤Cat
+```
 
-module _ {o h} {A : Precategory o h} where
-  private module A = Precategory A
+<!--
+```agda
+module _ {o h} {C : Precategory o h} where
+  private module C = Cat.Reasoning C
   open Functor
+  open _=>_
+```
+-->
 
-  const! : Ob A → Functor ⊤Cat A
-  const! = Const
+There is a unique functor from any category $\cC$ into the terminal
+category.
 
-  !F : Functor A ⊤Cat
+```agda
+  !F : Functor C ⊤Cat
   !F .F₀ _ = tt
   !F .F₁ _ = tt
   !F .F-id = refl
   !F .F-∘ _ _ = refl
 
-  const-η : ∀ (F G : Functor ⊤Cat A) → F .F₀ tt ≡ G .F₀ tt → F ≡ G
-  const-η F G p =
+  !F-unique : ∀ {F : Functor C ⊤Cat} → F ≡ !F
+  !F-unique = Functor-path (λ _ → refl) (λ _ → refl)
+```
+
+Conversely, functors $\top \to \cC$ are determined by their behaviour
+on a single object.
+
+```agda
+  !Const : C.Ob → Functor ⊤Cat C
+  !Const c .F₀ _ = c
+  !Const c .F₁ _ = C.id
+  !Const c .F-id = refl
+  !Const c .F-∘ _ _ = sym (C.idl _)
+
+  !Const-η : ∀ (F G : Functor ⊤Cat C) → F .F₀ tt ≡ G .F₀ tt → F ≡ G
+  !Const-η F G p =
     Functor-path
       (λ _ → p)
       (λ _ i → hcomp (∂ i) λ where
         j (i = i0) → F .F-id (~ j)
         j (i = i1) → G .F-id (~ j)
-        j (j = i0) → A.id)
+        j (j = i0) → C.id)
 ```
-
 
 Natural isomorphisms between functors $\top \to \cC$
 correspond to isomorphisms in $\cC$.
 
 ```agda
-module _ {o ℓ} {𝒞 : Precategory o ℓ} {F G : Functor ⊤Cat 𝒞} where
-  private
-    module 𝒞 = Cat.Reasoning 𝒞
-    open Functor
-    open _=>_
+  !constⁿ
+    : ∀ {F G : Functor ⊤Cat C}
+    → C.Hom (F .F₀ tt) (G .F₀ tt)
+    → F => G
+  !constⁿ {F = F} {G = G} f .η _ = f
+  !constⁿ {F = F} {G = G} f .is-natural _ _ _ =
+    C.elimr (F .F-id) ∙ C.introl (G .F-id)
 
-  hom→⊤-natural-trans : 𝒞.Hom (F .F₀ tt) (G .F₀ tt) → F => G
-  hom→⊤-natural-trans f .η _ = f
-  hom→⊤-natural-trans f .is-natural _ _ _ = 𝒞.elimr (F .F-id) ∙ 𝒞.introl (G .F-id)
-
-  iso→⊤-natural-iso : F .F₀ tt 𝒞.≅ G .F₀ tt → F ≅ⁿ G
-  iso→⊤-natural-iso i = iso→isoⁿ (λ _ → i) λ _ → 𝒞.eliml (G .F-id) ∙ 𝒞.intror (F .F-id)
+  !const-isoⁿ
+    : ∀ {F G : Functor ⊤Cat C}
+    → F .F₀ tt C.≅ G .F₀ tt
+    → F ≅ⁿ G
+  !const-isoⁿ {F = F} {G = G} f =
+    iso→isoⁿ (λ _ → f) (λ _ → C.eliml (G .F-id) ∙ C.intror (F .F-id))
 ```
-
-<!--
-```agda
-module _ {o ℓ o' ℓ'} {𝒞 : Precategory o ℓ} {𝒟 : Precategory o' ℓ'} where
-  private
-    module 𝒟 = Precategory 𝒟
-    open Functor
-    open _=>_
-
-  idnat-constr
-    : ∀ {M : Functor ⊤Cat 𝒟}
-    → M F∘ !F => Const {C = 𝒞} (M .F₀ tt)
-  idnat-constr .η _ = 𝒟.id
-  idnat-constr {M = M} .is-natural _ _ _ = ap (𝒟.id 𝒟.∘_) (M .F-id)
-```
--->

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -4,6 +4,7 @@ open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Diagram.Pullback.Properties
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Limit.Finite
+open import Cat.Instances.Shape.Terminal
 open import Cat.Morphism.Orthogonal
 open import Cat.Diagram.Equaliser
 open import Cat.Diagram.Pullback
@@ -281,7 +282,7 @@ strong-epi-mono→image f a→im (_ , str-epi) im→b mono fact = go where
   open ↓Obj
   open ↓Hom
 
-  obj : ↓Obj (Const (cut f)) (Forget-full-subcat {P = is-monic ⊙ map})
+  obj : ↓Obj (!Const (cut f)) (Forget-full-subcat {P = is-monic ⊙ map})
   obj .x = tt
   obj .y = cut im→b , mono
   obj .map = record { map = a→im ; commutes = fact }
@@ -304,7 +305,7 @@ in the relevant comma categories.
         {u = o.map .map}
         {v = im→b} (sym (o.map .commutes ∙ sym fact))
 
-    dh : ↓Hom (Const (cut f)) _ obj other
+    dh : ↓Hom (!Const (cut f)) _ obj other
     dh .α = tt
     dh .β .map = the-lifting .centre .fst
     dh .β .commutes = the-lifting .centre .snd .snd

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -2,9 +2,9 @@
 ```agda
 open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Diagram.Pullback.Properties
+open import Cat.Instances.Shape.Terminal
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Limit.Finite
-open import Cat.Instances.Shape.Terminal
 open import Cat.Morphism.Orthogonal
 open import Cat.Diagram.Equaliser
 open import Cat.Diagram.Pullback

--- a/src/Cat/Site/Instances/Canonical.lagda.md
+++ b/src/Cat/Site/Instances/Canonical.lagda.md
@@ -5,6 +5,7 @@ open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Elements
 open import Cat.Site.Constructions
 open import Cat.Functor.Kan.Base
+open import Cat.Functor.Constant
 open import Cat.Diagram.Sieve
 open import Cat.Site.Closure
 open import Cat.Functor.Hom
@@ -117,7 +118,7 @@ by these maps, we see that $p(-)$ is a transformation $S \To
 patch→cocone
   : ∀ {U V} (S : Sieve C U)
   → Patch (Hom-into C V) S
-  → πₚ C (to-presheaf S) => const! V F∘ !F
+  → πₚ C (to-presheaf S) => !Const V F∘ !F
 patch→cocone S p .η (elem _ (f , hf)) = p .part f hf
 ```
 
@@ -144,7 +145,7 @@ is-colim→よ-is-sheaf
 is-colim→よ-is-sheaf {U} {V} S colim p = uniq where
   module x = is-lan colim
 
-  p' : πₚ C (to-presheaf S) => const! V F∘ !F
+  p' : πₚ C (to-presheaf S) => !Const V F∘ !F
   p' = patch→cocone S p
 ```
 
@@ -168,7 +169,7 @@ colim sieve.
   uniq : is-contr (Section _ p)
   uniq .centre  = record { glues = πβ }
   uniq .paths x = ext $
-    x.σ-uniq {σ' = const-nt _} (ext λ i → sym (x .glues _ _)) ηₚ tt
+    x.σ-uniq {σ' = !constⁿ _} (ext λ i → sym (x .glues _ _)) ηₚ tt
 ```
 
 Generalising the proof above, we conclude that *any* representable

--- a/src/Cat/Site/Instances/Canonical.lagda.md
+++ b/src/Cat/Site/Instances/Canonical.lagda.md
@@ -4,8 +4,8 @@ open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Colimit.Base
 open import Cat.Instances.Elements
 open import Cat.Site.Constructions
-open import Cat.Functor.Kan.Base
 open import Cat.Functor.Constant
+open import Cat.Functor.Kan.Base
 open import Cat.Diagram.Sieve
 open import Cat.Site.Closure
 open import Cat.Functor.Hom


### PR DESCRIPTION
# Description

As noted by @ncfavier, there are too many ways to write cones! This PR attempts to remove some of this duplication by
redefining `Const` as `!Const . !F`, and banishing `counit->cone`. I've also done a bit of a naming pass, and renamed `const!` to `!Const` (among other things) so it doesn't look like a macro invocation.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
