### PR TITLE
chore: bump agda

### DIFF
--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -96,8 +96,8 @@ private module P where
 
   -- White/blacklist specific definitions for reduction while executing the TC computation
   -- 'true' for whitelist, 'false' for blacklist
-    withReduceDefs : ∀ {a} {A : Type a} → (Σ Bool λ _ → List Name) → TC A → TC A
-    askReduceDefs  : TC (Σ Bool λ _ → List Name)
+    withReduceDefs : ∀ {a} {A : Type a} → Bool × List Name → TC A → TC A
+    askReduceDefs  : TC (Bool × List Name)
 
   -- Fail if the given computation gives rise to new, unsolved
   -- "blocking" constraints.
@@ -106,14 +106,14 @@ private module P where
   -- Run the given TC action and return the first component. Resets to
   -- the old TC state if the second component is 'false', or keep the
   -- new TC state if it is 'true'.
-    run-speculative : ∀ {a} {A : Type a} → TC (Σ A λ _ → Bool) → TC A
+    run-speculative : ∀ {a} {A : Type a} → TC (A × Bool) → TC A
 
   -- Get a list of all possible instance candidates for the given meta
   -- variable (it does not have to be an instance meta).
     get-instances : Meta → TC (List Term)
 
     declareData      : Name → Nat → Term → TC ⊤
-    defineData       : Name → List (Σ Name (λ _ → Term)) → TC ⊤
+    defineData       : Name → List (Name × Quantity × Term) → TC ⊤
 ```
 
 <details>

--- a/src/1Lab/Reflection/HLevel.agda
+++ b/src/1Lab/Reflection/HLevel.agda
@@ -192,8 +192,12 @@ instance
   h-level-is-prop : ∀ {ℓ} {A : Type ℓ} {n : Nat} ⦃ _ : 1 ≤ n ⦄ → H-Level (is-prop A) n
   h-level-is-prop ⦃ s≤s _ ⦄ = hlevel-instance (is-prop→is-hlevel-suc is-prop-is-prop)
 
+  H-Level-Singleton : ∀ {ℓ} {A : Type ℓ} {a : A} {n : Nat} → H-Level (Singleton a) n
+  H-Level-Singleton {n = n} = hlevel-instance (is-contr→is-hlevel n (contr _ Singleton-is-contr))
+
   {-# INCOHERENT H-Level-projection #-}
   {-# OVERLAPPING h-level-is-prop #-}
+  {-# OVERLAPPING H-Level-Singleton #-}
 
 open Data.Nat.Base using (0≤x ; s≤s' ; x≤x ; x≤sucy) public
 

--- a/src/1Lab/Reflection/Signature.agda
+++ b/src/1Lab/Reflection/Signature.agda
@@ -67,7 +67,7 @@ get-type-constructors n = datatype <|> recordtype where
 -- Look up a constructor in the signature.
 get-constructor : Name → TC Constructor
 get-constructor n = get-definition n >>= λ where
-  (data-cons t) → do
+  (data-cons t _) → do
     (npars , cons) ← get-data-type t
     (args , ty)    ← pi-view <$> get-type n
     pure (conhead n t (drop npars args) ty)
@@ -111,7 +111,7 @@ instance
 private
   it-worker : Name → TC Term
   it-worker n = get-definition n <&> λ where
-    (data-cons _) →
+    (data-cons _ _) →
       def₀ (quote Has-constr.from-constr) ##ₙ def₀ (quote auto) ##ₙ lit (name n)
     _ →
       def₀ (quote Has-def.from-def) ##ₙ def₀ (quote auto) ##ₙ lit (name n)
@@ -180,8 +180,8 @@ render-name def-nm = do
   d ← is-defined def-nm
   let
     fancy = get-definition def-nm >>= λ where
-      (data-cons _) → formatErrorParts [ termErr (con₀ def-nm) ]
-      _             → formatErrorParts [ termErr (def₀ def-nm) ]
+      (data-cons _ _) → formatErrorParts [ termErr (con₀ def-nm) ]
+      _               → formatErrorParts [ termErr (def₀ def-nm) ]
     plain = show def-nm
   if d then fancy else pure plain
 

--- a/src/Cat/Diagram/Sieve.lagda.md
+++ b/src/Cat/Diagram/Sieve.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+{-# OPTIONS -vtc.instance:70 #-}
 open import Cat.Instances.Functor
 open import Cat.Instances.Slice
 open import Cat.Functor.Hom

--- a/src/Cat/Diagram/Sieve.lagda.md
+++ b/src/Cat/Diagram/Sieve.lagda.md
@@ -1,6 +1,5 @@
 <!--
 ```agda
-{-# OPTIONS -vtc.instance:70 #-}
 open import Cat.Instances.Functor
 open import Cat.Instances.Slice
 open import Cat.Functor.Hom

--- a/src/Cat/Monoidal/Instances/Day.lagda.md
+++ b/src/Cat/Monoidal/Instances/Day.lagda.md
@@ -303,12 +303,12 @@ $f(\day{h,x,y})$, in a way compatible with the relation above.
   -- computation rule for `factor W (day ...)` without exposing the
   -- computational behaviour of any other of the symbols here.
 
-  instance
-    Extensional-day-map
+  private
+    extensional-work
       : ∀ {i ℓ' ℓr} {C : Type ℓ'} ⦃ _ : H-Level C 2 ⦄
       → ⦃ sf : ∀ {a b} → Extensional ((h : Hom i (a ⊗ b)) (x : X ʻ a) (y : Y ʻ b) → C) ℓr ⦄
       → Extensional (⌞ Day.nadir i ⌟ → C) (ℓ ⊔ ℓr)
-    Extensional-day-map {i} {C = C} ⦃ sf ⦄ = done where
+    extensional-work {i} {C = C} ⦃ sf ⦄ = done where
       T : Type _
       T = {a b : Ob} (h : Hom i (a ⊗ b)) (x : X ʻ a) (y : Y ʻ b) → C
 
@@ -318,11 +318,23 @@ $f(\day{h,x,y})$, in a way compatible with the relation above.
       opaque
         unfolding Day-coend day
 
+        -- Note: Extensional-day-map and Extensional-coeq-map well and
+        -- truly overlap whenever Day.nadir is unfoldable (which it is
+        -- in the definition of to-p). So we can't let to-p see
+        -- Extensional-day-map as an instance.
+
         to-p : ∀ {f g} → Path T (unday f) (unday g) → f ≡ g
         to-p p = ext λ a b h x y i → p i {a} {b} h x y
 
       done : Extensional (⌞ Day.nadir i ⌟ → C) _
       done = injection→extensional (hlevel 2) to-p auto
+
+  instance
+    Extensional-day-map
+      : ∀ {i ℓ' ℓr} {C : Type ℓ'} ⦃ _ : H-Level C 2 ⦄
+      → ⦃ sf : ∀ {a b} → Extensional ((h : Hom i (a ⊗ b)) (x : X ʻ a) (y : Y ʻ b) → C) ℓr ⦄
+      → Extensional (⌞ Day.nadir i ⌟ → C) (ℓ ⊔ ℓr)
+    Extensional-day-map = extensional-work
 
   day-swap
     : ∀ {i a b a' b'} {f : Hom a' a} {g : Hom b' b} {h : Hom i (a' ⊗ b')}

--- a/src/Data/Reflection/Term.agda
+++ b/src/Data/Reflection/Term.agda
@@ -84,7 +84,7 @@ data Definition : Type where
   function    : (cs : List Clause) → Definition
   data-type   : (pars : Nat) (cs : List Name) → Definition
   record-type : (c : Name) (fs : List (Arg Name)) → Definition
-  data-cons   : (d : Name) → Definition
+  data-cons   : (d : Name) (q : Quantity) → Definition
   axiom       : Definition
   prim-fun    : Definition
 

--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -3,6 +3,6 @@
   "repo": "agda",
   "branch": "master",
   "private": false,
-  "rev": "403ee4263e0f14222956e398d2610ae1a4f05467",
-  "sha256": "09rbhysb06xbpw4hak69skxhdpcdxwj451rlgbk76dksa6rkk8wm"
+  "rev": "3a9d3893737b3a47c57e1c997f588931d592b0b6",
+  "sha256": "06a3v40gb1779ric56bhyhhmkrjbwdzkgxsr00fdnm192a63khnq"
 }

--- a/support/shake/app/HTML/Backend.hs
+++ b/support/shake/app/HTML/Backend.hs
@@ -291,23 +291,17 @@ killQual = Con.mapExpr (wrap . forget) where
 
 getClass :: QName -> TCM (Set QName)
 getClass q = isRecord q >>= \case
-  Just Record{ recFields = f } -> pure $! Set.fromList (map I.unDom f)
+  Just RecordData{ _recFields = f } -> pure $! Set.fromList (map I.unDom f)
   _ -> pure mempty
 
 usedInstances :: I.TermLike a => a -> TCM (Set QName)
-usedInstances =
-  let
-    getClass q = isRecord q >>= \case
-      Just Record{ recFields = f } -> pure $! Set.fromList (map I.unDom f)
-      _ -> pure mempty
-  in
-    I.foldTerm \case
-      I.Def q _ -> do
-        def <- getConstInfo q
-        case Agda.Compiler.Backend.defInstance def of
-          Just c  -> Set.insert q <$> getClass (instanceClass c)
-          Nothing -> pure mempty
-      _ -> pure mempty
+usedInstances = I.foldTerm \case
+  I.Def q _ -> do
+    def <- getConstInfo q
+    case Agda.Compiler.Backend.defInstance def of
+      Just c  -> Set.insert q <$> getClass (instanceClass c)
+      Nothing -> pure mempty
+  _ -> pure mempty
 
 typeToText :: Definition -> TCM Text
 typeToText d = do


### PR DESCRIPTION
Bump past 2.7.0; add the H-Level-Singleton instance from #374 